### PR TITLE
Address precision issues in the cubic bézier flattening code near the inflection points.

### DIFF
--- a/bezier/src/flatten_cubic.rs
+++ b/bezier/src/flatten_cubic.rs
@@ -486,3 +486,21 @@ fn test_iterator_builder_3() {
     assert!(iter_points.len() > 2);
     assert_approx_eq(&iter_points[..], &builder_points[..]);
 }
+
+#[test]
+fn test_issue_19() {
+    let mut tolerance = 0.15;
+    let c1 = CubicBezierSegment {
+        from: Point::new(11.71726, 9.07143),
+        ctrl1: Point::new(1.889879,13.22917),
+        ctrl2: Point::new(18.142855,19.27679),
+        to: Point::new(18.142855,19.27679),
+    };
+    let iter_points: Vec<Point> = c1.flattening_iter(tolerance).collect();
+    let mut builder_points = Vec::new();
+    c1.flattened_for_each(tolerance, &mut|p|{ builder_points.push(p); });
+
+    assert_approx_eq(&iter_points[..], &builder_points[..]);
+
+    assert!(iter_points.len() > 1);
+}


### PR DESCRIPTION
Fixes issue #19

The cubic bézier flattening code has specific logic to compute the linear approximation of the curve at the inflection points (if any). This logic was running into precision issues when the some of the control points are very close to each other ending up in a division by zero leading to the entire curve being included in the range of the linear approximation of inflection point. The solution to this is to have an empty range when the divisor is equal to zero to not special-case this region and let the rest of the algorithm deal with that range. We could probably always just split the curve at the inflection points with running special code to approximate these regions, the number of segments generated would be slightly less optimal, but the code would be simpler.
    
The flattening builder also had an issue when there was only one inflection point and its approximation range extended beyond the curve: the algorithm returned without connecting to the last point of the curve. This would also have been prevented if we did not have the complexity of special-casing the approximation of the inflection ranges. The iterator flattening code is not affected. Perhaps it would be best to remove the builder flattening logic and implement it on top of the iterator.