### PR TITLE
Simplify the cubic bezier flattening code.

### DIFF
--- a/bezier/src/flatten_cubic.rs
+++ b/bezier/src/flatten_cubic.rs
@@ -87,6 +87,12 @@ impl CubicFlatteningIter2 {
             );
             iter.following_inflection_start = clamp(iter.following_inflection_start, 0.0, 1.0);
             iter.following_inflection_end = clamp(iter.following_inflection_end, 0.0, 1.0);
+
+            // Adjust the second inflection since we are going to remove the part before the
+            // first inflection from the bezier curve.
+            let split = iter.next_inflection_end;
+            iter.following_inflection_start = (iter.following_inflection_start - split) / (1.0 - split);
+            iter.following_inflection_end = (iter.following_inflection_end - split) / (1.0 - split);
         }
 
         if iter.next_inflection_start > 0.0 {
@@ -306,6 +312,12 @@ fn flatten_cubic_bezier2<F: FnMut(Point)>(
             &mut second_inflection_start,
             &mut second_inflection_end,
         );
+
+        // Adjust the second inflection since we are going to remove the part before the
+        // first inflection from the bezier curve.
+        let split = first_inflection_end;
+        second_inflection_start = (second_inflection_start - split) / (1.0 - split);
+        second_inflection_end = (second_inflection_end - split) / (1.0 - split);
     }
 
     // Process ranges. [first_inflection_start, first_inflection_end] and


### PR DESCRIPTION
The cubic bezier flattening code finds up to two inflection points, and has special code to evaluate the approximation between the inflections and in the region very close to the inflections.

I think that it should be enough to only split the curve at the inflection points and evaluate the approximation on the sub curves without the special approximation of the region around the inflection point. This should result in an approximation that is almost as good (may generate an extra vertex but would not compromise the tolerance threshold) and greatly simplify the code.

This PR implements this simpler version of the flattening for both the iterator and callback versions. It would be best to figure out a way to verify that the approximation does not regress any important metric before removing the more complex version.

In the process of implementing this I also found and fixed a bug with the calculation of the second inflection point: once we have split the curve at the first inflection point, the position t2 of the second inflection point needs to be re-mapped into the space of the remaining portion of the curve.