### PR TITLE
Implement fill tessellation for rounded rectangles.

### DIFF
--- a/examples/gfx_basic/CHANGELOG.md
+++ b/examples/gfx_basic/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Change log
 
 ### (next)
+  - [tessellation] implement fill tessellation for rounded rectangles.
   - [svg] Bump svgparser dependency from 0.0.3 t0 0.4.0.
   - [lyon] Bump euclid dependency from 0.10.1 to 0.13.
   - [bezier] Fix a bug (issue #19) in the cubic bezier flattening code.

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -516,6 +516,23 @@ where
     }
 }
 
+// Returns the maximum length of individual line segments when approximating a
+// circle.
+//
+// From pythagora's theorem:
+// r² = (d/2)² + (r - t)²
+// r² = d²/4 + r² + t² - 2 * e * r
+// d² = 4 * (2 * t * r - t²)
+// d = 2 * sqrt(2 * t * r - t²)
+//
+// With:
+//  r: the radius
+//  t: the tolerance threshold
+//  d: the line segment length
+fn circle_flattening_step(radius:f32, tolerance: f32) -> f32 {
+    2.0 * (2.0 * tolerance * radius - tolerance * tolerance).sqrt()
+}
+
 #[test]
 fn test_polyline_events_open() {
     let points = &[

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -75,6 +75,8 @@
 //! # }
 //! ```
 
+// See https://github.com/nical/lyon/wiki/Stroke-tessellation for some notes
+// about how the path stroke tessellator is implemented.
 
 use math::*;
 use core::FlattenedEvent;


### PR DESCRIPTION
This PR implements lyon_tessellation::basic_shapes::fill_rounded_rectangle.
The implementation takes into account the flattening tolerance and outputs normals.

cc @Drakulix :)