### PR TITLE
Implement the fill tessellation of a circe.

### DIFF
--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -186,21 +186,20 @@ fn main() {
     let point_ids_1 = cpu.fill_primitives.alloc_range(num_points);
     let point_ids_2 = cpu.fill_primitives.alloc_range(num_points);
 
-    let ellipse_indices_start = cpu.fills.indices.len() as u32;
-    let ellipsis_count =
-        fill_ellipse(
-            vec2(0.0, 0.0),
-            vec2(1.0, 1.0),
-            64,
-            &mut BuffersBuilder::new(
-                &mut cpu.fills,
-                WithId(point_ids_1.range.start())
-            ),
-        );
-    fill_ellipse(
+    let circle_indices_start = cpu.fills.indices.len() as u32;
+    let circle_count = fill_circle(
         vec2(0.0, 0.0),
-        vec2(0.5, 0.5),
-        64,
+        1.0,
+        0.01,
+        &mut BuffersBuilder::new(
+            &mut cpu.fills,
+            WithId(point_ids_1.range.start())
+        ),
+    );
+    fill_circle(
+        vec2(0.0, 0.0),
+        0.5,
+        0.01,
         &mut BuffersBuilder::new(
             &mut cpu.fills,
             WithId(point_ids_2.range.start())
@@ -350,10 +349,10 @@ fn main() {
     gpu.transforms.update(&mut cpu.transforms, &mut factory, &mut init_queue);
     init_queue.flush(&mut device);
 
-    let split = ellipse_indices_start + (ellipsis_count.indices as u32);
-    let mut points_range_1 = gfx_sub_slice(gpu_fills.ibo.clone(), ellipse_indices_start, split);
+    let split = circle_indices_start + (circle_count.indices as u32);
+    let mut points_range_1 = gfx_sub_slice(gpu_fills.ibo.clone(), circle_indices_start, split);
     let mut points_range_2 =
-        gfx_sub_slice(gpu_fills.ibo.clone(), split, split + ellipsis_count.indices as u32);
+        gfx_sub_slice(gpu_fills.ibo.clone(), split, split + circle_count.indices as u32);
     points_range_1.instances = Some((num_points as u32, 0));
     points_range_2.instances = Some((num_points as u32, 0));
 

--- a/renderer/src/batch_builder.rs
+++ b/renderer/src/batch_builder.rs
@@ -85,10 +85,10 @@ pub trait VertexBuilder<PrimitiveId, Vertex> {
         geom: &mut Geometry<Vertex>
     ) -> GeometryRanges<Vertex>;
 
-    fn add_ellipse(
+    fn add_circle(
         &mut self,
         center: Point,
-        radii: Vec2,
+        radius: f32,
         prim_id: FillPrimitiveId,
         tolerance: f32,
         geom: &mut Geometry<Vertex>
@@ -265,10 +265,10 @@ impl VertexBuilder<FillPrimitiveId, GpuFillVertex> for FillVertexBuilder {
         };
     }
 
-    fn add_ellipse(
+    fn add_circle(
         &mut self,
         center: Point,
-        radii: Vec2,
+        radius: f32,
         prim_id: FillPrimitiveId,
         tolerance: f32,
         geom: &mut Geometry<GpuFillVertex>
@@ -276,9 +276,8 @@ impl VertexBuilder<FillPrimitiveId, GpuFillVertex> for FillVertexBuilder {
         let vtx_offset = geom.vertices.len();
         let idx_offset = geom.indices.len();
 
-        // TODO: compute num vertices for a given tolerance!
-        let count = basic_shapes::fill_ellipse(
-            center, radii, 64,
+        let count = basic_shapes::fill_circle(
+            center, radius, tolerance,
             &mut BuffersBuilder::new(geom, WithId(prim_id))
         );
 

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -107,7 +107,7 @@ impl GpuFillPrimitive {
             z_index: z_index,
             local_transform: local_transform.to_i32(),
             view_transform: view_transform.to_i32(),
-            width: 1.0,
+            width: 0.0,
         }
     }
 }

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -625,35 +625,6 @@ pub fn fill_circle<Output: GeometryBuilder<FillVertex>>(
     return output.end_geometry();
 }
 
-/// Tessellate an ellipsis.
-pub fn fill_ellipse<Output: GeometryBuilder<FillVertex>>(
-    center: Point,
-    radius: Vec2,
-    num_vertices: u32, // TODO: use a tolerance instead?
-    output: &mut Output,
-) -> Count {
-    output.begin_geometry();
-    let c = output.add_vertex(
-        FillVertex {
-            position: center,
-            normal: vec2(0.0, 0.0),
-        }
-    );
-    for i in 0..num_vertices {
-        let angle = i as f32 * 2.0 * PI / ((num_vertices - 1) as f32);
-        output.add_vertex(
-            FillVertex {
-                position: center + vec2(radius.x * angle.cos(), radius.y * angle.sin()),
-                normal: vec2(0.0, 0.0), // TODO
-            }
-        );
-    }
-    for i in 1..((num_vertices) as u16) {
-        output.add_triangle(c, VertexId(i), VertexId((i - 1) % num_vertices as u16 + 2));
-    }
-    return output.end_geometry();
-}
-
 /// Tessellate a convex polyline.
 ///
 /// TODO: normals are not implemented yet.


### PR DESCRIPTION
This implementation outputs normals and computes the flattening subdivision in function of the flattening tolerance threshold.
It replaces fill_ellipse which did not output normals and did not handle the flattening tolerance.