### PR TITLE
Bump euclid to 0.14

### DIFF
--- a/all.sh
+++ b/all.sh
@@ -10,5 +10,5 @@ cd ../path && cargo $1 &&
 cd ../renderer && cargo $1 &&
 cd ../cli && cargo $1 &&
 cd ../examples/gfx_basic && cargo build &&
-cd ../examples/gfx_advanced && cargo build &&
+cd ../gfx_advanced && cargo build &&
 echo "...done"

--- a/bezier/Cargo.toml
+++ b/bezier/Cargo.toml
@@ -13,5 +13,5 @@ workspace = ".."
 name = "lyon_bezier"
 
 [dependencies]
-euclid = "0.14"
+euclid = "0.14.2"
 arrayvec = "0.3"

--- a/bezier/Cargo.toml
+++ b/bezier/Cargo.toml
@@ -13,5 +13,5 @@ workspace = ".."
 name = "lyon_bezier"
 
 [dependencies]
-euclid = "0.13"
+euclid = "0.14"
 arrayvec = "0.3"

--- a/bezier/src/flatten_cubic.rs
+++ b/bezier/src/flatten_cubic.rs
@@ -186,8 +186,8 @@ pub fn find_cubic_bezier_inflection_points(bezier: &CubicBezierSegment) -> UpToT
     // See www.faculty.idc.ac.il/arik/quality/appendixa.html for an explanation
     // of this approach.
     let pa = bezier.ctrl1 - bezier.from;
-    let pb = bezier.ctrl2 - (bezier.ctrl1 * 2.0) + bezier.from;
-    let pc = bezier.to - (bezier.ctrl2 * 3.0) + (bezier.ctrl1 * 3.0) - bezier.from;
+    let pb = bezier.ctrl2 - (bezier.ctrl1.to_vector() * 2.0) + bezier.from.to_vector();
+    let pc = bezier.to - (bezier.ctrl2.to_vector() * 3.0) + (bezier.ctrl1.to_vector() * 3.0) - bezier.from.to_vector();
 
     let a = pb.x * pc.y - pb.y * pc.x;
     let b = pa.x * pc.y - pa.y * pc.x;

--- a/cli/src/tessellate.rs
+++ b/cli/src/tessellate.rs
@@ -25,7 +25,7 @@ impl ::std::convert::From<::std::io::Error> for TessError {
 pub fn tessellate(mut cmd: TessellateCmd) -> Result<(), TessError> {
 
     let mut builder = SvgPathBuilder::new(Path::builder());
-    let mut buffers: VertexBuffers<Vec2> = VertexBuffers::new();
+    let mut buffers: VertexBuffers<Point> = VertexBuffers::new();
 
     for item in parser::path::PathTokenizer::new(&cmd.input) {
         if let Ok(event) = item {
@@ -92,8 +92,8 @@ pub fn tessellate(mut cmd: TessellateCmd) -> Result<(), TessError> {
 
 struct StrokeWidth(f32);
 
-impl VertexConstructor<StrokeVertex, Vec2> for StrokeWidth {
-    fn new_vertex(&mut self, vertex: StrokeVertex) -> Vec2 {
+impl VertexConstructor<StrokeVertex, Point> for StrokeWidth {
+    fn new_vertex(&mut self, vertex: StrokeVertex) -> Point {
         assert!(!vertex.position.x.is_nan());
         assert!(!vertex.position.y.is_nan());
         assert!(!vertex.normal.x.is_nan());
@@ -105,8 +105,8 @@ impl VertexConstructor<StrokeVertex, Vec2> for StrokeWidth {
 
 struct ApplyNormal;
 
-impl VertexConstructor<FillVertex, Vec2> for ApplyNormal {
-    fn new_vertex(&mut self, vertex: FillVertex) -> Vec2 {
+impl VertexConstructor<FillVertex, Point> for ApplyNormal {
+    fn new_vertex(&mut self, vertex: FillVertex) -> Point {
         assert!(!vertex.position.x.is_nan());
         assert!(!vertex.position.y.is_nan());
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,4 +13,4 @@ workspace = ".."
 name = "lyon_core"
 
 [dependencies]
-euclid = "0.14"
+euclid = "0.14.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,4 +13,4 @@ workspace = ".."
 name = "lyon_core"
 
 [dependencies]
-euclid = "0.13"
+euclid = "0.14"

--- a/core/src/math.rs
+++ b/core/src/math.rs
@@ -1,17 +1,15 @@
 use euclid;
 use fixed;
 
-pub use euclid::TypedPoint2D;
-pub use euclid::Point2D;
-pub use euclid::Radians;
+pub use euclid::{Point2D, Vector2D, TypedPoint2D, Radians};
 
 pub type Point = euclid::Point2D<f32>;
 pub type IntPoint = euclid::Point2D<i32>;
 pub type Int64Point = euclid::Point2D<i64>;
 pub type F64Point = euclid::Point2D<f64>;
 // Point and Vec2 are the same type but they should probably be separate types.
-pub type Vec2 = euclid::Point2D<f32>;
-pub type IntVec2 = euclid::Point2D<i32>;
+pub type Vec2 = euclid::Vector2D<f32>;
+pub type IntVec2 = euclid::Vector2D<i32>;
 pub type Size = euclid::Size2D<f32>;
 pub type IntSize = euclid::Size2D<i32>;
 pub type Rect = euclid::Rect<f32>;
@@ -19,72 +17,39 @@ pub type IntRect = euclid::Rect<i32>;
 
 pub type FixedPoint32 = fixed::Fp32<fixed::_16>;
 pub type FixedPoint64 = fixed::Fp64<fixed::_16>;
-pub type TessVec2 = Point2D<FixedPoint32>;
+pub type TessVec2 = Vector2D<FixedPoint32>;
 pub type TessPoint = Point2D<FixedPoint32>;
 pub type TessPoint64 = Point2D<FixedPoint64>;
 #[inline]
 pub fn fixed(val: f32) -> FixedPoint32 { FixedPoint32::from_f32(val) }
 
-pub type Vec3 = euclid::Point3D<f32>;
-pub type IntVec3 = euclid::Point3D<i32>;
-pub type IntVec4 = euclid::Point4D<i32>;
+pub type Vec3 = euclid::Vector3D<f32>;
+pub type IntVec3 = euclid::Vector3D<i32>;
 
-pub type Mat4 = euclid::Matrix4D<f32>;
-pub type Transform2d = euclid::Matrix2D<f32>;
+pub type Mat4 = euclid::Transform3D<f32>;
+pub type Transform2d = euclid::Transform2D<f32>;
+
+pub use euclid::{vec2, rect};
+pub use euclid::point2 as point;
+pub use euclid::size2 as size;
 
 #[inline]
-pub fn point(x: f32, y: f32) -> Point { vec2(x, y) }
-#[inline]
-pub fn vec2(x: f32, y: f32) -> Vec2 { Vec2::new(x, y) }
-#[inline]
-pub fn int_vec2(x: i32, y: i32) -> IntVec2 { IntVec2::new(x, y) }
-#[inline]
-pub fn int_vec4(x: i32, y: i32, z: i32, w: i32) -> IntVec4 { IntVec4::new(x, y, z, w) }
-#[inline]
-pub fn size(w: f32, h: f32) -> Size { Size::new(w, h) }
+pub fn int_vec2(x: i32, y: i32) -> IntVec2 { vec2(x, y) }
 #[inline]
 pub fn int_size(w: i32, h: i32) -> IntSize { IntSize::new(w, h) }
 #[inline]
-pub fn rect(x: f32, y: f32, w: f32, h: f32) -> Rect { Rect::new(vec2(x, y), size(w, h)) }
-#[inline]
-pub fn int_rect(x: i32, y: i32, w: i32, h: i32) -> IntRect {
-    IntRect::new(int_vec2(x, y), int_size(w, h))
-}
+pub fn int_rect(x: i32, y: i32, w: i32, h: i32) -> IntRect { rect(x, y, w, h) }
 
 #[inline]
 pub fn rad(val: f32) -> Radians<f32> { Radians::new(val) }
 
-pub trait Vec2Array<S> {
-    #[inline]
-    fn array(self) -> [S; 2];
+pub trait Normalize {
+    fn normalize(self) -> Self;
 }
 
-impl<S> Vec2Array<S> for euclid::Point2D<S> {
+impl Normalize for Vec2 {
     #[inline]
-    fn array(self) -> [S; 2] { [self.x, self.y] }
-}
-
-pub trait Vec2Length {
-    fn length(self) -> f32;
-    fn normalized(self) -> Self;
-}
-
-pub trait Vec2SquareLength {
-    #[inline]
-    fn square_length(self) -> f32;
-}
-
-impl Vec2Length for Vec2 {
-    #[inline]
-    fn length(self) -> f32 { self.square_length().sqrt() }
-
-    #[inline]
-    fn normalized(self) -> Self { self / self.length() }
-}
-
-impl Vec2SquareLength for Vec2 {
-    #[inline]
-    fn square_length(self) -> f32 { self.x * self.x + self.y * self.y }
+    fn normalize(self) -> Self { self / self.length() }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/core/src/math_utils.rs
+++ b/core/src/math_utils.rs
@@ -11,12 +11,12 @@ pub fn fuzzy_eq_f32(a: f32, b: f32) -> bool {
 pub fn fuzzy_eq(a: Vec2, b: Vec2) -> bool { fuzzy_eq_f32(a.x, b.x) && fuzzy_eq_f32(a.y, b.y) }
 
 // Compute the vector from ce center of an ellipse on of its points
-pub fn ellipse_center_to_point(center: Vec2, ellipse_point: Vec2, radii: Vec2) -> Vec2 {
-    vec2((ellipse_point.x - center.x) / radii.x, (ellipse_point.y - center.y) / radii.y)
+pub fn ellipse_center_to_point(center: Point, ellipse_point: Point, radii: Vec2) -> Point {
+    point((ellipse_point.x - center.x) / radii.x, (ellipse_point.y - center.y) / radii.y)
 }
 
-pub fn ellipse_point_from_angle(center: Vec2, radii: Vec2, angle: f32) -> Vec2 {
-    vec2(center.x + radii.x * angle.cos(), center.y + radii.y * angle.sin())
+pub fn ellipse_point_from_angle(center: Point, radii: Vec2, angle: f32) -> Point {
+    point(center.x + radii.x * angle.cos(), center.y + radii.y * angle.sin())
 }
 
 
@@ -43,7 +43,7 @@ pub fn directed_angle(a: Vec2, b: Vec2) -> f32 {
     return if angle < 0.0 { angle + 2.0 * PI } else { angle };
 }
 
-pub fn directed_angle2(center: Vec2, a: Vec2, b: Vec2) -> f32 {
+pub fn directed_angle2(center: Point, a: Point, b: Point) -> f32 {
     directed_angle(a - center, b - center)
 }
 
@@ -89,7 +89,7 @@ pub fn tangent(v: Vec2) -> Vec2 {
     return vec2(-v.y / l, v.x / l);
 }
 
-pub fn line_intersection(a1: Vec2, a2: Vec2, b1: Vec2, b2: Vec2) -> Option<Vec2> {
+pub fn line_intersection(a1: Point, a2: Point, b1: Point, b2: Point) -> Option<Point> {
     let det = (a1.x - a2.x) * (b1.y - b2.y) - (a1.y - a2.y) * (b1.x - b2.x);
     if det.abs() <= 0.000001 {
         // The lines are very close to parallel
@@ -99,7 +99,7 @@ pub fn line_intersection(a1: Vec2, a2: Vec2, b1: Vec2, b2: Vec2) -> Option<Vec2>
     let a = a1.x * a2.y - a1.y * a2.x;
     let b = b1.x * b2.y - b1.y * b2.x;
     return Some(
-        vec2(
+        point(
             (a * (b1.x - b2.x) - b * (a1.x - a2.x)) * inv_det,
             (a * (b1.y - b2.y) - b * (a1.y - a2.y)) * inv_det,
         )
@@ -283,12 +283,12 @@ fn test_triangle_contains() {
 /// for generating strokes and vertex-aa).
 /// The normal points towards the left side of e1.
 pub fn compute_normal(e1: Vec2, e2: Vec2) -> Vec2 {
-    let e1_norm = e1.normalized();
-    let n = e1_norm - e2.normalized();
+    let e1_norm = e1.normalize();
+    let n = e1_norm - e2.normalize();
     if n.length() == 0.0 {
         return vec2(e1_norm.y, -e1_norm.x);
     }
-    let mut n_norm = n.normalized();
+    let mut n_norm = n.normalize();
 
     if e1_norm.cross(n_norm) > 0.0 {
         n_norm = -n_norm;

--- a/core/src/path_state.rs
+++ b/core/src/path_state.rs
@@ -1,5 +1,5 @@
 
-use math::{Point, Vec2};
+use math::{Point, Vec2, point, vec2};
 
 use super::{PathEvent, SvgEvent, FlattenedEvent};
 
@@ -16,9 +16,9 @@ pub struct PathState {
 impl PathState {
     pub fn new() -> Self {
         PathState {
-            current: Point::new(0.0, 0.0),
-            first: Point::new(0.0, 0.0),
-            last_ctrl: Point::new(0.0, 0.0),
+            current: point(0.0, 0.0),
+            first: point(0.0, 0.0),
+            last_ctrl: point(0.0, 0.0),
         }
     }
 }
@@ -63,19 +63,19 @@ impl PathState {
                 self.relative_next(to);
             }
             SvgEvent::HorizontalLineTo(x) => {
-                let to = Point::new(x, self.current.y);
+                let to = point(x, self.current.y);
                 self.line_to(to);
             }
             SvgEvent::VerticalLineTo(y) => {
-                let to = Point::new(self.current.x, y);
+                let to = point(self.current.x, y);
                 self.line_to(to);
             }
             SvgEvent::RelativeHorizontalLineTo(x) => {
-                let to = self.current + Point::new(x, 0.0);
+                let to = self.current + vec2(x, 0.0);
                 self.line_to(to);
             }
             SvgEvent::RelativeVerticalLineTo(y) => {
-                let to = self.current + Point::new(0.0, y);
+                let to = self.current + vec2(0.0, y);
                 self.line_to(to);
             }
             SvgEvent::SmoothQuadraticTo(to) => {
@@ -158,7 +158,7 @@ impl PathState {
 
     pub fn next(&mut self, to: Point) { self.current = to; }
 
-    pub fn relative_next(&mut self, to: Point) { self.current = self.from_relative(to); }
+    pub fn relative_next(&mut self, to: Vec2) { self.current = self.from_relative(to); }
 
     pub fn get_smooth_ctrl(&self) -> Point { self.current + (self.current - self.last_ctrl) }
 
@@ -184,14 +184,14 @@ impl PathState {
                 )
             }
             SvgEvent::HorizontalLineTo(x) => {
-                PathEvent::LineTo(Point::new(x, self.current.y))
+                PathEvent::LineTo(point(x, self.current.y))
             }
-            SvgEvent::VerticalLineTo(y) => PathEvent::LineTo(Point::new(self.current.x, y)),
+            SvgEvent::VerticalLineTo(y) => PathEvent::LineTo(point(self.current.x, y)),
             SvgEvent::RelativeHorizontalLineTo(x) => {
-                PathEvent::LineTo(Point::new(self.current.x + x, self.current.y))
+                PathEvent::LineTo(point(self.current.x + x, self.current.y))
             }
             SvgEvent::RelativeVerticalLineTo(y) => {
-                PathEvent::LineTo(Point::new(self.current.x, self.current.y + y))
+                PathEvent::LineTo(point(self.current.x, self.current.y + y))
             }
             SvgEvent::SmoothQuadraticTo(to) => {
                 PathEvent::QuadraticTo(self.get_smooth_ctrl(), to)

--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -70,7 +70,7 @@ pub fn gfx_sub_slice<R: gfx::Resources>(slice: gfx::Slice<R>, from: u32, to: u32
 struct BgVertexCtor;
 impl VertexConstructor<tessellation::FillVertex, BgVertex> for BgVertexCtor {
     fn new_vertex(&mut self, vertex: tessellation::FillVertex) -> BgVertex {
-        BgVertex { position: vertex.position.array() }
+        BgVertex { position: vertex.position.to_array() }
     }
 }
 
@@ -188,7 +188,7 @@ fn main() {
 
     let circle_indices_start = cpu.fills.indices.len() as u32;
     let circle_count = fill_circle(
-        vec2(0.0, 0.0),
+        point(0.0, 0.0),
         1.0,
         0.01,
         &mut BuffersBuilder::new(
@@ -197,7 +197,7 @@ fn main() {
         ),
     );
     fill_circle(
-        vec2(0.0, 0.0),
+        point(0.0, 0.0),
         0.5,
         0.01,
         &mut BuffersBuilder::new(
@@ -237,7 +237,7 @@ fn main() {
 
     let mut bg_mesh_cpu: VertexBuffers<BgVertex> = VertexBuffers::new();
     fill_rectangle(
-        &Rect::new(vec2(-1.0, -1.0), size(2.0, 2.0)),
+        &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
         &mut BuffersBuilder::new(&mut bg_mesh_cpu, BgVertexCtor),
     );
 
@@ -405,7 +405,7 @@ fn main() {
         *cpu.transforms[view_transform].as_mut_mat4() = Mat4::create_translation(
             -scene.scroll.x as f32,
             -scene.scroll.y as f32, 0.0
-        ).post_scaled(scene.zoom, scene.zoom, 1.0);
+        ).post_scale(scene.zoom, scene.zoom, 1.0);
 
         cmd_queue.clear(&main_fbo.clone(), [0.0, 0.0, 0.0, 0.0]);
         cmd_queue.clear_depth(&main_depth.clone(), 1.0);
@@ -419,7 +419,7 @@ fn main() {
             &Globals {
                 resolution: [w as f32, h as f32],
                 zoom: scene.zoom,
-                scroll_offset: scene.scroll.array(),
+                scroll_offset: scene.scroll.to_array(),
             },
         );
 

--- a/examples/gfx_basic/src/main.rs
+++ b/examples/gfx_basic/src/main.rs
@@ -39,7 +39,7 @@ impl VertexConstructor<tessellation::FillVertex, GpuFillVertex> for VertexCtor {
         GpuFillVertex {
             // (ugly hack) tweak the vertext position so that the logo fits roughly
             // within the (-1.0, 1.0) range.
-            position: (vertex.position * 0.0145 - point(1.0, 1.0)).array(),
+            position: (vertex.position * 0.0145 - vec2(1.0, 1.0)).to_array(),
         }
     }
 }
@@ -51,7 +51,7 @@ fn main() {
     let path = builder.build();
 
     let mut tessellator = FillTessellator::new();
-    
+
     let mut mesh = VertexBuffers::new();
 
     tessellator.tessellate_path(

--- a/extra/src/debugging.rs
+++ b/extra/src/debugging.rs
@@ -1,11 +1,11 @@
 use core::PathEvent;
-use core::math::Vec2;
+use core::math::Point;
 use path::{Path, PathSlice};
 use path_builder::BaseBuilder;
 
-pub type Polygons = Vec<Vec<Vec2>>;
+pub type Polygons = Vec<Vec<Point>>;
 
-pub fn path_to_polygons(path: PathSlice) -> Vec<Vec<Vec2>> {
+pub fn path_to_polygons(path: PathSlice) -> Polygons {
     let mut polygons = Vec::new();
     let mut poly = Vec::new();
     for evt in path.path_iter() {

--- a/extra/src/lib.rs
+++ b/extra/src/lib.rs
@@ -9,6 +9,6 @@ extern crate lyon_path_builder as path_builder;
 extern crate lyon_path_iterator as path_iterator;
 
 pub mod rust_logo;
-pub mod triangle_rasterizer;
+//pub mod triangle_rasterizer;
 pub mod debugging;
 pub mod image;

--- a/extra/src/rust_logo.rs
+++ b/extra/src/rust_logo.rs
@@ -1,8 +1,8 @@
 use path_builder::SvgBuilder;
-use core::math::vec2;
+use core::math::{vec2, point};
 
 pub fn build_logo_path<Builder: SvgBuilder>(path: &mut Builder) {;
-    path.move_to(vec2(122.631, 69.716));
+    path.move_to(point(122.631, 69.716));
     path.relative_line_to(vec2(-4.394, -2.72));
     path.relative_cubic_bezier_to(vec2(-0.037, -0.428), vec2(-0.079, -0.855), vec2(-0.125, -1.28));
     path.relative_line_to(vec2(3.776, -3.522));
@@ -162,17 +162,17 @@ pub fn build_logo_path<Builder: SvgBuilder>(path: &mut Builder) {;
     path.relative_cubic_bezier_to(vec2(0.046, -0.425), vec2(0.088, -0.853), vec2(0.125, -1.28));
     path.relative_line_to(vec2(4.394, -2.72));
     path.relative_cubic_bezier_to(vec2(0.445, -0.274), vec2(0.716, -0.761), vec2(0.716, -1.285));
-    path.smooth_cubic_bezier_to(vec2(123.076, 69.991), vec2(122.631, 69.716));
+    path.smooth_cubic_bezier_to(point(123.076, 69.991), point(122.631, 69.716));
     path.close();
 
-    path.move_to(vec2(93.222, 106.167));
+    path.move_to(point(93.222, 106.167));
     path.relative_cubic_bezier_to(vec2(-1.678, -0.362), vec2(-2.745, -2.016), vec2(-2.385, -3.699));
     path.relative_cubic_bezier_to(vec2(0.359, -1.681), vec2(2.012, -2.751), vec2(3.689, -2.389));
     path.relative_cubic_bezier_to(vec2(1.678, 0.359), vec2(2.747, 2.016), vec2(2.387, 3.696));
-    path.smooth_cubic_bezier_to(vec2(94.899, 106.526), vec2(93.222, 106.167));
+    path.smooth_cubic_bezier_to(point(94.899, 106.526), point(93.222, 106.167));
     path.close();
 
-    path.move_to(vec2(91.729, 96.069));
+    path.move_to(point(91.729, 96.069));
     path.relative_cubic_bezier_to(vec2(-1.531, -0.328), vec2(-3.037, 0.646), vec2(-3.365, 2.18));
     path.relative_line_to(vec2(-1.56, 7.28));
     path.relative_cubic_bezier_to(vec2(-4.814, 2.185), vec2(-10.16, 3.399), vec2(-15.79, 3.399));
@@ -194,24 +194,24 @@ pub fn build_logo_path<Builder: SvgBuilder>(path: &mut Builder) {;
     path.relative_horizontal_line_to(15.583);
     path.relative_cubic_bezier_to(vec2(0.177, 0.0), vec2(0.366, -0.02), vec2(0.565, -0.056));
     path.relative_cubic_bezier_to(vec2(-1.081, 1.469), vec2(-2.267, 2.859), vec2(-3.544, 4.158));
-    path.line_to(vec2(91.729, 96.069));
+    path.line_to(point(91.729, 96.069));
     path.close();
 
-    path.move_to(vec2(48.477, 106.015));
+    path.move_to(point(48.477, 106.015));
     path.relative_cubic_bezier_to(vec2(-1.678, 0.362), vec2(-3.33, -0.708), vec2(-3.691, -2.389));
     path.relative_cubic_bezier_to(vec2(-0.359, -1.684), vec2(0.708, -3.337), vec2(2.386, -3.699));
     path.relative_cubic_bezier_to(vec2(1.678, -0.359), vec2(3.331, 0.711), vec2(3.691, 2.392));
-    path.cubic_bezier_to(vec2(51.222, 103.999), vec2(50.154, 105.655), vec2(48.477, 106.015));
+    path.cubic_bezier_to(point(51.222, 103.999), point(50.154, 105.655), point(48.477, 106.015));
     path.close();
 
-    path.move_to(vec2(36.614, 57.91));
+    path.move_to(point(36.614, 57.91));
     path.relative_cubic_bezier_to(vec2(0.696, 1.571), vec2(-0.012, 3.412), vec2(-1.581, 4.107));
     path.relative_cubic_bezier_to(vec2(-1.569, 0.697), vec2(-3.405, -0.012), vec2(-4.101, -1.584));
     path.relative_cubic_bezier_to(vec2(-0.696, -1.572), vec2(0.012, -3.41), vec2(1.581, -4.107));
-    path.cubic_bezier_to(vec2(34.083, 55.63), vec2(35.918, 56.338), vec2(36.614, 57.91));
+    path.cubic_bezier_to(point(34.083, 55.63), point(35.918, 56.338), point(36.614, 57.91));
     path.close();
 
-    path.move_to(vec2(32.968, 66.553));
+    path.move_to(point(32.968, 66.553));
     path.relative_line_to(vec2(6.695, -2.975));
     path.relative_cubic_bezier_to(vec2(1.43, -0.635), vec2(2.076, -2.311), vec2(1.441, -3.744));
     path.relative_line_to(vec2(-1.379, -3.118));
@@ -223,10 +223,10 @@ pub fn build_logo_path<Builder: SvgBuilder>(path: &mut Builder) {;
         vec2(-1.458, -6.857),
         vec2(-1.458, -10.496),
     );
-    path.cubic_bezier_to(vec2(32.749, 69.275), vec2(32.824, 67.902), vec2(32.968, 66.553));
+    path.cubic_bezier_to(point(32.749, 69.275), point(32.824, 67.902), point(32.968, 66.553));
     path.close();
 
-    path.move_to(vec2(62.348, 64.179));
+    path.move_to(point(62.348, 64.179));
     path.relative_vertical_line_to(-7.205);
     path.relative_horizontal_line_to(12.914);
     path.relative_cubic_bezier_to(vec2(0.667, 0.0), vec2(4.71, 0.771), vec2(4.71, 3.794));
@@ -234,7 +234,7 @@ pub fn build_logo_path<Builder: SvgBuilder>(path: &mut Builder) {;
     //path.horizontal_line_to(62.348) //TODO;
     path.close();
 
-    path.move_to(vec2(109.28, 70.664));
+    path.move_to(point(109.28, 70.664));
     path.relative_cubic_bezier_to(vec2(0.0, 0.956), vec2(-0.035, 1.902), vec2(-0.105, 2.841));
     path.relative_horizontal_line_to(-3.926);
     path.relative_cubic_bezier_to(vec2(-0.393, 0.0), vec2(-0.551, 0.258), vec2(-0.551, 0.643));
@@ -262,20 +262,20 @@ pub fn build_logo_path<Builder: SvgBuilder>(path: &mut Builder) {;
     path.relative_line_to(vec2(-3.666, 8.28));
     path.relative_cubic_bezier_to(vec2(-0.633, 1.433), vec2(0.013, 3.109), vec2(1.442, 3.744));
     path.relative_line_to(vec2(7.058, 3.135));
-    path.cubic_bezier_to(vec2(109.216, 68.115), vec2(109.28, 69.381), vec2(109.28, 70.664));
+    path.cubic_bezier_to(point(109.216, 68.115), point(109.28, 69.381), point(109.28, 70.664));
     path.close();
 
-    path.move_to(vec2(68.705, 28.784));
+    path.move_to(point(68.705, 28.784));
     path.relative_cubic_bezier_to(vec2(1.24, -1.188), vec2(3.207, -1.141), vec2(4.394, 0.101));
     path.relative_cubic_bezier_to(vec2(1.185, 1.245), vec2(1.14, 3.214), vec2(-0.103, 4.401));
     path.relative_cubic_bezier_to(vec2(-1.24, 1.188), vec2(-3.207, 1.142), vec2(-4.394, -0.102));
-    path.cubic_bezier_to(vec2(67.418, 31.941), vec2(67.463, 29.972), vec2(68.705, 28.784));
+    path.cubic_bezier_to(point(67.418, 31.941), point(67.463, 29.972), point(68.705, 28.784));
     path.close();
 
-    path.move_to(vec2(105.085, 58.061));
+    path.move_to(point(105.085, 58.061));
     path.relative_cubic_bezier_to(vec2(0.695, -1.571), vec2(2.531, -2.28), vec2(4.1, -1.583));
     path.relative_cubic_bezier_to(vec2(1.569, 0.696), vec2(2.277, 2.536), vec2(1.581, 4.107));
     path.relative_cubic_bezier_to(vec2(-0.695, 1.572), vec2(-2.531, 2.281), vec2(-4.101, 1.584));
-    path.cubic_bezier_to(vec2(105.098, 61.473), vec2(104.39, 59.634), vec2(105.085, 58.061));
+    path.cubic_bezier_to(point(105.098, 61.473), point(104.39, 59.634), point(105.085, 58.061));
     path.close();
 }

--- a/path_builder/src/path_builder.rs
+++ b/path_builder/src/path_builder.rs
@@ -186,7 +186,7 @@ impl<Builder: PathBuilder> SvgPathBuilder<Builder> {
     pub fn new(builder: Builder) -> SvgPathBuilder<Builder> {
         SvgPathBuilder {
             builder: builder,
-            last_ctrl: vec2(0.0, 0.0),
+            last_ctrl: point(0.0, 0.0),
         }
     }
 }
@@ -209,7 +209,7 @@ impl<Builder: PathBuilder> BaseBuilder for SvgPathBuilder<Builder> {
         self.builder.close()
     }
 
-    fn current_position(&self) -> Vec2 { self.builder.current_position() }
+    fn current_position(&self) -> Point { self.builder.current_position() }
 
     fn build(self) -> Builder::PathType { self.builder.build() }
 
@@ -241,12 +241,12 @@ impl<Builder: PathBuilder> SvgBuilder for SvgPathBuilder<Builder> {
 
     fn relative_quadratic_bezier_to(&mut self, ctrl: Vec2, to: Vec2) {
         let offset = self.builder.current_position();
-        self.quadratic_bezier_to(ctrl + offset, to + offset);
+        self.quadratic_bezier_to(offset + ctrl, offset + to);
     }
 
     fn relative_cubic_bezier_to(&mut self, ctrl1: Vec2, ctrl2: Vec2, to: Vec2) {
         let offset = self.builder.current_position();
-        self.cubic_bezier_to(ctrl1 + offset, ctrl2 + offset, to + offset);
+        self.cubic_bezier_to(offset + ctrl1, offset + ctrl2, offset + to);
     }
 
     fn smooth_cubic_bezier_to(&mut self, ctrl2: Point, to: Point) {
@@ -273,22 +273,22 @@ impl<Builder: PathBuilder> SvgBuilder for SvgPathBuilder<Builder> {
 
     fn horizontal_line_to(&mut self, x: f32) {
         let y = self.builder.current_position().y;
-        self.line_to(vec2(x, y));
+        self.line_to(point(x, y));
     }
 
     fn relative_horizontal_line_to(&mut self, dx: f32) {
         let p = self.builder.current_position();
-        self.line_to(vec2(p.x + dx, p.y));
+        self.line_to(point(p.x + dx, p.y));
     }
 
     fn vertical_line_to(&mut self, y: f32) {
         let x = self.builder.current_position().x;
-        self.line_to(vec2(x, y));
+        self.line_to(point(x, y));
     }
 
     fn relative_vertical_line_to(&mut self, dy: f32) {
         let p = self.builder.current_position();
-        self.line_to(vec2(p.x, p.y + dy));
+        self.line_to(point(p.x, p.y + dy));
     }
 
     // x_rotation in radian
@@ -310,7 +310,7 @@ impl<Builder: PathBuilder> SvgBuilder for SvgPathBuilder<Builder> {
         flags: ArcFlags,
     ) {
         let offset = self.builder.current_position();
-        self.arc_to(to + offset, radii, x_rotation, flags);
+        self.arc_to(offset + to, radii, x_rotation, flags);
     }
 }
 

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -185,8 +185,8 @@ impl VertexConstructor<tessellation::FillVertex, GpuFillVertex> for WithId<GpuFi
         assert!(!vertex.normal.x.is_nan());
         assert!(!vertex.normal.y.is_nan());
         GpuFillVertex {
-            position: vertex.position.array(),
-            normal: vertex.normal.array(),
+            position: vertex.position.to_array(),
+            normal: vertex.normal.to_array(),
             prim_id: self.0.to_i32(),
         }
     }
@@ -199,8 +199,8 @@ impl VertexConstructor<tessellation::StrokeVertex, GpuStrokeVertex> for WithId<G
         assert!(!vertex.normal.x.is_nan());
         assert!(!vertex.normal.y.is_nan());
         GpuStrokeVertex {
-            position: vertex.position.array(),
-            normal: vertex.normal.array(),
+            position: vertex.position.to_array(),
+            normal: vertex.normal.to_array(),
             prim_id: self.0.to_i32(),
         }
     }

--- a/svg/src/parser/path.rs
+++ b/svg/src/parser/path.rs
@@ -2,7 +2,7 @@
 use svgparser::{ Tokenize, TextFrame };
 use svgparser::path::{ Tokenizer, Token };
 use core::SvgEvent;
-use core::math::*;
+use core::math;
 use core::ArcFlags;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -44,20 +44,21 @@ impl<'l> Iterator for PathTokenizer<'l> {
 }
 
 fn svg_event(token: &Token) -> SvgEvent {
-    fn v(x: f64, y: f64) -> Point { point(x as f32, y as f32) }
+    fn vec2(x: f64, y: f64) -> math::Vec2 { math::vec2(x as f32, y as f32) }
+    fn point2(x: f64, y: f64) -> math::Point { math::point(x as f32, y as f32) }
     match *token {
         Token::MoveTo { abs, x, y } => {
             if abs {
-                SvgEvent::MoveTo(v(x, y))
+                SvgEvent::MoveTo(point2(x, y))
             } else {
-                SvgEvent::RelativeMoveTo(v(x, y))
+                SvgEvent::RelativeMoveTo(vec2(x, y))
             }
         },
         Token::LineTo { abs, x, y } => {
             if abs {
-                SvgEvent::LineTo(v(x, y))
+                SvgEvent::LineTo(point2(x, y))
             } else {
-                SvgEvent::RelativeLineTo(v(x, y))
+                SvgEvent::RelativeLineTo(vec2(x, y))
             }
         },
         Token::HorizontalLineTo { abs, x } => {
@@ -76,42 +77,46 @@ fn svg_event(token: &Token) -> SvgEvent {
         },
         Token::CurveTo { abs, x1, y1, x2, y2, x, y } => {
             if abs {
-                SvgEvent::CubicTo(v(x1, y1), v(x2, y2), v(x, y))
+                SvgEvent::CubicTo(point2(x1, y1), point2(x2, y2), point2(x, y))
             } else {
-                SvgEvent::RelativeCubicTo(v(x1, y1), v(x2, y2), v(x, y))
+                SvgEvent::RelativeCubicTo(vec2(x1, y1), vec2(x2, y2), vec2(x, y))
             }
         },
         Token::SmoothCurveTo { abs, x2, y2, x, y } => {
             if abs {
-                SvgEvent::SmoothCubicTo(v(x2, y2), v(x, y))
+                SvgEvent::SmoothCubicTo(point2(x2, y2), point2(x, y))
             } else {
-                SvgEvent::SmoothRelativeCubicTo(v(x2, y2), v(x, y))
+                SvgEvent::SmoothRelativeCubicTo(vec2(x2, y2), vec2(x, y))
             }
         },
         Token::Quadratic { abs, x1, y1, x, y } => {
             if abs {
-                SvgEvent::QuadraticTo(v(x1, y1), v(x, y))
+                SvgEvent::QuadraticTo(point2(x1, y1), point2(x, y))
             } else {
-                SvgEvent::RelativeQuadraticTo(v(x1, y1), v(x, y))
+                SvgEvent::RelativeQuadraticTo(vec2(x1, y1), vec2(x, y))
             }
         },
         Token::SmoothQuadratic { abs, x, y } => {
             if abs {
-                SvgEvent::SmoothQuadraticTo(v(x, y))
+                SvgEvent::SmoothQuadraticTo(point2(x, y))
             } else {
-                SvgEvent::SmoothRelativeQuadraticTo(v(x, y))
+                SvgEvent::SmoothRelativeQuadraticTo(vec2(x, y))
             }
         },
         Token::EllipticalArc { abs, rx, ry, x_axis_rotation, large_arc, sweep, x, y } => {
             if abs {
                 SvgEvent::ArcTo(
-                v(x, y), v(rx, ry), Radians::new(x_axis_rotation.to_radians() as f32),
-                ArcFlags { large_arc: large_arc, sweep: sweep }
+                    point2(x, y),
+                    vec2(rx, ry),
+                    math::Radians::new(x_axis_rotation.to_radians() as f32),
+                    ArcFlags { large_arc: large_arc, sweep: sweep }
                 )
             } else {
                 SvgEvent::RelativeArcTo(
-                v(x, y), v(rx, ry), Radians::new(x_axis_rotation.to_radians() as f32),
-                ArcFlags { large_arc: large_arc, sweep: sweep }
+                    vec2(x, y),
+                    vec2(rx, ry),
+                    math::Radians::new(x_axis_rotation.to_radians() as f32),
+                    ArcFlags { large_arc: large_arc, sweep: sweep }
                 )
             }
         },

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -664,6 +664,8 @@ where
     return output.end_geometry();
 }
 
+/// Tessellate the stroke of a shape that is discribed by an iterator of points
+/// (convenient when tessellating a shape that is represented as a slice `&[Point]`).
 pub fn stroke_polyline<Iter, Output>(it: Iter, is_closed: bool, output: &mut Output) -> Count
 where
     Iter: Iterator<Item = Point>,

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -589,10 +589,22 @@ pub fn fill_circle<Output: GeometryBuilder<FillVertex>>(
     let right = vec2(1.0, 0.0);
 
     let v = [
-        output.add_vertex(FillVertex { position: left * radius, normal: left }),
-        output.add_vertex(FillVertex { position: up * radius, normal: up }),
-        output.add_vertex(FillVertex { position: right * radius, normal: right }),
-        output.add_vertex(FillVertex { position: down * radius, normal: down }),
+        output.add_vertex(FillVertex {
+            position: (left * radius).to_point(),
+            normal: left
+        }),
+        output.add_vertex(FillVertex {
+            position: (up * radius).to_point(),
+            normal: up
+        }),
+        output.add_vertex(FillVertex {
+            position: (right * radius).to_point(),
+            normal: right
+        }),
+        output.add_vertex(FillVertex {
+            position: (down * radius).to_point(),
+            normal: down
+        }),
     ];
 
     output.add_triangle(v[0], v[1], v[3]);

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -38,17 +38,98 @@
 //! * [geometry_builder](geometry_builder/index.html) - Which the above two are built on. It
 //!   provides traits to facilitate generating arbitrary vertex and index buffers.
 //!
+//! ## The tessellation pipeline
+//!
+//! <svg xmlns="http://www.w3.org/2000/svg" width="280mm" height="42mm" viewBox="0 0 280 42">
+//!   <defs>
+//!     <marker id="e" orient="auto" overflow="visible">
+//!       <path fill="#59f" fill-rule="evenodd" stroke="#59f" stroke-width=".532" d="M-4 0l-2 2 7-2-7-2z"/>
+//!     </marker>
+//!     <marker id="d" orient="auto" overflow="visible">
+//!       <path fill-rule="evenodd" stroke="#000" stroke-width=".532" d="M-4 0l-2 2 7-2-7-2z"/>
+//!     </marker>
+//!     <marker id="c" orient="auto" overflow="visible">
+//!       <path fill="#59f" fill-rule="evenodd" stroke="#59f" stroke-width=".532" d="M-4 0l-2 2 7-2-7-2z"/>
+//!     </marker>
+//!     <marker id="b" orient="auto" overflow="visible">
+//!       <path fill-rule="evenodd" stroke="#000" stroke-width=".532" d="M-4 0l-2 2 7-2-7-2z"/>
+//!     </marker>
+//!     <marker id="a" orient="auto" overflow="visible">
+//!       <path fill-rule="evenodd" stroke="#000" stroke-width=".532" d="M-4 0l-2 2 7-2-7-2z"/>
+//!     </marker>
+//!   </defs>
+//!   <path fill="#fff" stroke="#000" stroke-opacity=".56" stroke-width=".26" stroke-miterlimit="4.27" d="M39.55 17.37h15.8l2.15-1.7 2.06 1.7h15.36V38.8H39.55zM194.65 31.3h21.58l2.1-1.83 2.04 1.82h35.07v7.07h-60.8zM77.7 19.5h54.6l3.3-2.58 3.17 2.57h52.56v19H77.7z" color="#000" overflow="visible" stroke-linecap="round" stroke-linejoin="round"/>
+//!   <g color="#000">
+//!     <path fill="#80b3ff" d="M194.6 20.37h50.65v8.73H194.6z" overflow="visible"/>
+//!     <path fill="#d5f6ff" d="M194.6 19.3h50.65v8.74H194.6z" overflow="visible"/>
+//!   </g>
+//!   <g color="#000">
+//!     <path fill="#2a7fff" d="M221.6 5.74h21.56v8.73H221.6z" overflow="visible"/>
+//!     <path fill="#d5f6ff" d="M221.6 4.68h21.56v8.73H221.6z" overflow="visible"/>
+//!   </g>
+//!   <g color="#000">
+//!     <path fill="#2a7fff" d="M154.38 5.74h47.4v8.73h-47.4z" overflow="visible"/>
+//!     <path fill="#d5f6ff" d="M154.38 4.68h47.4v8.73h-47.4z" overflow="visible"/>
+//!   </g>
+//!   <g color="#000">
+//!     <path fill="#2a7fff" d="M91.94 5.74h39.34v8.73H91.94z" overflow="visible"/>
+//!     <path fill="#d5f6ff" d="M91.94 4.68h39.34v8.73H91.94z" overflow="visible"/>
+//!   </g>
+//!   <g color="#000">
+//!     <path fill="#2a7fff" d="M3.04 5.74H75.2v8.73H3.03z" overflow="visible"/>
+//!     <path fill="#d5f6ff" d="M3.04 4.68H75.2v8.73H3.03z" overflow="visible"/>
+//!   </g>
+//!   <text x="93.73" y="266.09" stroke-width=".26" style="line-height:6.61458302px" font-size="5.29" font-family="Sans" letter-spacing="0" word-spacing="0" transform="translate(0 -255)">
+//!     <tspan x="93.73" y="266.09">FillTessellator</tspan>
+//!   </text>
+//!   <text x="155.37" y="265.58" stroke-width=".26" style="line-height:6.61458302px" font-size="5.29" font-family="Sans" letter-spacing="0" word-spacing="0" transform="translate(0 -255)">
+//!     <tspan x="155.37" y="265.58">GeometryBuilder</tspan>
+//!   </text>
+//!   <text x="223.1" y="266.02" stroke-width=".26" style="line-height:6.61458302px" font-size="5.29" font-family="Sans" letter-spacing="0" word-spacing="0" transform="translate(0 -255)">
+//!     <tspan x="223.1" y="266.02">output</tspan>
+//!   </text>
+//!   <text x="196.17" y="280.9" stroke-width=".26" style="line-height:6.61458302px" font-size="5.29" font-family="Sans" letter-spacing="0" word-spacing="0" transform="translate(0 -255)">
+//!     <tspan x="196.17" y="280.9">VertexConstructor</tspan>
+//!   </text>
+//!   <text x="5.13" y="266.09" stroke-width=".26" style="line-height:6.61458302px" font-size="5.29" font-family="Sans" letter-spacing="0" word-spacing="0" transform="translate(0 -255)">
+//!     <tspan x="5.13" y="266.09">Iterator&lt;FlattenedEvent&gt;</tspan>
+//!   </text>
+//!   <text x="79.79" y="282.2" stroke-width=".26" style="line-height:6.61458302px" font-size="5.29" font-family="Sans" letter-spacing="0" word-spacing="0" transform="translate(0 -255)">
+//!     <tspan x="79.79" y="282.2" fill="navy" font-size="4.23">builder.add_vertex(FillVertex) -&gt; VertexId;</tspan><tspan x="79.79" y="289.09" fill="navy" font-size="4.23">builder.add_triangle(VertexId, <tspan stroke-width=".07" style="line-height:1.75010836px;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;shape-padding:0" white-space="normal">VertexId, VertexId);</tspan></tspan>
+//!   </text>
+//!   <path fill="none" stroke="#000" stroke-width=".3" stroke-miterlimit="4.4" d="M76.94 265l13.64-.1" marker-end="url(#a)" transform="translate(0 -255)"/>
+//!   <path fill="none" stroke="#000" stroke-width=".3" stroke-miterlimit="4.4" d="M132.86 265l19.55-.1" marker-end="url(#b)" transform="translate(0 -255)"/>
+//!   <path fill="#59f" fill-rule="evenodd" stroke="#59f" stroke-width=".3" stroke-miterlimit="4.4" d="M203.38 264.53l8.27 8.26" marker-end="url(#c)" transform="translate(0 -255)"/>
+//!   <path fill="none" stroke="#000" stroke-width=".3" stroke-miterlimit="4.4" d="M203.38 264.53l16 .06" marker-end="url(#d)" transform="translate(0 -255)"/>
+//!   <text x="196.69" y="291.41" stroke-width=".26" style="line-height:6.61458302px" font-size="5.29" font-family="Sans" letter-spacing="0" word-spacing="0" transform="translate(0 -255)">
+//!     <tspan x="196.69" y="291.41" fill="navy" font-size="4.23">FillVertex -&gt; CustomVertex</tspan>
+//!   </text>
+//!   <path fill="#59f" fill-rule="evenodd" stroke="#59f" stroke-width=".3" stroke-miterlimit="4.4" d="M212.97 272.98l6.75-6.5" marker-end="url(#e)" transform="translate(0 -255)"/>
+//!   <g fill="none" stroke="#000" stroke-width=".26">
+//!     <path d="M7.2 30.1l2.98 1.72h3.24l1.78-1.8 2.62-.75 2.08 1.83-1.6 2.87-5.64 1.54-3.5-1.62zM32.6 30.1l-3 1.72H26.4l-1.78-1.8-2.62-.75-2.08 1.83 1.6 2.87 5.64 1.54 3.5-1.62zM15 20.67l-.5 4.42 1.34 1 1.63-1.57-1.06-4.03zM24.53 20.67l.5 4.42-1.33 1-1.63-1.57 1.06-4.03z"/>
+//!   </g>
+//!   <path fill="#b7c8c4" fill-rule="evenodd" stroke="#000" stroke-width=".15" d="M251.68 19.5l2.98 1.74h3.23l1.78-1.8 2.62-.75 2.07 1.82-1.6 2.87-5.63 1.53-3.5-1.63z" stroke-linecap="round" stroke-linejoin="round"/>
+//!   <path fill="#b7c8c4" fill-rule="evenodd" stroke="#000" stroke-width=".15" d="M277.07 19.5l-2.98 1.74h-3.24l-1.8-1.8-2.6-.75-2.1 1.82L266 23.4l5.63 1.53 3.5-1.63zM259.48 10.08l-.5 4.42 1.33 1 1.65-1.55-1.07-4.03zM269 10.08l.52 4.42-1.34 1-1.64-1.55 1.07-4.03z" stroke-linecap="round" stroke-linejoin="round"/>
+//!   <path fill="none" stroke="#000" stroke-width=".15" d="M258.97 14.5l2.98-.55-2.47-3.87M266.54 13.95l2.98.55-1.9-4.58M254.66 21.24l-1 2.06 4.23-2.06-.76 3.7 2.54-5.5 3.1 3.95-.48-4.7M275.1 23.3l-1-2.06-2.5 3.7-.74-3.7-4.4-2.55-.48 4.7 4.88-2.16" stroke-linecap="round" stroke-linejoin="round"/>
+//!   <text x="43.5" y="277.68" stroke-width=".26" style="line-height:6.61458349px" font-size="5.29" font-family="Sans" letter-spacing="0" word-spacing="0" transform="translate(0 -255)">
+//!     <tspan x="43.5" y="277.68" fill="navy" font-size="3.88">MoveTo(Point)</tspan><tspan x="43.5" y="284.66" fill="navy" font-size="3.88">LineTo(Point)</tspan><tspan x="43.5" y="291.65" fill="navy" font-size="3.88">Close</tspan>
+//!   </text>
+//! </svg>
+//!
+//! The figure above shows each step of the fill tessellation pipeline.
+//! Tessellating strokes works the same way using `StrokeVertex` instead of `FillVertex`.
+//!
 //! ### The input: iterators
 //!
 //! The path tessellators are not tied to a particular data structure. Instead they consume
-//! iterators of [path events](https://docs.rs/lyon_core/*/lyon_core/events/index.html).
+//! iterators of flattened [path events](https://docs.rs/lyon_core/*/lyon_core/events/index.html).
 //! A [Path struct](https://docs.rs/lyon_path/*/lyon_path/struct.Path.html) in the crate
 //! [lyon_path](https://docs.rs/lyon_path/*/lyon_path/) is provided for convenience
-//! (but is not mandatory).
+//! (but is optional).
 //!
-//! The fill tessellator builds a [FillEvents object](path_fill/struct.FillEvents.html) from
-//! the iterator. It is an intermediate representation which can be cached if the path needs
-//! to be tessellated again.
+//! While the path tessellators use iterators, other more specific tessellation routines
+//! take simpler outputs like rectangles and circles.
+//! See the documentation of the [basic_shapes](basic_shapes/index.html) module.
 //!
 //! ### The output: geometry builders
 //!
@@ -56,22 +137,31 @@
 //! [GeometryBuilder trait](geometry_builder/trait.GeometryBuilder.html).
 //! This trait provides some simple methods to add vertices and triangles, without enforcing
 //! any particular representation for the resulting geometry. This is important because each
-//! application has its own internal representation for the vertex and index buffers sent to
-//! the GPU, and the tessellator needs to be able to write directly into these buffers without
-//! enforcing a particular vertex layout.
+//! application will usually want to work with its own vertex type tailored a certain rendering
+//! model.
 //!
 //! Each application will implement the ```GeometryBuilder<Point>``` trait in order to
 //! generate vertex buffers and index buffers any type of vertex they want taking a 2d Point
 //! as input for each vertex.
 //! The structs [VertexBuffers](geometry_builder/struct.VertexBuffers.html) and
 //! [geometry_buider::BuffersBuilder](geometry_builder/struct.BuffersBuilder.html) are provided
-//! for convenience.
+//! for convenience. `VertexBuffers<T>` is contains a `Vec<T>` for the vertices and a `Vec<u16>`
+//! for the indices.
+//!
+//! `BuffersBuilder` is generic over a `VertexConstructor<InputVertex, OutputVertex>` trait which
+//! creates the application's output vertices from the tessellator input vertices (either `FillVertex`
+//! or `StrokeVertex`).
 //!
 //! ## Examples
 //!
-//! See the examples in the [path_fill](path_fill/index.html) and [path_stroke](path_stroke/index.html)
-//! modules documentation.
+//! - [tessellating path fills](path_fill/index.html#examples).
+//! - [tessellating path strokes](path_stroke/index.html#examples).
+//! - [Generating custom vertices](geometry_builder/index.html#generating-custom-vertices).
+//! - [Generating completely custom output](geometry_builder/index.html#generating-a-completely-custom-output).
+//! - [Writing a tessellator](geometry_builder/index.html#writing-a-tessellator).
 //!
+
+
 
 #![allow(dead_code)]
 
@@ -100,7 +190,7 @@ pub use path_fill::*;
 pub use path_stroke::*;
 
 #[doc(inline)]
-pub use geometry_builder::{GeometryBuilder, VertexBuffers};
+pub use geometry_builder::{GeometryBuilder, BezierGeometryBuilder, VertexBuffers, BuffersBuilder, VertexConstructor, Count};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Side {

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -248,7 +248,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
             if self.options.line_cap == LineCap::Square {
                 // The easiest way to implement square caps is to lie about the current position
                 // and move it slightly to accommodate for the width/2 extra length.
-                self.current = self.current + d.normalized() * hw;
+                self.current = self.current + d.normalize() * hw;
             }
             let p = self.current + d;
             self.edge_to(p);
@@ -262,7 +262,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
             let d = first - self.second;
 
             if self.options.line_cap == LineCap::Square {
-                first = first + d.normalized() * hw;
+                first = first + d.normalize() * hw;
             }
 
             let n2 = tangent(d) * 0.5;
@@ -369,7 +369,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
     }
 }
 
-fn get_angle_info(previous: Point, current: Point, next: Point) -> (Point, Point, Option<Point>) {
+fn get_angle_info(previous: Point, current: Point, next: Point) -> (Vec2, Vec2, Option<Vec2>) {
     let amount = 0.5;
     let n1 = tangent(current - previous) * amount;
     let n2 = tangent(next - current) * amount;


### PR DESCRIPTION
This is a very big change thanks to the separation of vector and point types in euclid 0.14. lyon used to sort of fake this by having separate `Point` and `Vec2` aliases to the same underlying Point2D type, but now this is properly implemented upstream, so no more confusing absolute (points) and relative (vectors) coordinates.