### PR TITLE
Remove rustc beta from the CI test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 rust:
   - stable
-  - beta
   - nightly
 env:
   - TEST_DIR=core


### PR DESCRIPTION
Nightly and stable should be enough, beta tests haven't caught anything so far that wasn't already caught by the other two test configurations and adds to the turnaround time.