### PR TITLE
LineSegment & Triangle bounding_rect

### DIFF
--- a/bezier/src/line.rs
+++ b/bezier/src/line.rs
@@ -1,4 +1,4 @@
-use {Point, Vec2, vec2, Rect};
+use {Point, Vec2, vec2, Rect, Size};
 
 // TODO: Perhaps it would be better to have LineSegment<T> where T can be f32, f64
 // or some fixed precision number (See comment in the intersection function).
@@ -57,10 +57,15 @@ impl LineSegment {
         LineSegment { from: self.sample(t), to: self.to }
     }
 
-    /// [Not implemented]
+    /// Return the minimum bounding rectangle
     #[inline]
     pub fn bounding_rect(&self) -> Rect {
-        unimplemented!()
+        let min_x = self.from.x.min(self.to.x);
+        let min_y = self.from.y.min(self.to.y);
+
+        let width  = (self.from.x.max(self.to.x) - min_x).abs();
+        let height = (self.from.y.max(self.to.y) - min_y).abs();
+        Rect::new(Point::new(min_x, min_y), Size::new(width, height))
     }
 
     /// Returns the vector between this segment's `from` and `to` points.
@@ -241,4 +246,33 @@ fn intersection_overlap() {
 
     assert!(!l1.intersects(&l2));
     assert!(l1.intersection(&l2).is_none());
+}
+
+#[cfg(test)]
+use euclid::rect;
+
+#[test]
+fn bounding_rect() {
+    let l1 = LineSegment {
+        from: point(1., 5.),
+        to: point(5., 7.),
+    };
+    let r1 = rect(1., 5., 4., 2.);
+
+    let l2 = LineSegment {
+        from: point(5., 5.),
+        to: point(1., 1.),
+    };
+    let r2 = rect(1., 1., 4., 4.);
+
+    let l3 = LineSegment {
+        from: point(3., 3.),
+        to: point(1., 5.),
+    };
+    let r3 = rect(1., 3., 2., 2.);
+
+    let cases = vec![(l1, r1), (l2, r2), (l3, r3)];
+    for &(ls, r) in &cases {
+        assert_eq!(ls.bounding_rect(), r);
+    }
 }

--- a/bezier/src/triangle.rs
+++ b/bezier/src/triangle.rs
@@ -1,4 +1,4 @@
-use {Point, Rect, LineSegment};
+use {Point, Rect, LineSegment, Size};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Triangle {
@@ -26,10 +26,17 @@ impl Triangle {
         return u > 0.0 && v > 0.0 && u + v < 1.0;
     }
 
-    /// [Not implemented]
+    /// Return the minimum bounding rectangle
     #[inline]
     pub fn bounding_rect(&self) -> Rect {
-        unimplemented!()
+        let max_x = self.a.x.max(self.b.x).max(self.c.x);
+        let min_x = self.a.x.min(self.b.x).min(self.c.x);
+        let max_y = self.a.y.max(self.b.y).max(self.c.y);
+        let min_y = self.a.y.min(self.b.y).min(self.c.y);
+
+        let width = max_x - min_x;
+        let height = max_y - min_y;
+        Rect::new(Point::new(min_x, min_y), Size::new(width, height))
     }
 
     #[inline]
@@ -214,4 +221,36 @@ fn test_segment_intersection() {
     assert!(!tri.intersects_line_segment(&tri.ab()));
     assert!(!tri.intersects_line_segment(&tri.bc()));
     assert!(!tri.intersects_line_segment(&tri.ac()));
+}
+
+#[cfg(test)]
+use euclid::rect;
+
+#[test]
+fn test_bounding_rect() {
+    let t1 = Triangle {
+        a: point(10., 20.),
+        b: point(35., 40.),
+        c: point(50., 10.),
+    };
+    let r1 = rect(10., 10., 40., 30.);
+
+    let t2 = Triangle {
+        a: point(5., 30.),
+        b: point(25., 10.),
+        c: point(35., 40.),
+    };
+    let r2 = rect(5., 10., 30., 30.);
+
+    let t3 = Triangle {
+        a: point(1., 1.),
+        b: point(2., 5.),
+        c: point(0., 4.),
+    };
+    let r3 = rect(0., 1., 2., 4.);
+
+    let cases = vec![(t1, r1), (t2, r2), (t3, r3)];
+    for &(tri, r) in &cases {
+        assert_eq!(tri.bounding_rect(), r);
+    }
 }


### PR DESCRIPTION
Implement `bounding_rect` for `LineSegment` and `Triangle`

Addresses issue #65 