### PR TITLE
Measure the distance along a stroke and output it in the tessellator.

### DIFF
--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -20,8 +20,8 @@ use lyon_renderer::buffer::{Id, BufferStore};
 use lyon_renderer::glsl::*;
 use lyon_renderer::renderer::{
     GpuTransform, GpuFillVertex, GpuStrokeVertex, GpuFillPrimitive,
-    GpuStrokePrimitive, opaque_fill_pipeline, transparent_fill_pipeline,
-    opaque_stroke_pipeline, transparent_stroke_pipeline, GpuGeometry,
+    GpuStrokePrimitive, opaque_fill_pipeline,
+    opaque_stroke_pipeline, GpuGeometry,
     GpuBufferStore, Globals, WithId
 };
 // make  public so that the module in gfx_defines can see the types.
@@ -280,36 +280,34 @@ fn main() {
         &bg_mesh_cpu.indices[..]
     );
 
-    let model_shader = factory.link_program(
+    let fill_shader = factory.link_program(
         FILL_VERTEX_SHADER.as_bytes(),
         FILL_FRAGMENT_SHADER.as_bytes()
     ).unwrap();
 
+    let stroke_shader = factory.link_program(
+        STROKE_VERTEX_SHADER.as_bytes(),
+        STROKE_FRAGMENT_SHADER.as_bytes()
+    ).unwrap();
+
     let opaque_fill_pso = factory.create_pipeline_from_program(
-        &model_shader,
+        &fill_shader,
         gfx::Primitive::TriangleList,
         gfx::state::Rasterizer::new_fill(),
         opaque_fill_pipeline::new(),
     ).unwrap();
 
     let opaque_stroke_pso = factory.create_pipeline_from_program(
-        &model_shader,
+        &stroke_shader,
         gfx::Primitive::TriangleList,
         gfx::state::Rasterizer::new_fill(),
         opaque_stroke_pipeline::new(),
     ).unwrap();
 
-    let _transparent_pso = factory.create_pipeline_from_program(
-        &model_shader,
-        gfx::Primitive::TriangleList,
-        gfx::state::Rasterizer::new_fill(),
-        transparent_stroke_pipeline::new(),
-    ).unwrap();
-
     let mut fill_mode = gfx::state::Rasterizer::new_fill();
     fill_mode.method = gfx::state::RasterMethod::Line(1);
     let wireframe_fill_pso = factory.create_pipeline_from_program(
-        &model_shader,
+        &fill_shader,
         gfx::Primitive::TriangleList,
         fill_mode,
         opaque_fill_pipeline::new(),
@@ -318,17 +316,10 @@ fn main() {
     let mut fill_mode = gfx::state::Rasterizer::new_fill();
     fill_mode.method = gfx::state::RasterMethod::Line(1);
     let wireframe_stroke_pso = factory.create_pipeline_from_program(
-        &model_shader,
+        &stroke_shader,
         gfx::Primitive::TriangleList,
         fill_mode,
         opaque_stroke_pipeline::new(),
-    ).unwrap();
-
-    let _wireframe_transparent_pso = factory.create_pipeline_from_program(
-        &model_shader,
-        gfx::Primitive::TriangleList,
-        fill_mode,
-        transparent_fill_pipeline::new(),
     ).unwrap();
 
     let mut init_queue: gfx::Encoder<_, _> = factory.create_command_buffer().into();

--- a/renderer/src/glsl.rs
+++ b/renderer/src/glsl.rs
@@ -48,6 +48,53 @@ pub static FILL_VERTEX_SHADER: &'static str = &"
     }
 ";
 
+pub static STROKE_VERTEX_SHADER: &'static str = &"
+    #version 140
+    #line 53
+
+    #define PRIM_BUFFER_LEN 64
+
+    uniform Globals {
+        vec2 u_resolution;
+    };
+
+    struct GpuTransform { mat4 transform; };
+    uniform u_transforms { GpuTransform transforms[PRIM_BUFFER_LEN]; };
+
+    struct Primitive {
+        vec4 color;
+        float z_index;
+        int local_transform;
+        int view_transform;
+        float width;
+    };
+    uniform u_primitives { Primitive primitives[PRIM_BUFFER_LEN]; };
+
+    in vec2 a_position;
+    in vec2 a_normal;
+    in float a_advancement;
+    in int a_prim_id;
+
+    out vec4 v_color;
+    out float v_advancement;
+
+    void main() {
+        int id = a_prim_id + gl_InstanceID;
+        Primitive prim = primitives[id];
+
+        vec4 local_pos = vec4(a_position + a_normal * prim.width, 0.0, 1.0);
+        vec4 world_pos = transforms[prim.view_transform].transform
+            * transforms[prim.local_transform].transform
+            * local_pos;
+
+        vec2 transformed_pos = world_pos.xy / (vec2(0.5, -0.5) * u_resolution * world_pos.w);
+
+        gl_Position = vec4(transformed_pos, 1.0 - prim.z_index, 1.0);
+        v_color = prim.color;
+        v_advancement = a_advancement;
+    }
+";
+
 // The fragment shader is dead simple. It just applies the color computed in the vertex shader.
 // A more advanced renderer would probably compute texture coordinates in the vertex shader and
 // sample the color from a texture here.
@@ -57,6 +104,19 @@ pub static FILL_FRAGMENT_SHADER: &'static str = &"
     out vec4 out_color;
 
     void main() {
+        out_color = v_color;
+    }
+";
+
+pub static STROKE_FRAGMENT_SHADER: &'static str = &"
+    #version 140
+    in vec4 v_color;
+    in float v_advancement;
+    out vec4 out_color;
+
+    void main() {
+        //float a = mod(v_advancement * 1.0, 1.0);
+        //out_color = vec4(a, a, a, 1.0);
         out_color = v_color;
     }
 ";

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -46,6 +46,7 @@ gfx_defines!{
     vertex GpuStrokeVertex {
         position: [f32; 2] = "a_position",
         normal: [f32; 2] = "a_normal",
+        advancement: f32 = "a_advancement",
         prim_id: i32 = "a_prim_id", // An id pointing to the PrimData struct above.
     }
 
@@ -198,9 +199,11 @@ impl VertexConstructor<tessellation::StrokeVertex, GpuStrokeVertex> for WithId<G
         assert!(!vertex.position.y.is_nan());
         assert!(!vertex.normal.x.is_nan());
         assert!(!vertex.normal.y.is_nan());
+        assert!(!vertex.advancement.is_nan());
         GpuStrokeVertex {
             position: vertex.position.to_array(),
             normal: vertex.normal.to_array(),
+            advancement: vertex.advancement,
             prim_id: self.0.to_i32(),
         }
     }

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -61,6 +61,7 @@ pub fn stroke_triangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v1,
             normal: -na,
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -68,6 +69,7 @@ pub fn stroke_triangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v1,
             normal: na,
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -76,6 +78,7 @@ pub fn stroke_triangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v2,
             normal: -nb,
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -83,6 +86,7 @@ pub fn stroke_triangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v2,
             normal: nb,
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -91,6 +95,7 @@ pub fn stroke_triangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v3,
             normal: -nc,
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -98,6 +103,7 @@ pub fn stroke_triangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v3,
             normal: nc,
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -172,6 +178,7 @@ pub fn stroke_quad<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v1,
             normal: -na,
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -179,6 +186,7 @@ pub fn stroke_quad<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v1,
             normal: na,
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -187,6 +195,7 @@ pub fn stroke_quad<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v2,
             normal: -nb,
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -194,6 +203,7 @@ pub fn stroke_quad<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v2,
             normal: nb,
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -202,6 +212,7 @@ pub fn stroke_quad<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v3,
             normal: -nc,
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -209,6 +220,7 @@ pub fn stroke_quad<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v3,
             normal: nc,
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -217,6 +229,7 @@ pub fn stroke_quad<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v4,
             normal: -nc,
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -224,6 +237,7 @@ pub fn stroke_quad<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: v4,
             normal: nd,
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -288,6 +302,7 @@ pub fn stroke_rectangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: rect.origin,
             normal: -vec2(-1.0, -1.0),
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -295,6 +310,7 @@ pub fn stroke_rectangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: rect.origin,
             normal: vec2(-1.0, -1.0),
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -303,6 +319,7 @@ pub fn stroke_rectangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: rect.top_right(),
             normal: -vec2(1.0, -1.0),
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -310,6 +327,7 @@ pub fn stroke_rectangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: rect.top_right(),
             normal: vec2(1.0, -1.0),
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -318,6 +336,7 @@ pub fn stroke_rectangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: rect.bottom_right(),
             normal: -vec2(1.0, 1.0),
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -325,6 +344,7 @@ pub fn stroke_rectangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: rect.bottom_right(),
             normal: vec2(1.0, 1.0),
+            advancement: 0.0,
             side: Side::Left,
         }
     );
@@ -333,6 +353,7 @@ pub fn stroke_rectangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: rect.bottom_left(),
             normal: -vec2(1.0, 0.0),
+            advancement: 0.0,
             side: Side::Right,
         }
     );
@@ -340,6 +361,7 @@ pub fn stroke_rectangle<Output: GeometryBuilder<StrokeVertex>>(
         StrokeVertex {
             position: rect.bottom_left(),
             normal: vec2(1.0, 0.0),
+            advancement: 0.0,
             side: Side::Left,
         }
     );

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -210,6 +210,8 @@ pub struct StrokeVertex {
     /// Note that some tessellators aren't fully implemented and don't provide the
     /// normal (a nil vector is provided instead). Refer the documentation of each tessellator.
     pub normal: math::Vec2,
+    /// How far along the path this vertex is.
+    pub advancement: f32,
     /// Whether the vertex is on the left or right side of the path.
     pub side: Side,
 }


### PR DESCRIPTION
This PR adds an f32 `advance` member in stroke vertex that represents the distance along the path for each vertex.

This could be used in the shader to apply a texture along the path, do a crude approximation of dashes, or perform some kinds of stroke animations.