### PR TITLE
Fix tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,14 +140,14 @@
 //!
 //! The meta-crate (`lyon`) mostly reexports the other lyon crates for convenience.
 //!
-//! ```
+//! ```ignore
 //! extern crate lyon;
 //! use lyon::tessellation::FillTessellator;
 //! ```
 //!
 //! Is equivalent to:
 //!
-//! ```
+//! ```ignore
 //! extern crate lyon_tessellation;
 //! use lyon_tessellation::FillTessellator;
 //! ```

--- a/svg/src/lib.rs
+++ b/svg/src/lib.rs
@@ -10,9 +10,6 @@
 extern crate lyon_core as core;
 extern crate lyon_tessellation as tessellation;
 
-#[cfg(test)]
-extern crate lyon_extra as extra;
-
 extern crate svgparser;
 
 pub mod parser;


### PR DESCRIPTION
Hi @nical, 

I noticed while running `cargo test --all` that the crate `lyon_svg` wasn't compiling because of a missing dependency on `lyon_extra`, and that tests were failing in `lyon`, so here's the fix. 

I assumed you don't need to test the ability to reexport the crates to I set the docs to `ignore`, however I don't really understand why they were failing. So if this is a different problem that needs to be addressed, let me know. 