### PR TITLE
StrokeTessellator does not need to return a Result.

### DIFF
--- a/cli/src/tessellate.rs
+++ b/cli/src/tessellate.rs
@@ -13,7 +13,6 @@ use std::io;
 pub enum TessError {
     Io(io::Error),
     Fill,
-    Stroke,
     Parse,
 }
 
@@ -42,13 +41,11 @@ pub fn tessellate(mut cmd: TessellateCmd) -> Result<(), TessError> {
     }
 
     if let Some(width) = cmd.stroke {
-        if StrokeTessellator::new().tessellate(
+        StrokeTessellator::new().tessellate(
             path.path_iter().flattened(cmd.tolerance),
             &StrokeOptions::default(),
             &mut BuffersBuilder::new(&mut buffers, StrokeWidth(width))
-        ).is_err() {
-            return Err(TessError::Stroke);
-        }
+        );
     }
 
     if cmd.count {

--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -157,23 +157,20 @@ fn main() {
     }
 
     // Tessellate the stroke
-    let logo_stroke_id = cpu.stroke_primitives
-        .push(
-            GpuStrokePrimitive::new(
-                [0.0, 0.0, 0.0, 0.1],
-                0.2,
-                default_transform.element,
-                view_transform.element,
-            )
-        );
-
-    StrokeTessellator::new()
-        .tessellate(
-            path.path_iter().flattened(0.022),
-            &StrokeOptions::default(),
-            &mut BuffersBuilder::new(&mut cpu.strokes, WithId(logo_stroke_id.element)),
+    let logo_stroke_id = cpu.stroke_primitives.push(
+        GpuStrokePrimitive::new(
+            [0.0, 0.0, 0.0, 0.1],
+            0.2,
+            default_transform.element,
+            view_transform.element,
         )
-        .unwrap();
+    );
+
+    StrokeTessellator::new().tessellate(
+        path.path_iter().flattened(0.022),
+        &StrokeOptions::default(),
+        &mut BuffersBuilder::new(&mut cpu.strokes, WithId(logo_stroke_id.element)),
+    );
 
     let mut num_points = 0;
     for p in path.as_slice().iter() {

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -763,7 +763,7 @@ where
     let options = StrokeOptions::default();
     let mut tess = StrokeTessellator::new();
 
-    return tess.tessellate(PolylineEvents::new(is_closed, it), &options, output).unwrap();
+    return tess.tessellate(PolylineEvents::new(is_closed, it), &options, output);
 }
 
 // TODO: This should be in path_iterator but it creates a dependency.


### PR DESCRIPTION
The stroke tessellator code was confusing in that `StrokeTessellator` was calling `begin_geometry` while `StrokeBuilder` was calling `end_geometry`. This is error prone when using the latter without the former. In the process of fixing that I removed the `Result` returned by the tessellator since we don't really need it and it is one of these unidiomatic cases of returning a result with `()` as the error type (that ended up being a more visible change).