### PR TITLE
Use cargo test --all in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,7 @@ rust:
   - stable
   - nightly
 env:
-  - TEST_DIR=core
-  - TEST_DIR=tessellation
-  - TEST_DIR=path_builder
-  - TEST_DIR=path_iterator
-  - TEST_DIR=path
-  - TEST_DIR=extra
-  - TEST_DIR=examples/gfx_basic
-  - TEST_DIR=examples/gfx_advanced
-  - TEST_DIR=cli
-  - TEST_DIR=bezier
+  - RUST_BACKTRACE=1
 script:
-  - cd $TEST_DIR && cargo test
+  - cargo test --all
+


### PR DESCRIPTION
Thanks to @nivkner in #80 I learned about `cargo test --all` to test all crates in a workspace. This is a lot better than the current travis config which manually goes to each folder to run `cargo test` (forgetting a few of them in the process).
I also added the `RUST_BACKTRACE` environment variable to get more useful information if a test panics.