### PR TITLE
Implement round line joins

### DIFF
--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -1466,7 +1466,7 @@ impl FillOptions {
 }
 
 impl Side {
-    fn opposite(self) -> Side {
+    pub fn opposite(self) -> Side {
         match self {
             Side::Left => Side::Right,
             Side::Right => Side::Left,

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -428,7 +428,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
             }
 
             LineJoin::Round => {
-                let max_radius_segment_angle = compute_max_radius_segment_angle(0.1 /* line width / 2 */, 0.001/*self.options.tolerance as f64*/);
+                let max_radius_segment_angle = compute_max_radius_segment_angle(self.options.line_width / 2.0, self.options.tolerance);
                 let num_segments = (join_angle.abs() as f32 / max_radius_segment_angle).ceil() as u32;
                 if num_segments != 0 {
                     // Calculate angle of each step
@@ -565,6 +565,11 @@ pub struct StrokeOptions {
     /// Not implemented yet!
     pub line_join: LineJoin,
 
+    /// Line width
+    ///
+    /// This is currently only used for calculating the amount of detail required in round line joins.
+    pub line_width: f32,
+
     /// See the SVG specification.
     ///
     /// Not implemented yet!
@@ -589,6 +594,7 @@ impl StrokeOptions {
         StrokeOptions {
             line_cap: LineCap::Butt,
             line_join: LineJoin::Miter,
+            line_width: 1.0,
             miter_limit: 10.0,
             tolerance: 0.1,
             vertex_aa: false,
@@ -608,6 +614,11 @@ impl StrokeOptions {
 
     pub fn with_line_join(mut self, join: LineJoin) -> StrokeOptions {
         self.line_join = join;
+        return self;
+    }
+
+    pub fn with_line_width(mut self, width: f32) -> StrokeOptions {
+        self.line_width = width;
         return self;
     }
 

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -429,7 +429,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
 
             LineJoin::Round => {
                 let max_radius_segment_angle = compute_max_radius_segment_angle(0.1 /* line width / 2 */, 0.001/*self.options.tolerance as f64*/);
-                let num_segments = (join_angle.abs() as f32 / max_radius_segment_angle as f32).ceil() as u32;
+                let num_segments = (join_angle.abs() as f32 / max_radius_segment_angle).ceil() as u32;
                 if num_segments != 0 {
                     // Calculate angle of each step
                     let segment_angle = join_angle as f32 / num_segments as f32;
@@ -549,7 +549,7 @@ fn get_angle_normal(previous: Point, current: Point, next: Point) -> Vec2 {
 }
 
 /// Computes the max angle of a radius segment for a given tolerance
-pub fn compute_max_radius_segment_angle(radius: f64, tolerance: f64) -> f64 {
+pub fn compute_max_radius_segment_angle(radius: f32, tolerance: f32) -> f32 {
     let t = radius - tolerance;
     ((radius * radius - t * t) * 4.0).sqrt() / radius
 }

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -122,10 +122,10 @@ pub struct StrokeBuilder<'l, Output: 'l> {
     previous: Point,
     current: Point,
     second: Point,
-    previous_a_id: VertexId,
-    previous_b_id: VertexId,
-    second_a_id: VertexId,
-    second_b_id: VertexId,
+    previous_left_id: VertexId,
+    previous_right_id: VertexId,
+    second_left_id: VertexId,
+    second_right_id: VertexId,
     prev_normal: Vec2,
     nth: u32,
     length: f32,
@@ -155,7 +155,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> BaseBuilder for StrokeBuilder<'l,
             let second = self.second;
             self.edge_to(second);
 
-            let first_a_id = self.output.add_vertex(
+            let first_left_id = self.output.add_vertex(
                 Vertex {
                     position: self.first,
                     normal: self.prev_normal,
@@ -163,7 +163,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> BaseBuilder for StrokeBuilder<'l,
                     side: Side::Left,
                 }
             );
-            let first_b_id = self.output.add_vertex(
+            let first_right_id = self.output.add_vertex(
                 Vertex {
                     position: self.first,
                     normal: -self.prev_normal,
@@ -172,8 +172,8 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> BaseBuilder for StrokeBuilder<'l,
                 }
             );
 
-            self.output.add_triangle(first_b_id, first_a_id, self.second_b_id);
-            self.output.add_triangle(first_a_id, self.second_a_id, self.second_b_id);
+            self.output.add_triangle(first_right_id, first_left_id, self.second_right_id);
+            self.output.add_triangle(first_left_id, self.second_left_id, self.second_right_id);
         }
         self.nth = 0;
         self.current = self.first;
@@ -207,10 +207,10 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
                    previous: zero,
                    current: zero,
                    prev_normal: Vec2::new(0.0, 0.0),
-                   previous_a_id: VertexId(0),
-                   previous_b_id: VertexId(0),
-                   second_a_id: VertexId(0),
-                   second_b_id: VertexId(0),
+                   previous_left_id: VertexId(0),
+                   previous_right_id: VertexId(0),
+                   second_left_id: VertexId(0),
+                   second_right_id: VertexId(0),
                    nth: 0,
                    length: 0.0,
                    sub_path_start_length: 0.0,
@@ -300,7 +300,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
             let n2 = normalized_tangent(d) * 0.5;
             let n1 = -n2;
 
-            let first_a_id = self.output.add_vertex(
+            let first_left_id = self.output.add_vertex(
                 Vertex {
                     position: first,
                     normal: n1,
@@ -308,7 +308,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
                     side: Side::Left,
                 }
             );
-            let first_b_id = self.output.add_vertex(
+            let first_right_id = self.output.add_vertex(
                 Vertex {
                     position: first,
                     normal: n2,
@@ -317,8 +317,8 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
                 }
             );
 
-            self.output.add_triangle(first_b_id, first_a_id, self.second_b_id);
-            self.output.add_triangle(first_a_id, self.second_a_id, self.second_b_id);
+            self.output.add_triangle(first_right_id, first_left_id, self.second_right_id);
+            self.output.add_triangle(first_left_id, self.second_left_id, self.second_right_id);
         }
     }
 
@@ -339,7 +339,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
 
         let normal = get_angle_normal(self.previous, self.current, to);
 
-        let a_id = self.output.add_vertex(
+        let left_id = self.output.add_vertex(
             Vertex {
                 position: self.current,
                 normal: normal,
@@ -347,7 +347,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
                 side: Side::Left,
             }
         );
-        let b_id = self.output.add_vertex(
+        let right_id = self.output.add_vertex(
             Vertex {
                 position: self.current,
                 normal: -normal,
@@ -357,20 +357,20 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
         );
 
         if self.nth > 1 {
-            self.output.add_triangle(self.previous_b_id, self.previous_a_id, b_id);
-            self.output.add_triangle(self.previous_a_id, a_id, b_id);
+            self.output.add_triangle(self.previous_right_id, self.previous_left_id, right_id);
+            self.output.add_triangle(self.previous_left_id, left_id, right_id);
         }
 
         self.previous = self.current;
         self.prev_normal = normal;
-        self.previous_a_id = a_id;
-        self.previous_b_id = b_id;
+        self.previous_left_id = left_id;
+        self.previous_right_id = right_id;
         self.current = to;
 
         if self.nth == 1 {
             self.second = self.previous;
-            self.second_a_id = a_id;
-            self.second_b_id = b_id;
+            self.second_left_id = left_id;
+            self.second_right_id = right_id;
         }
 
         self.nth += 1;


### PR DESCRIPTION
This PR implements ``LineJoin::Round`` in the stroke tesselator (#5):

![round-line-join](https://user-images.githubusercontent.com/1093808/27555770-f2d12fd2-5aaa-11e7-8893-2b30351a3954.png)

For tolerance to work properly, we need to know the line width in the tesselator. Would you be happy with me adding line width to the tesselator?