### PR TITLE
Path fill tessellator bug fixes.

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,5 +9,6 @@ name = "lyon"
 
 [dependencies]
 lyon = { path = "../" }
+lyon_extra = { path = "../extra" }
 clap = "2.19.2"
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,12 +1,11 @@
 use std::io;
+use lyon::path::Path;
 
 pub struct TessellateCmd {
-    pub input: String,
-    pub output: Box<io::Write>,
+    pub path: Path,
     pub fill: bool,
     pub stroke: Option<f32>,
     pub tolerance: f32,
-    pub count: bool,
 }
 
 pub struct FlattenCmd {

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -2375,7 +2375,7 @@ fn test_unknown_issue_1() {
     // This test case used to fail but does not fail anymore, probably thanks to
     // the fixed-to-f32 workaround (cf.) test_fixed_to_f32_precision.
     // TODO: figure out what the issue was and what fixed it.
-    let mut builder = Path::builder().flattened(0.05);
+    let mut builder = Path::builder();
 
     builder.move_to(point(-3.3709216, 9.467676));
     builder.line_to(point(-13.078612, 7.0675235));
@@ -2562,7 +2562,7 @@ fn test_close_at_first_position() {
 fn test_fixed_to_f32_precision() {
     // This test appears to hit a precision issue in the conversion from fixed 16.16
     // to f32, causing a point to appear slightly above another when it should not.
-    let mut builder = Path::builder().flattened(0.05);
+    let mut builder = Path::builder();
 
     builder.move_to(point(68.97998, 796.05));
     builder.line_to(point(61.27998, 805.35));

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -2371,8 +2371,10 @@ fn test_colinear_touching_squares3() {
 
 
 #[test]
-#[ignore] // TODO
-fn reduced_test_case() {
+fn test_unknown_issue_1() {
+    // This test case used to fail but does not fail anymore, probably thanks to
+    // the fixed-to-f32 workaround (cf.) test_fixed_to_f32_precision.
+    // TODO: figure out what the issue was and what fixed it.
     let mut builder = Path::builder().flattened(0.05);
 
     builder.move_to(point(-3.3709216, 9.467676));

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -2495,3 +2495,19 @@ fn test_close_at_first_position() {
 
     test_path(builder.build().as_slice(), None);
 }
+
+#[test]
+#[ignore] // TODO
+fn test_fixed_to_f32_precision_failing() {
+    // This test appears to hit a precision issue in the conversion from fixed 16.16
+    // to f32, causing a point to appear slightly above another when it should not.
+    let mut builder = Path::builder().flattened(0.05);
+
+    builder.move_to(point(68.97998, 796.05));
+    builder.line_to(point(61.27998, 805.35));
+    builder.line_to(point(55.37999, 799.14996));
+    builder.line_to(point(68.98, 796.05));
+    builder.close();
+
+    test_path(builder.build().as_slice(), None);
+}

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -322,13 +322,12 @@ impl FillTessellator {
                 if edge.upper == current_position {
                     next_edge = edge_iter.next();
                     if edge.lower != current_position {
-                        self.below
-                            .push(
-                                EdgeBelow {
-                                    lower: edge.lower,
-                                    angle: compute_angle(edge.lower - edge.upper),
-                                }
-                            );
+                        self.below.push(
+                            EdgeBelow {
+                                lower: edge.lower,
+                                angle: compute_angle(edge.lower - edge.upper),
+                            }
+                        );
                     }
                     pending_events = true;
                     tess_log!(self, " edge at {:?} -> {:?}", edge.upper, edge.lower);
@@ -360,13 +359,12 @@ impl FillTessellator {
                     let inter = self.intersections.remove(0);
 
                     if inter.lower != current_position {
-                        self.below
-                            .push(
-                                EdgeBelow {
-                                    lower: inter.lower,
-                                    angle: compute_angle(inter.lower - current_position),
-                                }
-                            );
+                        self.below.push(
+                            EdgeBelow {
+                                lower: inter.lower,
+                                angle: compute_angle(inter.lower - current_position),
+                            }
+                        );
                     }
 
                     pending_events = true;
@@ -487,13 +485,12 @@ impl FillTessellator {
                 // time it is the right side instead of the left side of a span).
 
                 // Split the edge.
-                self.below
-                    .push(
-                        EdgeBelow {
-                            lower: span.right.lower,
-                            angle: compute_angle(span.right.lower - current_position),
-                        }
-                    );
+                self.below.push(
+                    EdgeBelow {
+                        lower: span.right.lower,
+                        angle: compute_angle(span.right.lower - current_position),
+                    }
+                );
                 span.right.lower = current_position;
 
                 status = E::RightEdge;
@@ -1050,10 +1047,8 @@ impl FillTessellator {
             let mr = if span.right.merge { "*" } else { " " };
             print!(
                 "| {:?}{}  {:?}{}|  ",
-                span.left.upper_id.offset(),
-                ml,
-                span.right.upper_id.offset(),
-                mr
+                span.left.upper_id.offset(), ml,
+                span.right.upper_id.offset(), mr
             );
         }
         println!("");
@@ -1272,11 +1267,11 @@ impl FillEvents {
     pub fn set_path_iter<Iter: Iterator<Item = FlattenedEvent>>(&mut self, it: Iter) {
         self.clear();
         let mut tmp = FillEvents::new();
-        ::std::mem::swap(self, &mut tmp);
+        swap(self, &mut tmp);
         let mut builder = EventsBuilder::new();
         builder.recycle(tmp);
         let mut tmp = builder.build_iter(it);
-        ::std::mem::swap(self, &mut tmp);
+        swap(self, &mut tmp);
     }
 }
 

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -1520,7 +1520,12 @@ impl MonotoneTessellator {
         };
         let right_side = current.side == Side::Right;
 
-        debug_assert!(is_after(current.pos, self.previous.pos));
+        // cf. test_fixed_to_f32_precision
+        // TODO: investigate whether we could do the conversion without this
+        // precision issue. Otherwise we could also make MonotoneTessellator
+        // manipulate fixed-point values instead of f32 to preverve the assertion.
+        //
+        //debug_assert!(is_after(current.pos, self.previous.pos));
         debug_assert!(!self.stack.is_empty());
 
         let changed_side = current.side != self.previous.side;
@@ -2497,8 +2502,7 @@ fn test_close_at_first_position() {
 }
 
 #[test]
-#[ignore] // TODO
-fn test_fixed_to_f32_precision_failing() {
+fn test_fixed_to_f32_precision() {
     // This test appears to hit a precision issue in the conversion from fixed 16.16
     // to f32, causing a point to appear slightly above another when it should not.
     let mut builder = Path::builder().flattened(0.05);

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -2515,3 +2515,8 @@ fn test_fixed_to_f32_precision() {
 
     test_path(builder.build().as_slice(), None);
 }
+
+#[test]
+fn test_empty_path() {
+    test_path(Path::new().as_slice(), Some(0));
+}


### PR DESCRIPTION
I had time to kill on a flight today so I added a way to create minimal test cases when tessellating paths using the cli tool (passing the `-d` or `--debug` option to the `tessellate` sub-command will try to reduce the path until the bug stops reproducing if an error happens during tessellation, and dump the test case to stdout).
From there I:

 - Worked around a problem that seems to happen when converting fixed-point coordinates back to f32 with some precision less that make a point appear slightly above another when it should be equal or slightly below, which would hit an assertion. The real fix for this might be to move to a more serious fixed point number implementation.
 - Fixed a very (shameful) bug in the path tessellator that I thought I had dealt with long ago (but apparently not), which was that some edges were not processed by the tessellator if the path is not manually closed (leading to an assertion in the middle of the tessellation).