### PR TITLE
Fix some clippy warnings in the tessellation crate.

### DIFF
--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -722,10 +722,13 @@ where
     Output: GeometryBuilder<FillVertex>,
 {
     let mut it1 = it.clone().cycle().skip(1);
-    let mut it2 = it.clone().cycle().skip(2);    
+    let mut it2 = it.clone().cycle().skip(2);
 
     output.begin_geometry();
-    if let (Some(a1), Some(a2), Some(a3), Some(b2), Some(b3), Some(b4)) = (it.next(), it1.next(), it2.next(), it.next(), it1.next(), it2.next()) {
+
+    if let (Some(a1), Some(a2), Some(a3), Some(b2), Some(b3), Some(b4)) = (
+        it.next(),it1.next(), it2.next(), it.next(), it1.next(), it2.next()
+    ) {
         let mut a = output.add_vertex(
             FillVertex {
                 position: a2,
@@ -738,26 +741,22 @@ where
                 normal: compute_normal(b3 - b2, b4 - b3),
             }
         );
-    
-        loop {
-            match (it.next(), it1.next(), it2.next()) {
-                (Some(p1), Some(p2), Some(p3)) => {
-                    let c = output.add_vertex(
-                        FillVertex {
-                            position: p2,
-                            normal: compute_normal(p2 - p1, p3 - p2),
-                        }
-                    );
 
-                    output.add_triangle(a, b, c);
+        while let (Some(p1), Some(p2), Some(p3)) = (it.next(), it1.next(), it2.next()) {
+            let c = output.add_vertex(
+                FillVertex {
+                    position: p2,
+                    normal: compute_normal(p2 - p1, p3 - p2),
+                }
+            );
 
-                    a = b;
-                    b = c;
-                },
-                (_, _, _) => break,
-            }            
+            output.add_triangle(a, b, c);
+
+            a = b;
+            b = c;
         }
     }
+
     return output.end_geometry();
 }
 
@@ -776,7 +775,7 @@ where
 
 // TODO: This should be in path_iterator but it creates a dependency.
 
-/// An iterator that consumes an iterator of points and produces FlattenedEvents.
+/// An iterator that consumes an iterator of points and produces `FlattenedEvent`s.
 pub struct PolylineEvents<Iter> {
     iter: Iter,
     first: bool,

--- a/tessellation/src/geometry_builder.rs
+++ b/tessellation/src/geometry_builder.rs
@@ -10,8 +10,8 @@
 //! layout, or even several vertex layouts, which is a very common use-case.
 //!
 //! In order to provide flexibility with the generation of geometry, this module provides with
-//! the [GeometryBuilder](trait.GeometryBuilder.html) and its extension the
-//! [BezierGeometryBuilder](trait.BezierGeometryBuilder.html) trait. The former exposes
+//! the [`GeometryBuilder`](trait.GeometryBuilder.html) and its extension the
+//! [`BezierGeometryBuilder`](trait.BezierGeometryBuilder.html) trait. The former exposes
 //! the methods to facilitate adding vertices and triangles. The latter adds a method to
 //! specifically handle quadratic bezier curves. Quadratic bezier curves have interesting
 //! properties that make them a lot easier to render than most types of curves and we want
@@ -23,17 +23,17 @@
 //!
 //! This modules provides with a basic implementation of these traits through the following types:
 //!
-//! * The struct [VertexBuffers<T>](struct.VertexBuffers.html) is a simple pair of vectors of u16
+//! * The struct [`VertexBuffers<T>`](struct.VertexBuffers.html) is a simple pair of vectors of u16
 //!   indices and T (generic parameter) vertices.
-//! * The struct [BuffersBuilder](struct.BuffersBuilder.html) which implements
-//!   [BezierGeometryBuilder](trait.BezierGeometryBuilder.html) and writes into a
-//!   [VertexBuffers](struct.VertexBuffers.html).
-//! * The trait [VertexConstructor](trait.VertexConstructor.html) used by
-//!   [BuffersBuilder](struct.BuffersBuilder.html) in order to generate any vertex type. In the
-//!   example below, a struct WithColor implements the VertexConstructor trait in order to
+//! * The struct [`BuffersBuilder`](struct.BuffersBuilder.html) which implements
+//!   [`BezierGeometryBuilder`](trait.BezierGeometryBuilder.html) and writes into a
+//!   [`VertexBuffers`](struct.VertexBuffers.html).
+//! * The trait [`VertexConstructor`](trait.VertexConstructor.html) used by
+//!   [`BuffersBuilder`](struct.BuffersBuilder.html) in order to generate any vertex type. In the
+//!   example below, a struct `WithColor` implements the `VertexConstructor` trait in order to
 //!   create vertices composed of a 2d position and a color value from an input 2d position.
 //!   This separates the construction of vertex values from the assembly of the vertex buffers.
-//!   Another, simpler example of vertex constructor is the [Identity](struct.Identity.html)
+//!   Another, simpler example of vertex constructor is the [`Identity`](struct.Identity.html)
 //!   constructor which just returns its input, untransformed.
 //!
 //! Geometry builders are a practical way to add one last step to the tessellation pipeline,
@@ -182,7 +182,7 @@
 //!
 //! ### Writing a tessellator
 //!
-//! The example below is the implementation of basic_shapes::fill_rectangle.
+//! The example below is the implementation of `basic_shapes::fill_rectangle`.
 //!
 //! ```
 //! use lyon_tessellation::geometry_builder::*;
@@ -227,9 +227,9 @@ pub type Index = u16;
 
 /// A virtual vertex offset in a geometry.
 ///
-/// The VertexIds are only valid between GeometryBuilder::begin_geometry and
-/// GeometryBuilder::end_geometry. GeometryBuilder implementations typically be translate
-/// the ids internally so that first VertexId after begin_geometry is zero.
+/// The `VertexId`s are only valid between `GeometryBuilder::begin_geometry` and
+/// `GeometryBuilder::end_geometry`. `GeometryBuilder` implementations typically be translate
+/// the ids internally so that first `VertexId` after `begin_geometry` is zero.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct VertexId(pub u16);
 
@@ -269,18 +269,18 @@ pub trait GeometryBuilder<Input> {
     fn abort_geometry(&mut self);
 }
 
-/// An extension to GeometryBuilder that can handle quadratic bezier segments.
+/// An extension to GeometryBuilder that can handle quadratic bézier segments.
 pub trait BezierGeometryBuilder<Input>: GeometryBuilder<Input> {
     /// Insert a quadratic bezier curve.
     /// The interrior is on the right side of the curve.
     ///
-    /// This method can only be called between begin_geometry and end_geometry.
+    /// This method can only be called between `begin_geometry` and `end_geometry`.
     fn add_quadratic_bezier(&mut self, from: VertexId, to: VertexId, ctrl: Input);
 }
 
 /// Structure that holds the vertex and index data.
 ///
-/// Usually writen into though temporary BuffersBuilder objects.
+/// Usually writen into though temporary `BuffersBuilder` objects.
 pub struct VertexBuffers<VertexType> {
     pub vertices: Vec<VertexType>,
     pub indices: Vec<Index>,
@@ -299,17 +299,17 @@ impl<VertexType> VertexBuffers<VertexType> {
     }
 }
 
-/// A temporary view on a VertexBuffers object which facilitate the population of vertex and index
+/// A temporary view on a `VertexBuffers` object which facilitate the population of vertex and index
 /// data.
 ///
-/// BuffersBuilders record the vertex offset from when they are created so that algorithms using
+/// `BuffersBuilders` record the vertex offset from when they are created so that algorithms using
 /// them don't need to worry about offsetting indices if some geometry was added beforehand. This
-/// means that from the point of view of a BuffersBuilder user, the first added vertex is at always
-/// offset at the offset 0 and VertexBuilfer takes care of translating indices adequately.
+/// means that from the point of view of a `BuffersBuilder` user, the first added vertex is at always
+/// offset at the offset 0 and `VertexBuilfer` takes care of translating indices adequately.
 ///
 /// Often, algorithms are built to generate vertex positions without knowledge of eventual other
-/// vertex attributes. The VertexConstructor does the translation from generic Input to VertexType.
-/// If your logic generates the actual vertex type directly, you can use the SimpleBuffersBuilder
+/// vertex attributes. The `VertexConstructor` does the translation from generic `Input` to `VertexType`.
+/// If your logic generates the actual vertex type directly, you can use the `SimpleBuffersBuilder`
 /// convenience typedef.
 pub struct BuffersBuilder<'l, VertexType: 'l, Input, Ctor: VertexConstructor<Input, VertexType>> {
     buffers: &'l mut VertexBuffers<VertexType>,
@@ -337,12 +337,14 @@ impl<'l, VertexType: 'l, Input, Ctor: VertexConstructor<Input, VertexType>>
     }
 }
 
-/// Creates a BuffersBuilder.
-pub fn vertex_builder<'l, VertexType, Input, Ctor: VertexConstructor<Input, VertexType>>
-    (
-    buffers: &'l mut VertexBuffers<VertexType>,
+/// Creates a `BuffersBuilder`.
+pub fn vertex_builder<VertexType, Input, Ctor>(
+    buffers: &mut VertexBuffers<VertexType>,
     ctor: Ctor,
-) -> BuffersBuilder<'l, VertexType, Input, Ctor> {
+) -> BuffersBuilder<VertexType, Input, Ctor>
+where
+    Ctor: VertexConstructor<Input, VertexType>
+{
     BuffersBuilder::new(buffers, ctor)
 }
 
@@ -357,15 +359,12 @@ impl<T> VertexConstructor<T, T> for Identity {
     fn new_vertex(&mut self, input: T) -> T { input }
 }
 
-/// A BuffersBuilder that takes the actual vertex type as input.
-pub type SimpleBuffersBuilder<'l, VertexType> = BuffersBuilder<'l,
-                                                               VertexType,
-                                                               VertexType,
-                                                               Identity>;
+/// A `BuffersBuilder` that takes the actual vertex type as input.
+pub type SimpleBuffersBuilder<'l, VertexType> = BuffersBuilder<'l, VertexType, VertexType, Identity>;
 
-/// Creates a SimpleBuffersBuilder.
-pub fn simple_builder<'l, VertexType>(buffers: &'l mut VertexBuffers<VertexType>)
-    -> SimpleBuffersBuilder<'l, VertexType> {
+/// Creates a `SimpleBuffersBuilder`.
+pub fn simple_builder<VertexType>(buffers: &mut VertexBuffers<VertexType>)
+    -> SimpleBuffersBuilder<VertexType> {
     let vertex_offset = buffers.vertices.len() as Index;
     let index_offset = buffers.indices.len() as Index;
     BuffersBuilder {

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -161,9 +161,8 @@
 //! - [Writing a tessellator](geometry_builder/index.html#writing-a-tessellator).
 //!
 
-
-
 #![allow(dead_code)]
+#![allow(needless_return, new_without_default_derive)] // clippy
 
 extern crate lyon_core as core;
 extern crate lyon_path_builder as path_builder;

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -13,16 +13,16 @@
 //! is shaded once no matter how many times the path overlaps with itself at this
 //! location.
 //!
-//! The main interface is the [StrokeTessellator](struct.StrokeTessellator.html),
+//! The main interface is the [`StrokeTessellator`](struct.StrokeTessellator.html),
 //! which exposes a similar interface to its
 //! [fill equivalent](../path_fill/struct.FillTessellator.html).
 //!
 //! This stroke tessellator takes an iterator of path events as inputs as well as
-//! a [StrokeOption](struct.StrokeOptions.html), and produces its outputs using
-//! a [GeometryBuilder](../geometry_builder/trait.GeometryBuilder.html).
+//! a [`StrokeOption`](struct.StrokeOptions.html), and produces its outputs using
+//! a [`GeometryBuilder`](../geometry_builder/trait.GeometryBuilder.html).
 //!
 //!
-//! See the [geometry_builder module documentation](../geometry_builder/index.html)
+//! See the [`geometry_builder` module documentation](../geometry_builder/index.html)
 //! for more details about how to output custom vertex layouts.
 //!
 //! # Examples
@@ -298,7 +298,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
             if self.options.line_cap == LineCap::Square {
                 // The easiest way to implement square caps is to lie about the current position
                 // and move it slightly to accommodate for the width/2 extra length.
-                self.current = self.current + d.normalize() * hw;
+                self.current += d.normalize() * hw;
             }
             let p = self.current + d;
             self.edge_to(p);
@@ -312,7 +312,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
             let d = first - self.second;
 
             if self.options.line_cap == LineCap::Square {
-                first = first + d.normalize() * hw;
+                first += d.normalize() * hw;
             }
 
             let n2 = normalized_tangent(d) * 0.5;


### PR DESCRIPTION
A lot of the reported warnings were documentation quoting code (type names mostly) without back ticks, there's also a bit of code cleanup.