### PR TITLE
Implement rounded rectangle stroke

### DIFF
--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -4,9 +4,10 @@
 
 use core::FlattenedEvent;
 use geometry_builder::{GeometryBuilder, Count, VertexId};
-use path_stroke::{StrokeOptions, StrokeTessellator};
+use path_stroke::{StrokeOptions, StrokeTessellator, StrokeBuilder};
 use math_utils::compute_normal;
 use math::*;
+use path_builder::BaseBuilder;
 use {FillVertex, StrokeVertex, Side};
 
 use std::f32::consts::PI;
@@ -712,6 +713,32 @@ pub fn stroke_circle<Output>(center: Point, radius: f32, tolerance: f32, output:
     );
 
     return output.end_geometry();
+}
+
+// build the border using the inner points.
+// assumming the builder started with move_to().
+fn stroke_border_radius_build<Output: GeometryBuilder<StrokeVertex>>(
+    center: Point,
+    angle: (f32, f32),
+    radius: f32,
+    num_points: u32,
+    builder: &mut StrokeBuilder<Output>,
+) {
+    let angle_size = (angle.0 - angle.1).abs();
+    let starting_angle = angle.0.min(angle.1);
+
+    let points = (1..num_points + 1).map(move |i| {
+        let new_angle = i as f32 * (angle_size) / (num_points + 1) as f32 + starting_angle;
+        let normal =
+        vec2(new_angle.cos(),
+        new_angle.sin());
+        center + normal * radius
+    });
+
+    for point in points {
+        builder.line_to(point)
+    };
+
 }
 
 /// Tessellate a convex polyline.

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -611,11 +611,116 @@ fn stroke_border_radius<Output: GeometryBuilder<StrokeVertex>>(
 
 /// Tessellate the stroke of an axis-aligned rounded rectangle.
 pub fn stroke_rounded_rectangle<Output: GeometryBuilder<StrokeVertex>>(
-    _rect: &Rect,
-    _radii: &BorderRadii,
-    _output: &mut Output,
+    rect: &Rect,
+    radii: &BorderRadii,
+    tolerance: f32,
+    output: &mut Output,
 ) -> Count {
-    unimplemented!();
+    output.begin_geometry();
+
+    let w = rect.size.width;
+    let h = rect.size.height;
+    let x_min = rect.min_x();
+    let y_min = rect.min_y();
+    let x_max = rect.max_x();
+    let y_max = rect.max_y();
+    let min_wh = w.min(h);
+    let mut tl = radii.top_left.abs().min(min_wh);
+    let mut tr = radii.top_right.abs().min(min_wh);
+    let mut bl = radii.bottom_left.abs().min(min_wh);
+    let mut br = radii.bottom_right.abs().min(min_wh);
+
+    // clamp border radii if they don't fit in the rectangle.
+    if tl + tr > w {
+        let x = (tl + tr - w) * 0.5;
+        tl -= x;
+        tr -= x;
+    }
+    if bl + br > w {
+        let x = (bl + br - w) * 0.5;
+        bl -= x;
+        br -= x;
+    }
+    if tr + br > h {
+        let x = (tr + br - h) * 0.5;
+        tr -= x;
+        br -= x;
+    }
+    if tl + bl > h {
+        let x = (tl + bl - h) * 0.5;
+        tl -= x;
+        bl -= x;
+    }
+
+    // top
+    let p1 = point(x_min + tl, y_min);
+    let p2 = point(x_max - tr, y_min);
+
+    // bottom
+    let p6 = point(x_min + bl, y_max);
+    let p5 = point(x_max - br, y_max);
+
+    // left
+    let p0 = point(x_min, y_min + tl);
+    let p7 = point(x_min, y_max - bl);
+
+    // right
+    let p3 = point(x_max, y_min + tr);
+    let p4 = point(x_max, y_max - br);
+
+    let sides = &[
+        [p1, p2],
+        [p5, p6],
+        [p3, p4],
+        [p0, p7],
+    ];
+
+    let radii = [tl, tr, br, bl];
+    let angles = [
+        (PI, 1.5 * PI),
+        (1.5* PI, 2.0 * PI),
+        (0.0, PI * 0.5),
+        (PI * 0.5, PI),
+    ];
+
+    let centers = [
+        point(p1.x, p0.y),
+        point(p2.x, p3.y),
+        point(p5.x, p4.y),
+        point(p6.x, p7.y),
+    ];
+
+    let mut nums = radii.iter().map(|&radius| {
+        if radius > 0.0 {
+
+            let arc_len = 0.5 * PI * radius;
+            let step = circle_flattening_step(radius, tolerance);
+            let num_segments = (arc_len / step).ceil();
+
+            num_segments.log2() as u32 - 1
+        } else {
+            0
+        }
+    });
+
+    let options = StrokeOptions::default();
+    { // output borrow scope start
+        let mut builder = StrokeBuilder::new(&options, output);
+        builder.move_to(p7);
+        for i in 0..4 {
+            stroke_border_radius_build(
+                centers[i],
+                angles[i],
+                radii[i],
+                nums.next().unwrap(),
+                &mut builder,
+            );
+            builder.line_to(sides[i][0]);
+            builder.line_to(sides[i][1]);
+        }
+    } // output borrow scope end
+
+    return output.end_geometry();
 }
 
 /// Tessellate a circle.


### PR DESCRIPTION
Fixes #38.

The problem with the #82 was the segmentation of the shape, which could result in a mismatch between the different parts. This is addressed by producing one continuous shape, and by finding only the inner points in rounded borders (since the outer ones could be part of other paths).