### PR TITLE
Removed multisampling in the gfx_advanced example.

### DIFF
--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -244,7 +244,6 @@ fn main() {
         .with_dimensions(700, 700)
         .with_decorations(true)
         .with_title("tessellation".to_string())
-        .with_multisampling(8)
         .with_vsync();
 
     let (window, mut device, mut factory, mut main_fbo, mut main_depth) =


### PR DESCRIPTION
This fixes #116 , and maybe #29 ? 