### PR TITLE
A few API changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon"
-version = "0.6.1"
+version = "0.6.2"
 description = "2D Graphics rendering on the GPU using tessellation."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 
-lyon_tessellation = { version = "0.6.1", path = "tessellation/" }
+lyon_tessellation = { version = "0.6.2", path = "tessellation/" }
 lyon_core = { version = "0.6.0", path = "core/" }
 lyon_bezier = { version = "0.6.1", path = "bezier/" }
 lyon_path = { version = "0.6.0", path = "path/" }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The intent is for this library to be useful in projects like [Servo](https://ser
         let mut vertex_builder = simple_builder(&mut geometry_cpu);
 
         // Compute the tessellation.
-        tessellator.tessellate_path(
+        tessellator.tessellate_flattened_path(
             path.path_iter().flattened(0.1),
             &FillOptions::default(),
             &mut vertex_builder

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -127,7 +127,7 @@ fn main() {
         };
 
         let res = ::std::panic::catch_unwind(|| {
-            tessellate::tessellate(cmd)
+            tessellate:.tessellate_flattened_path(cmd)
         });
 
         match res {
@@ -142,7 +142,7 @@ fn main() {
                     find_reduced_test_case(
                         path.as_slice(),
                         &|path: Path| {
-                            tessellate::tessellate(TessellateCmd {
+                            tessellate:.tessellate_flattened_path(TessellateCmd {
                                 path: path,
                                 fill: fill,
                                 stroke: stroke_cmd,

--- a/cli/src/tessellate.rs
+++ b/cli/src/tessellate.rs
@@ -17,14 +17,14 @@ impl ::std::convert::From<::std::io::Error> for TessError {
     fn from(err: io::Error) -> Self { TessError::Io(err) }
 }
 
-pub fn tessellate(cmd: TessellateCmd) -> Result<VertexBuffers<Point>, TessError> {
+pub fn.tessellate_flattened_path(cmd: TessellateCmd) -> Result<VertexBuffers<Point>, TessError> {
 
     let mut buffers: VertexBuffers<Point> = VertexBuffers::new();
 
     if cmd.fill {
         if FillTessellator::new().tessellate_path(
-            cmd.path.path_iter().flattened(cmd.tolerance),
-            &FillOptions::default(),
+            cmd.path.path_iter(),
+            &FillOptions::tolerance(cmd.tolerance),
             &mut BuffersBuilder::new(&mut buffers, ApplyNormal)
         ).is_err() {
             return Err(TessError::Fill);
@@ -32,7 +32,7 @@ pub fn tessellate(cmd: TessellateCmd) -> Result<VertexBuffers<Point>, TessError>
     }
 
     if let Some(width) = cmd.stroke {
-        StrokeTessellator::new().tessellate(
+        StrokeTessellator::new().tessellate_flattened_path(
             cmd.path.path_iter().flattened(cmd.tolerance),
             &StrokeOptions::default(),
             &mut BuffersBuilder::new(&mut buffers, StrokeWidth(width))

--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -130,11 +130,10 @@ fn main() {
     // zoom level changes (not done here for simplicity).
     let fill_count = FillTessellator::new()
         .tessellate_path(
-            path.path_iter().flattened(0.09),
-            &FillOptions::default(),
+            path.path_iter(),
+            &FillOptions::tolerance(0.09),
             &mut BuffersBuilder::new(&mut cpu.fills, WithId(logo_fill_ids.range.start())),
-        )
-        .unwrap();
+        ).unwrap();
 
     cpu.fill_primitives[logo_fill_ids.first()] = GpuFillPrimitive::new(
         [1.0, 1.0, 1.0, 1.0],
@@ -166,9 +165,9 @@ fn main() {
         )
     );
 
-    StrokeTessellator::new().tessellate(
-        path.path_iter().flattened(0.022),
-        &StrokeOptions::default().dont_apply_line_width(),
+    StrokeTessellator::new().tessellate_path(
+        path.path_iter(),
+        &StrokeOptions::tolerance(0.022).dont_apply_line_width(),
         &mut BuffersBuilder::new(&mut cpu.strokes, WithId(logo_stroke_id.element)),
     );
 

--- a/examples/gfx_basic/src/main.rs
+++ b/examples/gfx_basic/src/main.rs
@@ -55,8 +55,8 @@ fn main() {
     let mut mesh = VertexBuffers::new();
 
     tessellator.tessellate_path(
-        path.path_iter().flattened(0.01),
-        &FillOptions::default(),
+        path.path_iter(),
+        &FillOptions::tolerance(0.01),
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     ).unwrap();
 

--- a/examples/intersections/src/main.rs
+++ b/examples/intersections/src/main.rs
@@ -150,12 +150,12 @@ fn main() {
         )
     );
 
-    StrokeTessellator::new().tessellate(
+    StrokeTessellator::new().tessellate_flattened_path(
         bezier_path.path_iter().flattened(0.01),
         &StrokeOptions::default().dont_apply_line_width(),
         &mut BuffersBuilder::new(&mut cpu.strokes, WithId(bezier_id.element)),
     );
-    StrokeTessellator::new().tessellate(
+    StrokeTessellator::new().tessellate_flattened_path(
         line_path.path_iter().flattened(0.01),
         &StrokeOptions::default().dont_apply_line_width(),
         &mut BuffersBuilder::new(&mut cpu.strokes, WithId(line_id.element)),

--- a/examples/svg_bench/src/svg_renderer.rs
+++ b/examples/svg_bench/src/svg_renderer.rs
@@ -281,7 +281,7 @@ fn tessellate_scene(scene: &mut[RenderItem]) {
             }
             if let Some(color) = item.stroke {
                 println!(" -- tessellate stroke");
-                stroke_tessellator.tessellate(
+                stroke_tessellator.tessellate_flattened_path(
                     item.path.path_iter().flattened(0.03),
                     &StrokeOptions::default(),
                     &mut BuffersBuilder::new(&mut buffers, WithColorAndStrokeWidth([

--- a/renderer/src/batch_builder.rs
+++ b/renderer/src/batch_builder.rs
@@ -247,7 +247,7 @@ impl VertexBuilder<FillPrimitiveId, GpuFillVertex> for FillVertexBuilder {
         let vtx_offset = geom.vertices.len();
         let idx_offset = geom.indices.len();
 
-        let count = self.tessellator.tessellate_path(
+        let count = self.tessellator.tessellate_flattened_path(
             path.path_iter().flattened(tolerance),
             &FillOptions::default(),
             &mut BuffersBuilder::new(geom, WithId(prim_id))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 //!         let tolerance = 0.1;
 //!
 //!         // Compute the tessellation.
-//!         tessellator.tessellate_path(
+//!         tessellator.tessellate_flattened_path(
 //!             path.path_iter().flattened(tolerance),
 //!             &FillOptions::default(),
 //!             &mut geom_builder

--- a/tessellation/Cargo.toml
+++ b/tessellation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_tessellation"
-version = "0.6.1"
+version = "0.6.2"
 description = "A low level path tessellation library."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -744,7 +744,7 @@ where
 {
     let mut tess = StrokeTessellator::new();
 
-    return tess.tessellate(PolylineEvents::new(is_closed, it), options, output);
+    return tess.tessellate_flattened_path(PolylineEvents::new(is_closed, it), options, output);
 }
 
 /// Tessellate an arbitray shape that is discribed by an iterator of points.
@@ -758,7 +758,7 @@ where
     Iter: Iterator<Item = Point>,
     Output: GeometryBuilder<FillVertex>,
 {
-    tessellator.tessellate_path(
+    tessellator.tessellate_flattened_path(
         PolylineEvents::new(true, polyline),
         options,
         output

--- a/tessellation/src/geometry_builder.rs
+++ b/tessellation/src/geometry_builder.rs
@@ -119,7 +119,7 @@
 //!
 //! ```
 //! extern crate lyon_tessellation;
-//! use lyon_tessellation::{GeometryBuilder, Count};
+//! use lyon_tessellation::{GeometryBuilder, StrokeOptions, Count};
 //! use lyon_tessellation::geometry_builder::VertexId;
 //! use lyon_tessellation::basic_shapes::stroke_polyline;
 //! use lyon_tessellation::math::point;
@@ -175,6 +175,7 @@
 //!     stroke_polyline(
 //!         [point(0.0, 0.0), point(10.0, 0.0), point(5.0, 5.0)].iter().cloned(),
 //!         true,
+//!         &StrokeOptions::default(),
 //!         &mut output,
 //!     );
 //! }

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -166,12 +166,11 @@
 
 extern crate lyon_core as core;
 extern crate lyon_path_builder as path_builder;
+extern crate lyon_path_iterator as path_iterator;
 extern crate lyon_bezier as bezier;
 
 #[cfg(test)]
 extern crate lyon_path as path;
-#[cfg(test)]
-extern crate lyon_path_iterator as path_iterator;
 #[cfg(test)]
 extern crate lyon_extra as extra;
 

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -61,8 +61,8 @@
 //!     let mut tessellator = StrokeTessellator::new();
 //!
 //!     // Compute the tessellation.
-//!     tessellator.tessellate(
-//!         path.path_iter().flattened(0.05),
+//!     tessellator.tessellate_path(
+//!         path.path_iter(),
 //!         &StrokeOptions::default(),
 //!         &mut vertex_builder
 //!     );
@@ -82,6 +82,7 @@ use core::FlattenedEvent;
 use bezier::utils::normalized_tangent;
 use geometry_builder::{VertexId, GeometryBuilder, Count};
 use path_builder::BaseBuilder;
+use path_iterator::PathIterator;
 use StrokeVertex as Vertex;
 use Side;
 
@@ -91,7 +92,26 @@ pub struct StrokeTessellator {}
 impl StrokeTessellator {
     pub fn new() -> StrokeTessellator { StrokeTessellator {} }
 
-    pub fn tessellate<Input, Output>(
+    /// Compute the tessellation from a path iterator.
+    pub fn tessellate_path<Input, Output>(
+        &mut self,
+        input: Input,
+        options: &StrokeOptions,
+        builder: &mut Output,
+    ) -> Count
+    where
+        Input: PathIterator,
+        Output: GeometryBuilder<Vertex>,
+    {
+        self.tessellate_flattened_path(
+            input.flattened(options.tolerance),
+            options,
+            builder,
+        )
+    }
+
+    /// Compute the tessellation from a flattened path iterator.
+    pub fn tessellate_flattened_path<Input, Output>(
         &mut self,
         input: Input,
         options: &StrokeOptions,
@@ -630,6 +650,10 @@ impl StrokeOptions {
             apply_line_width: true,
             _private: (),
         }
+    }
+
+    pub fn tolerance(tolerance: f32) -> Self {
+        StrokeOptions::default().with_tolerance(tolerance)
     }
 
     pub fn with_tolerance(mut self, tolerance: f32) -> StrokeOptions {


### PR DESCRIPTION
- Pass StrokeOptions to the stroke tessellators in basic_shapes.rs
- Implement basic_shapes::fill_polyline
- Have the two path tessellators expose `tessellate_path` taking an iterator of path events (with curves) and `tessellate_flattened_path` with an iterator of flattened events (no curve).