### PR TITLE
Fix circle tessellation.

### DIFF
--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -569,19 +569,19 @@ pub fn fill_circle<Output: GeometryBuilder<FillVertex>>(
 
     let v = [
         output.add_vertex(FillVertex {
-            position: (left * radius).to_point(),
+            position: center + (left * radius),
             normal: left
         }),
         output.add_vertex(FillVertex {
-            position: (up * radius).to_point(),
+            position: center + (up * radius),
             normal: up
         }),
         output.add_vertex(FillVertex {
-            position: (right * radius).to_point(),
+            position: center + (right * radius),
             normal: right
         }),
         output.add_vertex(FillVertex {
-            position: (down * radius).to_point(),
+            position: center + (down * radius),
             normal: down
         }),
     ];


### PR DESCRIPTION
Fixes #129.

The circle is tessellated by first adding four vertices (up, down, left and right) that form a lozenge that fills the bulk of the interior, and then recursively building up the circle around it. See: http://imgur.com/6aGjnNc

Unfortunately these first four vertices were not translated along with the specified center. Ouch.

cc @icefoxen 