### PR TITLE
Fix borken links to path_fill and path_stroke module docs.

### DIFF
--- a/tessellation/src/geometry_builder.rs
+++ b/tessellation/src/geometry_builder.rs
@@ -240,6 +240,8 @@ impl VertexId {
 
 /// An interface separating tessellators and other geometry generation algorithms from the
 /// actual vertex construction.
+///
+/// See the [`geometry_builder`](index.html) module documentation for more detailed explanation.
 pub trait GeometryBuilder<Input> {
     /// Called at the beginning of a generation.
     ///

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -29,14 +29,15 @@
 //!
 //! ## Overview
 //!
-//! The most interesting modules of this crate are:
+//! The most interesting types and traits of this crate are:
 //!
-//! * [path_fill](path_fill/index.html) - Implementing the tessellation of complex path fill
-//!   operations.
-//! * [path_stroke](path_stroke/index.html) - Implementing the tessellation of complex path
-//!   stroke operations.
-//! * [geometry_builder](geometry_builder/index.html) - Which the above two are built on. It
-//!   provides traits to facilitate generating arbitrary vertex and index buffers.
+//! * [FillTessellator](struct.FillTessellator.html) - Tessellator for complex path fill operations.
+//! * [StrokeTessellator](struct.StrokeTessellator.html) - Tessellator for complex path stroke operations.
+//! * [`GeometryBuilder`](geometry_builder/trait.GeometryBuilder.html) - (See the documentation of the
+//!   [geometry_builder module](geometry_builder/index.html)) Which the above two are built on. This trait
+//!   provides an interface for types that help with building and assembling the vertices and triangles that
+//!   form the tessellation, usually in the form of arbitrary vertex and index buffers.
+//! * The various specialised tessellators in the [`basic_shapes`](basic_shapes/index.html) modules.
 //!
 //! ## The tessellation pipeline
 //!
@@ -127,10 +128,6 @@
 //! [lyon_path](https://docs.rs/lyon_path/*/lyon_path/) is provided for convenience
 //! (but is optional).
 //!
-//! While the path tessellators use iterators, other more specific tessellation routines
-//! take simpler outputs like rectangles and circles.
-//! See the documentation of the [basic_shapes](basic_shapes/index.html) module.
-//!
 //! ### The output: geometry builders
 //!
 //! The tessellators are parametrized over a type implementing the
@@ -191,6 +188,7 @@ pub use path_stroke::*;
 #[doc(inline)]
 pub use geometry_builder::{GeometryBuilder, BezierGeometryBuilder, VertexBuffers, BuffersBuilder, VertexConstructor, Count};
 
+/// Left or right.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Side {
     Left,

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -1,96 +1,3 @@
-//! # Path fill tessellator
-//!
-//! Tessellation routines for complex path fill operations.
-//!
-//! <svg version="1.1" viewBox="0 0 400 200" height="200" width="400">
-//!   <g transform="translate(0,-852.36216)">
-//!     <path style="fill:#aad400;stroke:none;" transform="translate(0,852.36216)" d="M 20 20 L 20 180 L 180.30273 180 L 180.30273 20 L 20 20 z M 100 55 L 145 145 L 55 145 L 100 55 z "/>
-//!     <path style="fill:#aad400;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-" d="m 219.75767,872.36216 0,160.00004 160.30273,0 0,-160.00004 -160.30273,0 z m 80,35 45,90 -90,0 45,-90 z"/>
-//!     <path style="fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-" d="m 220,1032.3622 35,-35.00004 125,35.00004 -35,-35.00004 35,-125 -80,35 -80,-35 35,125"/>
-//!     <circle r="5" cy="872.36218" cx="20" style="color:#000000;;fill:#ff6600;fill-;stroke:#000000;" />
-//!     <circle r="5" cx="180.10918" cy="872.61475" style="fill:#ff6600;stroke:#000000;"/>
-//!     <circle r="5" cy="1032.2189" cx="180.10918" style="fill:#ff6600;stroke:#000000;"/>
-//!     <circle r="5" cx="20.505075" cy="1032.4714" style="fill:#ff6600;stroke:#000000;"/>
-//!     <circle r="5" cy="907.21252" cx="99.802048" style="fill:#ff6600;stroke:#000000;"/>
-//!     <circle r="5" cx="55.102798" cy="997.36865" style="fill:#ff6600;stroke:#000000;"/>
-//!     <circle r="5" cy="997.62122" cx="145.25891" style="fill:#ff6600;stroke:#000000;"/>
-//!   </g>
-//! </svg>
-//!
-//! ## Overview
-//!
-//! The most important structure is [`FillTessellator`](struct.FillTessellator.html).
-//! It implements the path fill tessellation algorithm which is by far the most advanced
-//! feature in all lyon crates.
-//!
-//! The `FillTessellator` takes a [`FillEvents`](struct.FillEvents.html) object and
-//! [`FillOptions`](struct.FillOptions.html) as input. The former is an intermediate representaion
-//! of the path, containing all edges sorted from top to bottom. `FillOption` contains
-//! some extra parameters (Some of which are not implemented yet).
-//!
-//! The output of the tessellator is produced by the
-//! [`GeometryBuilder`](../geometry_builder/trait.GeometryBuilder.html) (see the
-//! [`geometry_builder` documentation](../geometry_builder/index.html) for more details about
-//! how tessellators produce their output geometry, and how to generate custom vertex layouts).
-//!
-//! The [tessellator's wiki page](https://github.com/nical/lyon/wiki/Tessellator) is a good place
-//! to learn more about how the tessellator's algorithm works. The source code also contains
-//! inline documentation for the adventurous who want to delve into more details.
-//!
-//! # Examples
-//!
-//! ```
-//! # extern crate lyon_tessellation;
-//! # extern crate lyon_core;
-//! # extern crate lyon_path;
-//! # extern crate lyon_path_builder;
-//! # extern crate lyon_path_iterator;
-//! # use lyon_path::Path;
-//! # use lyon_path_builder::*;
-//! # use lyon_path_iterator::*;
-//! # use lyon_core::math::{Point, point};
-//! # use lyon_tessellation::geometry_builder::{VertexBuffers, simple_builder};
-//! # use lyon_tessellation::*;
-//! # fn main() {
-//! // Create a simple path.
-//! let mut path_builder = Path::builder();
-//! path_builder.move_to(point(0.0, 0.0));
-//! path_builder.line_to(point(1.0, 2.0));
-//! path_builder.line_to(point(2.0, 0.0));
-//! path_builder.line_to(point(1.0, 1.0));
-//! path_builder.close();
-//! let path = path_builder.build();
-//!
-//! // Create the destination vertex and index buffers.
-//! let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
-//!
-//! {
-//!     // Create the destination vertex and index buffers.
-//!     let mut vertex_builder = simple_builder(&mut buffers);
-//!
-//!     // Create the tessellator.
-//!     let mut tessellator = FillTessellator::new();
-//!
-//!     // Compute the tessellation.
-//!     let result = tessellator.tessellate_flattened_path(
-//!         path.path_iter().flattened(0.05),
-//!         &FillOptions::default(),
-//!         &mut vertex_builder
-//!     );
-//!     assert!(result.is_ok());
-//! }
-//!
-//! println!("The generated vertices are: {:?}.", &buffers.vertices[..]);
-//! println!("The generated indices are: {:?}.", &buffers.indices[..]);
-//!
-//! # }
-//! ```
-//!
-//! # How the fill tessellator works
-//!
-//! Learn more about how the algrorithm works on the [tessellator wiki page](https://github.com/nical/lyon/wiki/Tessellator).
-//!
-
 // TODO[optim]
 //
 // # Segment intersection
@@ -179,9 +86,94 @@ struct EdgeBelow {
 
 /// A Context object that can tessellate fill operations for complex paths.
 ///
-/// The Tessellator API is not stable yet. For example it is not clear whether we will use
-/// separate Tessellator structs for some of the different configurations (vertex-aa, etc),
-/// or if evertything can be implemented with the same algorithm.
+/// <svg version="1.1" viewBox="0 0 400 200" height="200" width="400">
+///   <g transform="translate(0,-852.36216)">
+///     <path style="fill:#aad400;stroke:none;" transform="translate(0,852.36216)" d="M 20 20 L 20 180 L 180.30273 180 L 180.30273 20 L 20 20 z M 100 55 L 145 145 L 55 145 L 100 55 z "/>
+///     <path style="fill:#aad400;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-" d="m 219.75767,872.36216 0,160.00004 160.30273,0 0,-160.00004 -160.30273,0 z m 80,35 45,90 -90,0 45,-90 z"/>
+///     <path style="fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-" d="m 220,1032.3622 35,-35.00004 125,35.00004 -35,-35.00004 35,-125 -80,35 -80,-35 35,125"/>
+///     <circle r="5" cy="872.36218" cx="20" style="color:#000000;;fill:#ff6600;fill-;stroke:#000000;" />
+///     <circle r="5" cx="180.10918" cy="872.61475" style="fill:#ff6600;stroke:#000000;"/>
+///     <circle r="5" cy="1032.2189" cx="180.10918" style="fill:#ff6600;stroke:#000000;"/>
+///     <circle r="5" cx="20.505075" cy="1032.4714" style="fill:#ff6600;stroke:#000000;"/>
+///     <circle r="5" cy="907.21252" cx="99.802048" style="fill:#ff6600;stroke:#000000;"/>
+///     <circle r="5" cx="55.102798" cy="997.36865" style="fill:#ff6600;stroke:#000000;"/>
+///     <circle r="5" cy="997.62122" cx="145.25891" style="fill:#ff6600;stroke:#000000;"/>
+///   </g>
+/// </svg>
+///
+/// ## Overview
+///
+/// The most important structure is [`FillTessellator`](struct.FillTessellator.html).
+/// It implements the path fill tessellation algorithm which is by far the most advanced
+/// feature in all lyon crates.
+///
+/// The `FillTessellator` takes a [`FillEvents`](struct.FillEvents.html) object and
+/// [`FillOptions`](struct.FillOptions.html) as input. The former is an intermediate representaion
+/// of the path, containing all edges sorted from top to bottom. `FillOption` contains
+/// some extra parameters (Some of which are not implemented yet).
+///
+/// The output of the tessellator is produced by the
+/// [`GeometryBuilder`](geometry_builder/trait.GeometryBuilder.html) (see the
+/// [`geometry_builder` documentation](geometry_builder/index.html) for more details about
+/// how tessellators produce their output geometry, and how to generate custom vertex layouts).
+///
+/// The [tessellator's wiki page](https://github.com/nical/lyon/wiki/Tessellator) is a good place
+/// to learn more about how the tessellator's algorithm works. The source code also contains
+/// inline documentation for the adventurous who want to delve into more details.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate lyon_tessellation;
+/// # extern crate lyon_core;
+/// # extern crate lyon_path;
+/// # extern crate lyon_path_builder;
+/// # extern crate lyon_path_iterator;
+/// # use lyon_path::Path;
+/// # use lyon_path_builder::*;
+/// # use lyon_path_iterator::*;
+/// # use lyon_core::math::{Point, point};
+/// # use lyon_tessellation::geometry_builder::{VertexBuffers, simple_builder};
+/// # use lyon_tessellation::*;
+/// # fn main() {
+/// // Create a simple path.
+/// let mut path_builder = Path::builder();
+/// path_builder.move_to(point(0.0, 0.0));
+/// path_builder.line_to(point(1.0, 2.0));
+/// path_builder.line_to(point(2.0, 0.0));
+/// path_builder.line_to(point(1.0, 1.0));
+/// path_builder.close();
+/// let path = path_builder.build();
+///
+/// // Create the destination vertex and index buffers.
+/// let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
+///
+/// {
+///     // Create the destination vertex and index buffers.
+///     let mut vertex_builder = simple_builder(&mut buffers);
+///
+///     // Create the tessellator.
+///     let mut tessellator = FillTessellator::new();
+///
+///     // Compute the tessellation.
+///     let result = tessellator.tessellate_flattened_path(
+///         path.path_iter().flattened(0.05),
+///         &FillOptions::default(),
+///         &mut vertex_builder
+///     );
+///     assert!(result.is_ok());
+/// }
+///
+/// println!("The generated vertices are: {:?}.", &buffers.vertices[..]);
+/// println!("The generated indices are: {:?}.", &buffers.indices[..]);
+///
+/// # }
+/// ```
+///
+/// # How the fill tessellator works
+///
+/// Learn more about how the algrorithm works on the [tessellator wiki page](https://github.com/nical/lyon/wiki/Tessellator).
+///
 pub struct FillTessellator {
     events: FillEvents,
     sweep_line: Vec<Span>,


### PR DESCRIPTION
Fixes #127.

These two modules are not public anymore so their documentation isn't generated. I moved the documentation into the `FillTessellator` and `StrokeTessellator` types directly to fix that.