### PR TITLE
Add meaningful errors for the svg crate #88

### DIFF
--- a/svg/src/parser/error.rs
+++ b/svg/src/parser/error.rs
@@ -1,0 +1,24 @@
+
+use std::fmt;
+use svgparser::Error;
+
+/// Errors which can occur when attempting to parse a token.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ParserError {
+    /// Error that occurs when attempting to get the next path token.
+    PathToken(Error),
+    /// Error that occurs when attempting to get the next style token.
+    StyleToken(Error),
+    ///Error during a style attribute parsing.
+    StyleAttribute(Error),
+}
+
+impl fmt::Display for ParserError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ParserError::PathToken(ref err) => write!(f, "Path token parsing error : {}", err),
+            ParserError::StyleToken(ref err) => write!(f, "Style token parsing error : {}", err),
+            ParserError::StyleAttribute(ref err) => write!(f, "Style attribute parsing error : {}", err),
+        }
+    }
+}

--- a/svg/src/parser/mod.rs
+++ b/svg/src/parser/mod.rs
@@ -2,6 +2,7 @@
 mod path;
 mod style;
 mod attribute;
+mod error;
 
 pub use svgparser::Color;
 pub use svgparser::Length;
@@ -12,6 +13,7 @@ pub use svgparser::ValueId;
 pub use self::attribute::{
     Attribute, AttributeId, AttributeValue, RefAttributeValue,
 };
+pub use self::error::ParserError;
 
-pub use self::path::{PathTokenizer, build_path, ParserError};
+pub use self::path::{PathTokenizer, build_path};
 pub use self::style::StyleTokenizer;

--- a/svg/src/parser/path.rs
+++ b/svg/src/parser/path.rs
@@ -5,9 +5,7 @@ use core::SvgEvent;
 use core::math;
 use core::ArcFlags;
 use path_builder::SvgBuilder;
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct ParserError;
+use super::error::ParserError;
 
 pub fn build_path<Builder>(mut builder: Builder, src: &str) -> Result<Builder::PathType, ParserError>
 where
@@ -54,7 +52,7 @@ impl<'l> Iterator for PathTokenizer<'l> {
                     None
                 }
             }
-            Err(_) => { Some(Err(ParserError)) }
+            Err(err) => { Some(Err(ParserError::PathToken(err))) }
         }
     }
 }


### PR DESCRIPTION
First little contribution, I will mainly focus on API guidelines issues for now.

This is a pull request for #88 but there could be additional changes.

If there is no point to group parser errors in one enum, I can split them.

I also checked other lyon crates and I didn't find similar cases. If you find more, let me know.