### PR TITLE
API guidelines: iterator type names should match the methods that produce them

### DIFF
--- a/bezier/src/cubic_bezier.rs
+++ b/bezier/src/cubic_bezier.rs
@@ -161,7 +161,7 @@ impl CubicBezierSegment {
 
     /// Returns the flattened representation of the curve as an iterator, starting *after* the
     /// current point.
-    pub fn flattening_iter(&self, tolerance: f32) -> CubicFlatteningIter {
+    pub fn cubic_flattening_iter(&self, tolerance: f32) -> CubicFlatteningIter {
         CubicFlatteningIter::new(*self, tolerance)
     }
 

--- a/bezier/src/flatten_cubic.rs
+++ b/bezier/src/flatten_cubic.rs
@@ -348,7 +348,7 @@ fn test_iterator_builder_1() {
         ctrl2: Point::new(1.0, 1.0),
         to: Point::new(0.0, 1.0),
     };
-    let iter_points: Vec<Point> = c1.flattening_iter(tolerance).collect();
+    let iter_points: Vec<Point> = c1.cubic_flattening_iter(tolerance).collect();
     let mut builder_points = Vec::new();
     c1.flattened_for_each(tolerance, &mut |p| { builder_points.push(p); });
 
@@ -365,7 +365,7 @@ fn test_iterator_builder_2() {
         ctrl2: Point::new(0.0, 1.0),
         to: Point::new(1.0, 1.0),
     };
-    let iter_points: Vec<Point> = c1.flattening_iter(tolerance).collect();
+    let iter_points: Vec<Point> = c1.cubic_flattening_iter(tolerance).collect();
     let mut builder_points = Vec::new();
     c1.flattened_for_each(tolerance, &mut |p| { builder_points.push(p); });
 
@@ -382,7 +382,7 @@ fn test_iterator_builder_3() {
         ctrl2: Point::new(140.0, 130.0),
         to: Point::new(131.0, 130.0),
     };
-    let iter_points: Vec<Point> = c1.flattening_iter(tolerance).collect();
+    let iter_points: Vec<Point> = c1.cubic_flattening_iter(tolerance).collect();
     let mut builder_points = Vec::new();
     c1.flattened_for_each(tolerance, &mut |p| { builder_points.push(p); });
 
@@ -399,7 +399,7 @@ fn test_issue_19() {
         ctrl2: Point::new(18.142855, 19.27679),
         to: Point::new(18.142855, 19.27679),
     };
-    let iter_points: Vec<Point> = c1.flattening_iter(tolerance).collect();
+    let iter_points: Vec<Point> = c1.cubic_flattening_iter(tolerance).collect();
     let mut builder_points = Vec::new();
     c1.flattened_for_each(tolerance, &mut |p| { builder_points.push(p); });
 

--- a/bezier/src/quadratic_bezier.rs
+++ b/bezier/src/quadratic_bezier.rs
@@ -239,7 +239,7 @@ impl QuadraticBezierSegment {
 
     /// Returns the flattened representation of the curve as an iterator, starting *after* the
     /// current point.
-    pub fn flattening_iter(&self, tolerance: f32) -> QuadraticFlatteningIter {
+    pub fn quadratic_flattening_iter(&self, tolerance: f32) -> QuadraticFlatteningIter {
         QuadraticFlatteningIter::new(*self, tolerance)
     }
 

--- a/path_iterator/src/path_iterator.rs
+++ b/path_iterator/src/path_iterator.rs
@@ -221,7 +221,7 @@ where
                             from: current,
                             ctrl: ctrl,
                             to: to,
-                    }.flattening_iter(self.tolerance)
+                    }.quadratic_flattening_iter(self.tolerance)
                 );
                 return self.next();
             }
@@ -232,7 +232,7 @@ where
                         ctrl1: ctrl1,
                         ctrl2: ctrl2,
                         to: to,
-                    }.flattening_iter(self.tolerance)
+                    }.cubic_flattening_iter(self.tolerance)
                 );
                 return self.next();
             }


### PR DESCRIPTION
Fixes https://github.com/nical/lyon/issues/87