### PR TITLE
[WIP] API guidelines: iterator type names should match the methods that produce them

### DIFF
--- a/bezier/src/cubic_bezier.rs
+++ b/bezier/src/cubic_bezier.rs
@@ -2,7 +2,7 @@ use {Point, Vec2, Rect, rect, Line, LineSegment, Transform2D};
 use up_to_two::UpToTwo;
 use arrayvec::ArrayVec;
 use flatten_cubic::{flatten_cubic_bezier, find_cubic_bezier_inflection_points};
-pub use flatten_cubic::CubicFlatteningIter;
+pub use flatten_cubic::Flattened;
 pub use cubic_to_quadratic::cubic_to_quadratic;
 use monotone::{XMonotoneParametricCurve, solve_t_for_x};
 use utils::cubic_polynomial_roots;
@@ -161,8 +161,8 @@ impl CubicBezierSegment {
 
     /// Returns the flattened representation of the curve as an iterator, starting *after* the
     /// current point.
-    pub fn flattening_iter(&self, tolerance: f32) -> CubicFlatteningIter {
-        CubicFlatteningIter::new(*self, tolerance)
+    pub fn flattened(&self, tolerance: f32) -> Flattened {
+        Flattened::new(*self, tolerance)
     }
 
     /// Iterates through the curve invoking a callback at each point.

--- a/bezier/src/flatten_cubic.rs
+++ b/bezier/src/flatten_cubic.rs
@@ -17,7 +17,7 @@ use std::mem::swap;
 ///
 /// The iterator starts at the first point *after* the origin of the curve and ends at the
 /// destination.
-pub struct CubicFlatteningIter {
+pub struct Flattened {
     remaining_curve: CubicBezierSegment,
     // current portion of the curve, does not have inflections.
     current_curve: Option<CubicBezierSegment>,
@@ -27,13 +27,13 @@ pub struct CubicFlatteningIter {
     check_inflection: bool,
 }
 
-impl CubicFlatteningIter {
+impl Flattened {
     /// Creates an iterator that yields points along a cubic bezier segment, useful to build a
     /// flattened approximation of the curve given a certain tolerance.
     pub fn new(bezier: CubicBezierSegment, tolerance: f32) -> Self {
         let inflections = find_cubic_bezier_inflection_points(&bezier);
 
-        let mut iter = CubicFlatteningIter {
+        let mut iter = Flattened {
             remaining_curve: bezier,
             current_curve: None,
             next_inflection: inflections.get(0).cloned(),
@@ -62,7 +62,7 @@ impl CubicFlatteningIter {
     }
 }
 
-impl Iterator for CubicFlatteningIter {
+impl Iterator for Flattened {
     type Item = Point;
     fn next(&mut self) -> Option<Point> {
 
@@ -348,7 +348,7 @@ fn test_iterator_builder_1() {
         ctrl2: Point::new(1.0, 1.0),
         to: Point::new(0.0, 1.0),
     };
-    let iter_points: Vec<Point> = c1.flattening_iter(tolerance).collect();
+    let iter_points: Vec<Point> = c1.flattened(tolerance).collect();
     let mut builder_points = Vec::new();
     c1.flattened_for_each(tolerance, &mut |p| { builder_points.push(p); });
 
@@ -365,7 +365,7 @@ fn test_iterator_builder_2() {
         ctrl2: Point::new(0.0, 1.0),
         to: Point::new(1.0, 1.0),
     };
-    let iter_points: Vec<Point> = c1.flattening_iter(tolerance).collect();
+    let iter_points: Vec<Point> = c1.flattened(tolerance).collect();
     let mut builder_points = Vec::new();
     c1.flattened_for_each(tolerance, &mut |p| { builder_points.push(p); });
 
@@ -382,7 +382,7 @@ fn test_iterator_builder_3() {
         ctrl2: Point::new(140.0, 130.0),
         to: Point::new(131.0, 130.0),
     };
-    let iter_points: Vec<Point> = c1.flattening_iter(tolerance).collect();
+    let iter_points: Vec<Point> = c1.flattened(tolerance).collect();
     let mut builder_points = Vec::new();
     c1.flattened_for_each(tolerance, &mut |p| { builder_points.push(p); });
 
@@ -399,7 +399,7 @@ fn test_issue_19() {
         ctrl2: Point::new(18.142855, 19.27679),
         to: Point::new(18.142855, 19.27679),
     };
-    let iter_points: Vec<Point> = c1.flattening_iter(tolerance).collect();
+    let iter_points: Vec<Point> = c1.flattened(tolerance).collect();
     let mut builder_points = Vec::new();
     c1.flattened_for_each(tolerance, &mut |p| { builder_points.push(p); });
 

--- a/bezier/src/lib.rs
+++ b/bezier/src/lib.rs
@@ -71,8 +71,8 @@ extern crate euclid;
 mod flatten_cubic;
 mod cubic_to_quadratic;
 mod up_to_two;
-mod quadratic_bezier;
-mod cubic_bezier;
+pub mod quadratic_bezier;
+pub mod cubic_bezier;
 mod triangle;
 mod line;
 mod arc;
@@ -99,8 +99,8 @@ pub type Transform2D = euclid::Transform2D<f32>;
 
 pub type Radians = euclid::Radians<f32>;
 
-pub use quadratic_bezier::{QuadraticBezierSegment, QuadraticFlatteningIter};
-pub use cubic_bezier::{CubicBezierSegment, CubicFlatteningIter};
+pub use quadratic_bezier::QuadraticBezierSegment;
+pub use cubic_bezier::CubicBezierSegment;
 pub use triangle::{Triangle};
 pub use line::{LineSegment, Line};
 pub use arc::{Arc, SvgArc, ArcFlags};

--- a/bezier/src/quadratic_bezier.rs
+++ b/bezier/src/quadratic_bezier.rs
@@ -239,8 +239,8 @@ impl QuadraticBezierSegment {
 
     /// Returns the flattened representation of the curve as an iterator, starting *after* the
     /// current point.
-    pub fn flattening_iter(&self, tolerance: f32) -> QuadraticFlatteningIter {
-        QuadraticFlatteningIter::new(*self, tolerance)
+    pub fn flattened(&self, tolerance: f32) -> Flattened {
+        Flattened::new(*self, tolerance)
     }
 
     /// Compute the length of the segment using a flattened approximation.
@@ -400,16 +400,16 @@ fn yx(point: Point) -> Point { Point::new(point.y, point.x) }
 ///
 /// The iterator starts at the first point *after* the origin of the curve and ends at the
 /// destination.
-pub struct QuadraticFlatteningIter {
+pub struct Flattened {
     curve: QuadraticBezierSegment,
     tolerance: f32,
     done: bool,
 }
 
-impl QuadraticFlatteningIter {
+impl Flattened {
     pub fn new(curve: QuadraticBezierSegment, tolerance: f32) -> Self {
         assert!(tolerance > 0.0);
-        QuadraticFlatteningIter {
+        Flattened {
             curve: curve,
             tolerance: tolerance,
             done: false,
@@ -417,7 +417,7 @@ impl QuadraticFlatteningIter {
     }
 }
 
-impl Iterator for QuadraticFlatteningIter {
+impl Iterator for Flattened {
     type Item = Point;
     fn next(&mut self) -> Option<Point> {
         if self.done {

--- a/path/src/path.rs
+++ b/path/src/path.rs
@@ -1,5 +1,5 @@
 use path_builder::{BaseBuilder, PathBuilder, SvgPathBuilder, FlatteningBuilder};
-use path_iterator::PathStateIter;
+use path_iterator::PathIter;
 
 use core::PathEvent;
 use core::math::*;
@@ -60,9 +60,9 @@ impl Path {
         }
     }
 
-    pub fn iter(&self) -> PathIter { PathIter::new(&self.points[..], &self.verbs[..]) }
+    pub fn iter(&self) -> Iter { Iter::new(&self.points[..], &self.verbs[..]) }
 
-    pub fn path_iter(&self) -> PathStateIter<PathIter> { PathStateIter::new(self.iter()) }
+    pub fn path_iter(&self) -> PathIter<Iter> { PathIter::new(self.iter()) }
 
     pub fn points(&self) -> &[Point] { &self.points[..] }
 
@@ -73,9 +73,9 @@ impl Path {
 
 impl<'l> IntoIterator for &'l Path {
     type Item = PathEvent;
-    type IntoIter = PathIter<'l>;
+    type IntoIter = Iter<'l>;
 
-    fn into_iter(self) -> PathIter<'l> { self.iter() }
+    fn into_iter(self) -> Iter<'l> { self.iter() }
 }
 
 /// An immutable view over a Path.
@@ -87,9 +87,9 @@ impl<'l> PathSlice<'l> {
         }
     }
 
-    pub fn iter(&self) -> PathIter { PathIter::new(self.points, self.verbs) }
+    pub fn iter(&self) -> Iter { Iter::new(self.points, self.verbs) }
 
-    pub fn path_iter(&self) -> PathStateIter<PathIter> { PathStateIter::new(self.iter()) }
+    pub fn path_iter(&self) -> PathIter<Iter> { PathIter::new(self.iter()) }
 
     pub fn points(&self) -> &[Point] { self.points }
 
@@ -98,9 +98,9 @@ impl<'l> PathSlice<'l> {
 
 //impl<'l> IntoIterator for PathSlice<'l> {
 //    type Item = PathEvent;
-//    type IntoIter = PathIter<'l>;
+//    type IntoIter = Iter<'l>;
 //
-//    fn into_iter(self) -> PathIter<'l> { self.iter() }
+//    fn into_iter(self) -> Iter<'l> { self.iter() }
 //}
 
 /// Builds path object using the BaseBuilder interface.
@@ -213,21 +213,21 @@ impl PathBuilder for Builder {
 }
 
 #[derive(Clone, Debug)]
-pub struct PathIter<'l> {
+pub struct Iter<'l> {
     points: ::std::slice::Iter<'l, Point>,
     verbs: ::std::slice::Iter<'l, Verb>,
 }
 
-impl<'l> PathIter<'l> {
+impl<'l> Iter<'l> {
     pub fn new(points: &'l [Point], verbs: &'l [Verb]) -> Self {
-        PathIter {
+        Iter {
             points: points.iter(),
             verbs: verbs.iter(),
         }
     }
 }
 
-impl<'l> Iterator for PathIter<'l> {
+impl<'l> Iterator for Iter<'l> {
     type Item = PathEvent;
     fn next(&mut self) -> Option<PathEvent> {
         return match self.verbs.next() {


### PR DESCRIPTION
working on https://github.com/nical/lyon/issues/87.

I changed the iterators to match the method names.  However, I run into this error when trying to use Flattened for both classes.  Sorry, I'm new to Rust, so perhaps this issue was too challenging for me.

  cargo test --all
   Compiling lyon_bezier v0.7.1 (file:///Users/annaliao/repos/lyon/bezier)
error[E0252]: a type named `Flattened` has already been imported in this module
   --> bezier/src/lib.rs:103:44
    |
102 | pub use quadratic_bezier::{QuadraticBezierSegment, Flattened};
    |                                                    --------- previous import of `Flattened` here
103 | pub use cubic_bezier::{CubicBezierSegment, Flattened};
    |                                            ^^^^^^^^^ `Flattened` already imported

error[E0252]: a type named `Flattened` has already been imported in this module
   --> bezier/src/lib.rs:103:44
    |
102 | pub use quadratic_bezier::{QuadraticBezierSegment, Flattened};
    |                                                    --------- previous import of `Flattened` here
103 | pub use cubic_bezier::{CubicBezierSegment, Flattened};
    |                                            ^^^^^^^^^ `Flattened` already imported

error: aborting due to previous error

error: Could not compile `lyon_bezier`.
Build failed, waiting for other jobs to finish...
error: aborting due to previous error

error: build failed
