### PR TITLE
Remove vertex-aa from fill and stroke options.

### DIFF
--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -321,12 +321,6 @@ pub struct StrokeOptions {
     /// See [Flattening and tolerance](index.html#flattening-and-tolerance).
     pub tolerance: f32,
 
-    /// An anti-aliasing trick extruding a 1-px wide strip around the edges with
-    /// a gradient to smooth the edges.
-    ///
-    /// Not implemented yet!
-    pub vertex_aa: bool,
-
     /// Apply line width
     ///
     /// When set to false, the generated vertices will all be positioned in the centre
@@ -348,7 +342,6 @@ impl StrokeOptions {
             line_width: 1.0,
             miter_limit: 10.0,
             tolerance: 0.1,
-            vertex_aa: false,
             apply_line_width: true,
             _private: (),
         }
@@ -391,11 +384,6 @@ impl StrokeOptions {
 
     pub fn with_miter_limit(mut self, limit: f32) -> StrokeOptions {
         self.miter_limit = limit;
-        return self;
-    }
-
-    pub fn with_vertex_aa(mut self) -> StrokeOptions {
-        self.vertex_aa = true;
         return self;
     }
 

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -250,10 +250,6 @@ impl FillTessellator {
     where
         Output: GeometryBuilder<Vertex>,
     {
-        if options.vertex_aa {
-            println!("warning: Vertex-aa is not supported yet.");
-        }
-
         if options.fill_rule != FillRule::EvenOdd {
             println!("warning: Fill rule {:?} is not supported yet.", options.fill_rule);
         }
@@ -1481,12 +1477,6 @@ pub struct FillOptions {
     /// Currently, only the EvenOdd rule is implemented.
     pub fill_rule: FillRule,
 
-    /// An anti-aliasing trick extruding a 1-px wide strip around the edges with
-    /// a gradient to smooth the edges.
-    ///
-    /// Not implemented yet!
-    pub vertex_aa: bool,
-
     // To be able to add fields without making it a breaking change, add an empty private field
     // which makes it impossible to create a FillOptions without the calling constructor.
     _private: (),
@@ -1499,7 +1489,6 @@ impl FillOptions {
         FillOptions {
             tolerance: 0.1,
             fill_rule: FillRule::EvenOdd,
-            vertex_aa: false,
             _private: (),
         }
     }
@@ -1516,11 +1505,6 @@ impl FillOptions {
 
     pub fn with_tolerance(mut self, tolerance: f32) -> FillOptions {
         self.tolerance = tolerance;
-        return self;
-    }
-
-    pub fn with_vertex_aa(mut self) -> FillOptions {
-        self.vertex_aa = true;
         return self;
     }
 }


### PR DESCRIPTION
They aren't implemented and I have no plan to do it in the short term. We can always add them back later.