### PR TITLE
Track active edges instead of spans in the sweep line.

### DIFF
--- a/tessellation/Cargo.toml
+++ b/tessellation/Cargo.toml
@@ -21,6 +21,7 @@ lyon_path = { version = "0.7.0", path = "../path" }
 lyon_bezier = { version = "0.7.1", path = "../bezier" }
 lyon_path_builder = { version = "0.7.0", path = "../path_builder" }
 lyon_path_iterator = { version = "0.7.0", path = "../path_iterator" }
+sid = "0.5"
 
 [dev-dependencies]
 lyon_extra = { version = "0.7.0", path = "../extra" }

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -188,6 +188,8 @@ extern crate lyon_path as path;
 #[cfg(test)]
 extern crate lyon_extra as extra;
 
+extern crate sid;
+
 pub mod basic_shapes;
 pub mod geometry_builder;
 mod path_fill;

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -196,7 +196,7 @@ struct EdgeBelow {
 ///
 pub struct FillTessellator {
     events: FillEvents,
-    monotone_tessellators: Vec<MonotoneTessellator>,
+    monotone_tessellators: IdVec<SpanId, MonotoneTessellator>,
     active_edges: ActiveEdges,
     intersections: Vec<Edge>,
     below: Vec<EdgeBelow>,
@@ -212,7 +212,7 @@ impl FillTessellator {
         FillTessellator {
             events: FillEvents::new(),
             active_edges: ActiveEdges::with_capacity(16),
-            monotone_tessellators: Vec::with_capacity(16),
+            monotone_tessellators: IdVec::with_capacity(16),
             below: Vec::with_capacity(8),
             intersections: Vec::with_capacity(8),
             previous_position: TessPoint::new(FixedPoint32::min_val(), FixedPoint32::min_val()),
@@ -1086,7 +1086,10 @@ fn even(edge: ActiveEdgeId) -> bool { edge.handle % 2 == 0 }
 fn odd(edge: ActiveEdgeId) -> bool { edge.handle % 2 == 1 }
 
 #[inline]
-fn span_for_edge(edge: ActiveEdgeId) -> usize { edge.handle / 2 }
+fn span_for_edge(edge: ActiveEdgeId) -> SpanId {
+    // TODO: this assumes the even-odd fill rule.
+    SpanId::new(edge.handle / 2)
+}
 
 fn compare_positions(a: TessPoint, b: TessPoint) -> Ordering {
     if a.y > b.y {


### PR DESCRIPTION
Representing the sweep line as pairs of active edges (spans) only makes sense for the even-odd fill rule and makes it hard to implement other fill rules. In addition it involved duplicating code in various places to handle the left and right edges.

This puts us in a better place to implement the non-zero fill rule and implement, bentley-ottmann style intersection checks and maybe reorganize the intersection code to take advantage of SIMD.