### PR TITLE
Small tessellator enhancements.

### DIFF
--- a/tessellation/src/geometry_builder.rs
+++ b/tessellation/src/geometry_builder.rs
@@ -285,6 +285,7 @@ pub trait BezierGeometryBuilder<Input>: GeometryBuilder<Input> {
 /// Structure that holds the vertex and index data.
 ///
 /// Usually writen into though temporary `BuffersBuilder` objects.
+#[derive(Clone, Debug)]
 pub struct VertexBuffers<VertexType> {
     pub vertices: Vec<VertexType>,
     pub indices: Vec<Index>,


### PR DESCRIPTION
This speeds up a little bit (4.5% improvement on the logo benchmark) by merging `test_span_side` and `test_span_touch` into a single function.

Also implements Clone and Debug for VertexBuffers (cf #167).