### PR TITLE
A bit of FillTessellator optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ license = "MIT/Apache-2.0"
 name = "lyon"
 path = "src/lib.rs"
 
+# Uncomment this when profiling.
+#[profile.release]
+#debug = true
+
 [dependencies]
 
 lyon_tessellation = { version = "0.7.3", path = "tessellation/" }

--- a/bench/path_fill/src/fill_bench.rs
+++ b/bench/path_fill/src/fill_bench.rs
@@ -11,7 +11,9 @@ use lyon::path_iterator::PathIterator;
 
 use bencher::Bencher;
 
-fn logo_tess(bench: &mut Bencher) {
+const N: usize = 100;
+
+fn logo_tess_only(bench: &mut Bencher) {
     let mut path = Path::builder().with_svg();
     build_logo_path(&mut path);
     let path = path.build();
@@ -21,8 +23,10 @@ fn logo_tess(bench: &mut Bencher) {
     let events = FillEvents::from_iterator(path.path_iter().flattened(0.05));
 
     bench.iter(|| {
-        let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
-        tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers))
+        for _ in 0..N {
+            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::with_capacity(512, 1450);
+            tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers)).unwrap();
+        }
     })
 }
 
@@ -36,8 +40,10 @@ fn logo_tess_no_intersection(bench: &mut Bencher) {
     let events = FillEvents::from_iterator(path.path_iter().flattened(0.05));
 
     bench.iter(|| {
-        let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
-        tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers))
+        for _ in 0..N {
+            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
+            tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers)).unwrap();
+        }
     })
 }
 
@@ -51,8 +57,10 @@ fn logo_tess_no_curve(bench: &mut Bencher) {
     let events = FillEvents::from_iterator(path.path_iter().flattened(1000000.0));
 
     bench.iter(|| {
-        let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
-        tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers))
+        for _ in 0..N {
+            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
+            tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers)).unwrap();
+        }
     })
 }
 
@@ -67,9 +75,11 @@ fn logo_events_and_tess(bench: &mut Bencher) {
     let mut events = FillEvents::new();
 
     bench.iter(|| {
-        events.set_path_iter(path.path_iter().flattened(0.05));
-        let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
-        tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers))
+        for _ in 0..N {
+            events.set_path_iter(path.path_iter().flattened(0.05));
+            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
+            tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers)).unwrap();
+        }
     })
 }
 
@@ -79,7 +89,9 @@ fn logo_events_only(bench: &mut Bencher) {
     let path = path.build();
 
     bench.iter(|| {
-        let _events = FillEvents::from_iterator(path.path_iter().flattened(0.05));
+        for _ in 0..N {
+            let _events = FillEvents::from_iterator(path.path_iter().flattened(0.05));
+        }
     })
 }
 
@@ -89,7 +101,9 @@ fn logo_events_only_pre_flattened(bench: &mut Bencher) {
     let path = path.build();
 
     bench.iter(|| {
-        let _events = FillEvents::from_iterator(path.path_iter().flattened(0.05));
+        for _ in 0..N {
+            let _events = FillEvents::from_iterator(path.path_iter().flattened(0.05));
+        }
     })
 }
 
@@ -99,12 +113,14 @@ fn logo_flattening(bench: &mut Bencher) {
     let path = path.build();
 
     bench.iter(|| {
-        for _ in path.path_iter().flattened(0.05) {}
+        for _ in 0..N {
+            for _ in path.path_iter().flattened(0.05) {}
+        }
     })
 }
 
 benchmark_group!(tess,
-  logo_tess,
+  logo_tess_only,
   logo_tess_no_curve,
   logo_tess_no_intersection
 );

--- a/tessellation/src/math_utils.rs
+++ b/tessellation/src/math_utils.rs
@@ -4,22 +4,6 @@ use math::*;
 use bezier::utils::directed_angle;
 use path_fill::Edge;
 
-/// Fixed-point version of the line vs horizontal line intersection test.
-pub fn line_horizontal_intersection_fixed(
-    edge: &Edge,
-    y: FixedPoint32,
-) -> Option<FixedPoint32> {
-    let v = edge.lower - edge.upper;
-
-    if v.y.is_zero() {
-        // the line is horizontal
-        return None;
-    }
-
-    let tmp: FixedPoint64 = (y - edge.upper.y).to_fp64();
-    return Some(edge.upper.x + tmp.mul_div(v.x.to_fp64(), v.y.to_fp64()).to_fp32());
-}
-
 #[inline]
 fn x_aabb_test(a1: FixedPoint32, b1: FixedPoint32, a2: FixedPoint32, b2: FixedPoint32) -> bool {
     let (min1, max1) = a1.min_max(b1);

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -1597,8 +1597,8 @@ impl MonotoneTessellator {
                     swap(&mut a, &mut b);
                 }
 
-                // TODO(perf) this call to directed_angle shows up in profiles.
-                if directed_angle2(b.pos, current.pos, a.pos) <= PI {
+                let cross = (current.pos - b.pos).cross(a.pos - b.pos);
+                if cross >= 0.0 {
                     self.push_triangle(&a, &b, &current);
                     last_popped = self.stack.pop();
                 } else {

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -1011,6 +1011,10 @@ impl FillTessellator {
         self.error = Some(err);
     }
 
+    #[cfg(not(debug))]
+    fn debug_check_sl(&self, _: TessPoint) {}
+
+    #[cfg(debug)]
     fn debug_check_sl(&self, current: TessPoint) {
         for edge in &self.active_edges {
             if !edge.merge {
@@ -1030,6 +1034,10 @@ impl FillTessellator {
         }
     }
 
+    #[cfg(not(debug))]
+    fn log_sl(&self, _: TessPoint, _: ActiveEdgeId) {}
+
+    #[cfg(debug)]
     fn log_sl(&self, current_position: TessPoint, start_edge: ActiveEdgeId) {
         println!("\n\n");
         self.log_sl_ids();
@@ -1040,6 +1048,10 @@ impl FillTessellator {
         }
     }
 
+    #[cfg(not(debug))]
+    fn log_sl_ids(&self) {}
+
+    #[cfg(debug)]
     fn log_sl_ids(&self) {
         print!("\n|  sl: ");
         let mut left = true;
@@ -1056,6 +1068,10 @@ impl FillTessellator {
         println!("");
     }
 
+    #[cfg(not(debug))]
+    fn log_sl_points(&self) {}
+
+    #[cfg(debug)]
     fn log_sl_points(&self) {
         print!("\n sl: [");
         let mut left = true;
@@ -1080,6 +1096,10 @@ impl FillTessellator {
         println!("]\n");
     }
 
+    #[cfg(not(debug))]
+    fn log_sl_points_at(&self, _: FixedPoint32) {}
+
+    #[cfg(debug)]
     fn log_sl_points_at(&self, y: FixedPoint32) {
         print!("\nat y={:?}  sl: [", y);
         let mut left = true;


### PR DESCRIPTION
I spent some time profiling and optimizing the tessellator this weekend.

before:
```
test logo_events_and_tess           ... bench:  15,668,913 ns/iter (+/- 173,931)
test logo_tess_no_curve             ... bench:   4,509,290 ns/iter (+/- 63,883)
test logo_tess_no_intersection      ... bench:   7,758,496 ns/iter (+/- 639,328)
test logo_tess_only                 ... bench:   9,252,560 ns/iter (+/- 984,362)
```


after:
```
test logo_events_and_tess           ... bench:  12,028,170 ns/iter (+/- 153,927)
test logo_tess_no_curve             ... bench:   3,337,986 ns/iter (+/- 21,012)
test logo_tess_no_intersection      ... bench:   5,540,060 ns/iter (+/- 65,196)
test logo_tess_only                 ... bench:   6,798,144 ns/iter (+/- 79,672)
```

