### PR TITLE
Improve the performance of the stroke tessellator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,5 @@ members = [
     "examples/gfx_basic",
     "examples/intersections",
     "bench/svg_bench",
-    "bench/path_fill"
+    "bench/tess"
 ]

--- a/bench/tess/Cargo.toml
+++ b/bench/tess/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
-name = "Fill tessellator benchmark"
+name = "tess_bench"
 version = "0.0.1"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 workspace = "../.."
 
 [[bin]]
-name = "fill_bench"
-path = "src/fill_bench.rs"
+name = "tess_bench"
 
 [dependencies]
 lyon = { path = "../../" }

--- a/tessellation/src/math_utils.rs
+++ b/tessellation/src/math_utils.rs
@@ -74,6 +74,8 @@ pub fn segment_intersection(
 /// would yield parallel segments exactly 1 unit away from their original. (useful
 /// for generating strokes and vertex-aa).
 /// The normal points towards the left side of e1.
+///
+/// TODO(perf) this is slower than the approach taken in the stroke tessellator.
 pub fn compute_normal(e1: Vec2, e2: Vec2) -> Vec2 {
     let e1_norm = e1.normalize();
     let n = e1_norm - e2.normalize();

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -1,6 +1,6 @@
 use math::*;
 use core::FlattenedEvent;
-use bezier::utils::{normalized_tangent, directed_angle};
+use bezier::utils::{normalized_tangent, directed_angle, fast_atan2};
 use geometry_builder::{VertexId, GeometryBuilder, Count};
 use basic_shapes::circle_flattening_step;
 use path_builder::FlatPathBuilder;
@@ -638,7 +638,7 @@ impl<'l, Output: 'l + GeometryBuilder<Vertex>> StrokeBuilder<'l, Output> {
         front_side: Side,
         back_vertex: VertexId,
     ) -> (VertexId, VertexId) {
-        let mut join_angle = prev_tangent.y.atan2(prev_tangent.x) - next_tangent.y.atan2(next_tangent.x);
+        let mut join_angle = fast_atan2(prev_tangent.y, prev_tangent.x) - fast_atan2(next_tangent.y, next_tangent.x);
 
         // Make sure to stay within the [-Pi, Pi] range.
         if join_angle > PI {


### PR DESCRIPTION
Until now there had been no effort into measuring and optimizing the stroke tessellator, so there were some pretty low hanging fruits to pick.

In this PR:

 - a few new simple benchmarks that tessellate the stroke of the rust logo with various join types.
 - a bit of code reorganization to avoid redundant computations
 - the usual trick of avoiding to compute the angle if we only need to know if it is positive (cross product gives this information at a much lower cost)
 - use the `fast_atan2` approximation instead of `atan2`

With this, tessellating a stroke is about 30% faster than before (at least in the case of miter joins).