### PR TITLE
Use flattened_for_each in the fill tessellator.

### DIFF
--- a/bench/svg_bench/src/svg_renderer.rs
+++ b/bench/svg_bench/src/svg_renderer.rs
@@ -271,7 +271,7 @@ fn tessellate_scene(scene: &mut[RenderItem]) {
             let mut buffers: VertexBuffers<Vertex> = VertexBuffers::new();
             if let Some(color) = item.fill {
                 println!(" -- tessellate fill");
-                fill_events.set_path_iter(item.path.path_iter().flattened(0.03));
+                fill_events.set_path(0.03, item.path.path_iter());
                 fill_tessellator.tessellate_events(
                     &fill_events,
                     &FillOptions::default(),


### PR DESCRIPTION
This improves the performance of generating the fill events a bit.
The PR also adds a few flattening benchmark illustrating the difference between the iterator and builder approaches.

Before:

```
test fill_logo_events_and_tess         ... bench:  13,466,828 ns/iter (+/- 1,275,885)
test fill_logo_events_only             ... bench:   5,216,015 ns/iter (+/- 613,182)
```

After:

```
test fill_logo_events_and_tess         ... bench:  12,624,150 ns/iter (+/- 803,110)
test fill_logo_events_only             ... bench:   4,368,951 ns/iter (+/- 1,420,001)
```