### PR TITLE
Rename some of the iterators to satisfy the API guidelines.

### DIFF
--- a/path_iterator/src/lib.rs
+++ b/path_iterator/src/lib.rs
@@ -48,7 +48,7 @@
 //!     let simple_iter = events.iter().cloned();
 //!
 //!     // Make it a SvgIterator (keeps tracks of the path state).
-//!     let svg_path_iter = PathStateSvgIter::new(simple_iter);
+//!     let svg_path_iter = SvgPathIter::new(simple_iter);
 //!
 //!     // Make it a PathIterator (iterates on simpler PathEvents).
 //!     let path_iter = svg_path_iter.path_iter();
@@ -92,7 +92,7 @@
 //!         SvgEvent::Close,
 //!     ];
 //!
-//!     for evt in PathStateSvgIter::new(events.iter().cloned()).flattened(0.01) {
+//!     for evt in SvgPathIter::new(events.iter().cloned()).flattened(0.01) {
 //!         // ...
 //!     }
 //! }

--- a/path_iterator/src/lib.rs
+++ b/path_iterator/src/lib.rs
@@ -18,7 +18,7 @@
 //! All of this extra information is conveniently exposed in the `PathState` struct
 //! that can be accessed by `PathIterator`, `SvgIterator` and `FlattenedIterator`.
 //!
-//! The `PathStateIter<Iter>` adapter automatically implements `PathIterator` for
+//! The `PathIter<Iter>` adapter automatically implements `PathIterator` for
 //! any `Iter` that implements `Iterator<PathEvent>`
 //!
 //! This crate provides adapters between these iterator types. For example iterating

--- a/path_iterator/src/lib.rs
+++ b/path_iterator/src/lib.rs
@@ -51,9 +51,9 @@
 //!     let svg_path_iter = SvgPathIter::new(simple_iter);
 //!
 //!     // Make it a PathIterator (iterates on simpler PathEvents).
-//!     let path_iter = svg_path_iter.path_iter();
+//!     let path_iter = svg_path_iter.path_events();
 //!     // Equivalent to:
-//!     // let path_iter = SvgToPathIter::new(svg_path_iter);
+//!     // let path_iter = PathEvents::new(svg_path_iter);
 //!
 //!     // Make it an iterator over even simpler primitives: FlattenedEvent,
 //!     // which do not contain any curve. To do so we approximate each curve
@@ -64,7 +64,7 @@
 //!     // while iterating with no memory allocation.
 //!     let flattened_iter = path_iter.flattened(0.01);
 //!     // equivalent to:
-//!     // let flattened = FlatteningIter::new(0.01, path_iter);
+//!     // let flattened = Flattened::new(0.01, path_iter);
 //!
 //!     for evt in flattened_iter {
 //!         match evt {

--- a/path_iterator/src/path_iterator.rs
+++ b/path_iterator/src/path_iterator.rs
@@ -7,15 +7,6 @@ use bezier::quadratic_bezier;
 use bezier::CubicBezierSegment;
 use bezier::cubic_bezier;
 
-/// Convenience for algorithms which prefer to iterate over segments directly rather than
-/// path events.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum Segment {
-    Line(Point, Point),
-    QuadraticBezier(Point, Point, Point),
-    CubicBezier(Point, Point, Point, Point),
-}
-
 /// An extension to the common Iterator interface, that adds information which is useful when
 /// chaining path-specific iterators.
 pub trait PathIterator: Iterator<Item = PathEvent> + Sized {

--- a/path_iterator/src/path_iterator.rs
+++ b/path_iterator/src/path_iterator.rs
@@ -176,29 +176,33 @@ where
     }
 }
 
+// TODO: SvgPathIter and PathIter should be merged into a single struct using
+// specialization to implement the Iterator trait depending on the type of
+// event but specialization isn't stable in rust yet.
+
 /// An adapater iterator that implements SvgIterator on top of an Iterator<Item=SvgEvent>.
-pub struct PathStateSvgIter<Iter> {
+pub struct SvgPathIter<Iter> {
     it: Iter,
     state: PathState,
 }
 
-impl<Iter: Iterator<Item = SvgEvent>> PathStateSvgIter<Iter> {
+impl<Iter: Iterator<Item = SvgEvent>> SvgPathIter<Iter> {
     pub fn new(it: Iter) -> Self {
-        PathStateSvgIter {
+        SvgPathIter {
             it: it,
             state: PathState::new(),
         }
     }
 }
 
-impl<Iter> SvgIterator for PathStateSvgIter<Iter>
+impl<Iter> SvgIterator for SvgPathIter<Iter>
 where
     Iter: Iterator<Item = SvgEvent>,
 {
     fn get_state(&self) -> &PathState { &self.state }
 }
 
-impl<Iter: Iterator<Item = SvgEvent>> Iterator for PathStateSvgIter<Iter> {
+impl<Iter: Iterator<Item = SvgEvent>> Iterator for SvgPathIter<Iter> {
     type Item = SvgEvent;
     fn next(&mut self) -> Option<SvgEvent> {
         let next = self.it.next();
@@ -351,51 +355,3 @@ fn test_from_polyline_closed() {
     assert_eq!(evts.next(), Some(FlattenedEvent::LineTo(point(5.0, 2.0))));
     assert_eq!(evts.next(), Some(FlattenedEvent::Close));
 }
-
-/*
-#[test]
-fn test_svg_to_flattened_iter() {
-    let mut it = PathStateSvgIter::new(
-        [
-            SvgEvent::MoveTo(point(1.0, 1.0)),
-            SvgEvent::LineTo(point(2.0, 2.0)),
-            SvgEvent::LineTo(point(3.0, 3.0)),
-            SvgEvent::MoveTo(point(0.0, 0.0)),
-            SvgEvent::QuadraticTo(point(1.0, 0.0), point(1.0, 1.0)),
-            SvgEvent::MoveTo(point(10.0, 10.0)),
-            SvgEvent::CubicTo(point(11.0, 10.0), point(11.0, 11.0), point(11.0, 11.0)),
-        ].iter()
-    ).flattened(0.05);
-
-    assert_eq!(it.next(), FlattenedEvent::MoveTo(point(1.0, 1.0)));
-    assert_eq!(it.next(), FlattenedEvent::LineTo(point(2.0, 2.0)));
-    assert_eq!(it.next(), FlattenedEvent::LineTo(point(3.0, 3.0)));
-    assert_eq!(it.next(), FlattenedEvent::MoveTo(point(0.0, 0.0)));
-
-    // Flattened quadratic curve.
-    loop {
-        let evt = it.next();
-        if evt == Some(FlattenedEvent::MoveTo(point(10.0, 10.0))) {
-            break;
-        }
-        if let Some(FlattenedEvent::MoveTo(to)) = evt {
-            // ok
-        } else {
-            panic!("Expected a MoveTo event, got {:?}", evt);
-        }
-    }
-
-    // Flattened cubic curve.
-    loop {
-        let evt = it.next();
-        if evt.is_none() {
-            break;
-        }
-        if let Some(FlattenedEvent::MoveTo(to)) = evt {
-            // ok
-        } else {
-            panic!("Expected a MoveTo event, got {:?}", evt);
-        }
-    }
-}
-*/


### PR DESCRIPTION
This addresses most of the remaining items in #87.