### PR TITLE
Fix a fill tessellator bug.

### DIFF
--- a/tessellation/src/fuzz_tests.rs
+++ b/tessellation/src/fuzz_tests.rs
@@ -352,8 +352,7 @@ fn fuzzing_test_case_4() {
 }
 
 #[test]
-#[ignore]
-fn fuzzing_failure_5() {
+fn fuzzing_test_case_5() {
     let mut builder = Path::builder();
 
     builder.move_to(point(280.44034, 16.12854));

--- a/tessellation/src/fuzz_tests.rs
+++ b/tessellation/src/fuzz_tests.rs
@@ -434,3 +434,27 @@ fn fuzzing_test_case_7() {
 
     test_path(builder.build().as_slice());
 }
+
+#[test]
+fn fuzzing_test_case_8() {
+    let mut builder = Path::builder();
+    // This test a rather complex shape with plenty of intersections
+    // including three lines intersecting very close to a certain point.
+    // The failure was fixed by increasing the threshold in compare_edge_against_position.
+
+    builder.move_to(point(786.3492, 715.7762));
+    builder.line_to(point(108.706955, 396.7073));
+    builder.line_to(point(744.5795, 645.1025));
+    builder.line_to(point(359.92264, 194.16666));
+    builder.line_to(point(432.9413, 690.4683));
+    builder.line_to(point(592.9548, 277.76956));
+    builder.line_to(point(145.36989, 641.0073));
+    builder.close();
+
+    builder.move_to(point(608.8108, 554.82874));
+    builder.line_to(point(215.48784, 523.1583));
+    builder.line_to(point(821.7586, 872.91003));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+}

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -1213,7 +1213,7 @@ fn compare_edge_against_position(
     let dy: FixedPoint64 = (position.y - edge.upper.y).to_fp64();
     let x = edge.upper.x + dy.mul_div(v.x.to_fp64(), v.y.to_fp64()).to_fp32();
 
-    let threshold = FixedPoint32::epsilon() * 4;
+    let threshold = FixedPoint32::epsilon() * 8;
 
     //println!("dx = {} ({})", x - position.x, (x - position.x).raw());
     *on_edge = (x - position.x).abs() <= threshold;


### PR DESCRIPTION
Another bug found by the fuzzer, fixed by increasing the threshold when determining whether a point is on an edge.