### PR TITLE
Don't inflate fill geometry in the cli renderer.

### DIFF
--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -134,7 +134,7 @@ pub fn show_path(cmd: TessellateCmd) {
                 Primitive {
                     color: [1.0, 1.0, 1.0, 1.0],
                     z_index: 0.1,
-                    width: scene.target_stroke_width,
+                    width: 0.0,
                     padding: [0.0, 0.0],
                 },
                 Primitive {


### PR DESCRIPTION
I temporarily added that to debug the fill normals but didn't intend to merge it.