### PR TITLE
Remove tessellate_flattened_path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The intent is for this library to be useful in projects like [Servo](https://ser
         let mut vertex_builder = simple_builder(&mut geometry_cpu);
 
         // Compute the tessellation.
-        tessellator.tessellate_flattened_path(
+        tessellator.tessellate_path(
             path.path_iter().flattened(0.1),
             &FillOptions::default(),
             &mut vertex_builder

--- a/bench/svg_bench/src/svg_renderer.rs
+++ b/bench/svg_bench/src/svg_renderer.rs
@@ -282,9 +282,9 @@ fn tessellate_scene(scene: &mut[RenderItem]) {
             }
             if let Some(color) = item.stroke {
                 println!(" -- tessellate stroke");
-                stroke_tessellator.tessellate_flattened_path(
-                    item.path.path_iter().flattened(0.03),
-                    &StrokeOptions::default(),
+                stroke_tessellator.tessellate_path(
+                    item.path.path_iter(),
+                    &StrokeOptions::tolerance(0.03),
                     &mut BuffersBuilder::new(&mut buffers, WithColorAndStrokeWidth([
                             color.red as f32 / 255.0,
                             color.green as f32 / 255.0,

--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -65,7 +65,7 @@ fn fill_logo_tess_only(bench: &mut Bencher) {
 
     let mut tess = FillTessellator::new();
     let options = FillOptions::default();
-    let events = FillEvents::from_flattened_path(path.path_iter().flattened(0.05));
+    let events = FillEvents::from_path(0.05, path.path_iter());
 
     bench.iter(|| {
         for _ in 0..N {
@@ -82,7 +82,7 @@ fn fill_logo_tess_no_intersection(bench: &mut Bencher) {
 
     let mut tess = FillTessellator::new();
     let options = FillOptions::default().assume_no_intersections();
-    let events = FillEvents::from_flattened_path(path.path_iter().flattened(0.05));
+    let events = FillEvents::from_path(0.05, path.path_iter());
 
     bench.iter(|| {
         for _ in 0..N {
@@ -99,7 +99,7 @@ fn fill_logo_tess_no_curve(bench: &mut Bencher) {
 
     let mut tess = FillTessellator::new();
     let options = FillOptions::default();
-    let events = FillEvents::from_flattened_path(path.path_iter().flattened(1000000.0));
+    let events = FillEvents::from_path(1000000.0, path.path_iter());
 
     bench.iter(|| {
         for _ in 0..N {
@@ -144,7 +144,7 @@ fn fill_logo_events_only_pre_flattened(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let _events = FillEvents::from_flattened_path(path.path_iter().flattened(0.05));
+            let _events = FillEvents::from_path(0.05, path.path_iter());
         }
     })
 }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -87,3 +87,15 @@ impl FlattenedEvent {
         };
     }
 }
+
+impl Into<PathEvent> for FlattenedEvent {
+    fn into(self) -> PathEvent { self.to_path_event() }
+}
+
+impl Into<SvgEvent> for FlattenedEvent {
+    fn into(self) -> SvgEvent { self.to_svg_event() }
+}
+
+impl Into<SvgEvent> for PathEvent {
+    fn into(self) -> SvgEvent { self.to_svg_event() }
+}

--- a/examples/intersections/src/main.rs
+++ b/examples/intersections/src/main.rs
@@ -13,7 +13,6 @@ use lyon::tessellation::basic_shapes::*;
 use lyon::tessellation::{StrokeTessellator, StrokeOptions};
 use lyon::tessellation;
 use lyon::path::Path;
-use lyon::path_iterator::PathIterator;
 use lyon_renderer::buffer::{Id, BufferStore};
 use lyon_renderer::glsl::*;
 use lyon_renderer::renderer::{
@@ -152,14 +151,15 @@ fn main() {
         )
     );
 
-    StrokeTessellator::new().tessellate_flattened_path(
-        bezier_path.path_iter().flattened(0.01),
-        &StrokeOptions::default().dont_apply_line_width(),
+    let stroke_options = StrokeOptions::tolerance(0.01).dont_apply_line_width();
+    StrokeTessellator::new().tessellate_path(
+        bezier_path.path_iter(),
+        &stroke_options,
         &mut BuffersBuilder::new(&mut cpu.strokes, WithId(bezier_id.element)),
     );
-    StrokeTessellator::new().tessellate_flattened_path(
-        line_path.path_iter().flattened(0.01),
-        &StrokeOptions::default().dont_apply_line_width(),
+    StrokeTessellator::new().tessellate_path(
+        line_path.path_iter(),
+        &stroke_options,
         &mut BuffersBuilder::new(&mut cpu.strokes, WithId(line_id.element)),
     );
 

--- a/renderer/src/batch_builder.rs
+++ b/renderer/src/batch_builder.rs
@@ -247,9 +247,9 @@ impl VertexBuilder<FillPrimitiveId, GpuFillVertex> for FillVertexBuilder {
         let vtx_offset = geom.vertices.len();
         let idx_offset = geom.indices.len();
 
-        let count = self.tessellator.tessellate_flattened_path(
-            path.path_iter().flattened(tolerance),
-            &FillOptions::default(),
+        let count = self.tessellator.tessellate_path(
+            path.path_iter(),
+            &FillOptions::tolerance(tolerance),
             &mut BuffersBuilder::new(geom, WithId(prim_id))
         ).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,8 @@
 //!         let tolerance = 0.1;
 //!
 //!         // Compute the tessellation.
-//!         tessellator.tessellate_flattened_path(
-//!             path.path_iter().flattened(tolerance),
+//!         tessellator.tessellate_path(
+//!             path.path_iter(),
 //!             &FillOptions::default(),
 //!             &mut geom_builder
 //!         ).unwrap();

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -836,7 +836,11 @@ where
 {
     let mut tess = StrokeTessellator::new();
 
-    return tess.tessellate_flattened_path(FromPolyline::new(is_closed, it), options, output);
+    return tess.tessellate_path(
+        FromPolyline::new(is_closed, it).path_iter(),
+        options,
+        output
+    );
 }
 
 /// Tessellate an arbitray shape that is discribed by an iterator of points.
@@ -849,8 +853,8 @@ pub fn fill_polyline<Iter>(
 where
     Iter: Iterator<Item = Point>,
 {
-    tessellator.tessellate_flattened_path(
-        FromPolyline::closed(polyline),
+    tessellator.tessellate_path(
+        FromPolyline::closed(polyline).path_iter(),
         options,
         output
     )

--- a/tessellation/src/earcut_tests.rs
+++ b/tessellation/src/earcut_tests.rs
@@ -22,7 +22,6 @@
 use geometry_builder::{VertexBuffers, simple_builder};
 use path::{Path, PathSlice};
 use path_fill::*;
-use path_iterator::PathIterator;
 use path_builder::FlatPathBuilder;
 use math::*;
 use FillVertex as Vertex;
@@ -1315,7 +1314,11 @@ fn tessellate_path(path: PathSlice, log: bool) -> Result<usize, FillError> {
             tess.enable_logging();
         }
         try!{
-            tess.tessellate_flattened_path(path.path_iter().flattened(0.05), &FillOptions::default(), &mut vertex_builder)
+            tess.tessellate_path(
+                path.path_iter(),
+                &FillOptions::tolerance(0.05),
+                &mut vertex_builder
+            )
         };
     }
     return Ok(buffers.indices.len() / 3);

--- a/tessellation/src/fuzz_tests.rs
+++ b/tessellation/src/fuzz_tests.rs
@@ -1,7 +1,6 @@
 use geometry_builder::{VertexBuffers, simple_builder};
 use path::{Path, PathSlice};
 use path_fill::*;
-use path_iterator::PathIterator;
 use path_builder::FlatPathBuilder;
 use math::*;
 use FillVertex as Vertex;
@@ -16,9 +15,9 @@ fn tessellate_path(path: PathSlice, log: bool) -> Result<usize, FillError> {
             tess.enable_logging();
         }
         try!{
-            tess.tessellate_flattened_path(
-                path.path_iter().flattened(0.05),
-                &FillOptions::default(),
+            tess.tessellate_path(
+                path.path_iter(),
+                &FillOptions::tolerance(0.05),
                 &mut vertex_builder
             )
         };

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -114,29 +114,6 @@ impl StrokeTessellator {
         }
         return builder.end_geometry();
     }
-
-    /// Compute the tessellation from a flattened path iterator.
-    pub fn tessellate_flattened_path<Input>(
-        &mut self,
-        input: Input,
-        options: &StrokeOptions,
-        builder: &mut GeometryBuilder<Vertex>,
-    ) -> Count
-    where
-        Input: Iterator<Item = FlattenedEvent>,
-    {
-        builder.begin_geometry();
-        {
-            let mut stroker = StrokeBuilder::new(options, builder);
-
-            for evt in input {
-                stroker.flat_event(evt);
-            }
-
-            stroker.build();
-        }
-        return builder.end_geometry();
-    }
 }
 
 macro_rules! add_vertex {


### PR DESCRIPTION
Since `tessellate_path` is usually more efficient with curved paths and doesn't have any overhead with already flattened paths.

In the process of doing that a bunch of undefined behavior surfaced in the tests due to large floats being casted to 16.16 fixed points. I have absolutely no idea why this didn't blow up before, but that what's fun with UB.