### PR TITLE
Update the license terms to allow MPL2 in the future.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,12 @@ For escalation or moderation issues, please contact Nical (nical@fastmail.com) i
 
 ## License
 
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
-dual licensed as above, without any additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed dual MIT/Apache 2, or Mozilla Public License 2.0, without any additional terms or conditions.
+
+We reserve the right to publish future versions of this project under the Mozilla Public License 2.0 (MPL2) instead of the three-licenses scheme described above, including all contributions.
+If such a change occurs, it will not affect versions of the project prior to the application of the license change.
+
+### In other words...
+
+At this time we are not entirely certain which of MPL2 or dual MIT/Apache2 is the best licensing scheme for this project. Both approaches are very permissive and we want to keep the door open to changing to MPL2 in the future.
+This project will remain usable under the MIT/Apache2 license for the foreseeable future. However, by contributing to this project you accept that your contributions may be re-licensed under the Mozilla Public License 2.0 without the MIT and Apache2 options.

--- a/README.md
+++ b/README.md
@@ -131,11 +131,12 @@ Licensed under either of
 
  * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+ * [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/)
 
 at your option.
+
+Dual MIT/Apache2 is strictly more permissive
 
 ### Contribution
 
 There is useful information for contributors in the [contribution guidelines](https://github.com/nical/lyon/blob/master/CONTRIBUTING.md).
-
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
As discussed in #244, I would like to keep the door open to re-licensing lyon under MPLv2. It may never happen, but with the approval of all current contributors I updated the license terms to make such a change possible in the future.

Lyon will remain usable under MIT or Apache 2 in the foreseeable future.