### PR TITLE
Return t instead of the point in intersection functions.

### DIFF
--- a/examples/intersections/src/main.rs
+++ b/examples/intersections/src/main.rs
@@ -152,8 +152,8 @@ fn main() {
 
     // Intance primitives
     println!(" -- intersections {:?}", intersections);
-    for (i, p) in intersections.iter().enumerate() {
-        let pos = p.to_array();
+    for (i, t) in intersections.iter().enumerate() {
+        let pos = bezier.sample(*t).to_array();
         cpu_primitives[point_ids_1 as usize + i] = Primitive {
             color: [0.0, 0.2, 0.0, 1.0],
             z_index: 3,

--- a/geom/src/flatten_cubic.rs
+++ b/geom/src/flatten_cubic.rs
@@ -8,8 +8,7 @@
 
 use CubicBezierSegment;
 use math::Point;
-use up_to_two::UpToTwo;
-
+use arrayvec::ArrayVec;
 use std::f32;
 use std::mem::swap;
 
@@ -208,7 +207,7 @@ fn no_inflection_flattening_step(bezier: &CubicBezierSegment, tolerance: f32) ->
 }
 
 // Find the inflection points of a cubic bezier curve.
-pub fn find_cubic_bezier_inflection_points(bezier: &CubicBezierSegment) -> UpToTwo<f32> {
+pub fn find_cubic_bezier_inflection_points(bezier: &CubicBezierSegment) -> ArrayVec<[f32; 2]> {
     // Find inflection points.
     // See www.faculty.idc.ac.il/arik/quality/appendixa.html for an explanation
     // of this approach.
@@ -220,7 +219,7 @@ pub fn find_cubic_bezier_inflection_points(bezier: &CubicBezierSegment) -> UpToT
     let b = pa.cross(pc);
     let c = pa.cross(pb);
 
-    let mut ret = UpToTwo::new();
+    let mut ret = ArrayVec::new();
 
     if a.abs() < 1e-5 {
         // Not a quadratic equation.

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -65,7 +65,7 @@
 
 //#![allow(needless_return)] // clippy
 
-extern crate arrayvec;
+pub extern crate arrayvec;
 pub extern crate euclid;
 
 #[macro_use] mod segment;
@@ -75,13 +75,11 @@ pub mod arc;
 pub mod utils;
 mod flatten_cubic;
 mod cubic_to_quadratic;
-mod up_to_two;
 mod triangle;
 mod line;
 mod monotone;
 
 pub use cubic_to_quadratic::cubic_to_quadratic;
-pub use up_to_two::UpToTwo;
 
 pub use quadratic_bezier::QuadraticBezierSegment;
 pub use cubic_bezier::CubicBezierSegment;

--- a/geom/src/quadratic_bezier.rs
+++ b/geom/src/quadratic_bezier.rs
@@ -309,34 +309,38 @@ impl QuadraticBezierSegment {
         YMonotoneQuadraticBezierSegment { segment: *self }
     }
 
-    pub fn line_intersections(&self, line: &Line) -> ArrayVec<[Point; 2]> {
+    /// Computes the intersections (if any) between this segment a line.
+    ///
+    /// The result is provided in the form of the `t` parameters of each
+    /// point along curve. To get the intersection points, sample the curve
+    /// at the corresponding values.
+    pub fn line_intersections(&self, line: &Line) -> ArrayVec<[f32; 2]> {
         // TODO: a specific quadratic bézier vs line intersection function
         // would allow for better performance.
         let intersections = self.to_cubic().line_intersections(line);
 
         let mut result = ArrayVec::new();
-        if intersections.len() > 0 {
-            result.push(intersections[0]);
-        }
-        if intersections.len() > 1 {
-            result.push(intersections[1]);
+        for t in intersections {
+            result.push(t);
         }
 
         return result;
     }
 
-    pub fn line_segment_intersections(&self, segment: &LineSegment) -> ArrayVec<[Point; 2]> {
+    /// Computes the intersections (if any) between this segment a line segment.
+    ///
+    /// The result is provided in the form of the `t` parameters of each
+    /// point along curve and segment. To get the intersection points, sample
+    /// the segments at the corresponding values.
+    pub fn line_segment_intersections(&self, segment: &LineSegment) -> ArrayVec<[(f32, f32); 2]> {
         // TODO: a specific quadratic bézier vs line intersection function
         // would allow for better performance.
-        let intersections = self.to_cubic().line_intersections(&segment.to_line());
-        let aabb = segment.fast_bounding_rect();
+        let intersections = self.to_cubic().line_segment_intersections(&segment);
+        assert!(intersections.len() <= 2);
 
         let mut result = ArrayVec::new();
-        if intersections.len() > 0 && aabb.contains(&intersections[0]) {
-            result.push(intersections[0]);
-        }
-        if intersections.len() > 1 && aabb.contains(&intersections[1]) {
-            result.push(intersections[1]);
+        for t in intersections {
+            result.push(t);
         }
 
         return result;

--- a/geom/src/up_to_two.rs
+++ b/geom/src/up_to_two.rs
@@ -1,3 +1,0 @@
-use arrayvec::ArrayVec;
-
-pub type UpToTwo<T> = ArrayVec<[T; 2]>;

--- a/tessellation/src/math_utils.rs
+++ b/tessellation/src/math_utils.rs
@@ -4,6 +4,7 @@ use fixed;
 use geom::math::*;
 use path_fill::Edge;
 use geom::euclid;
+use std::f64;
 
 pub type FixedPoint32 = fixed::Fp32<fixed::_16>;
 pub type FixedPoint64 = fixed::Fp64<fixed::_16>;
@@ -56,8 +57,8 @@ pub fn segment_intersection(
         return None;
     }
 
-    let sign_v1_cross_v2 = if v1_cross_v2 > 0.0 { 1.0 } else { -1.0 };
-    let abs_v1_cross_v2 = v1_cross_v2 * sign_v1_cross_v2;
+    let sign_v1_cross_v2 = v1_cross_v2.signum();
+    let abs_v1_cross_v2 = f64::abs(v1_cross_v2);
 
     // t and u should be divided by v1_cross_v2, but we postpone that to not lose precision.
     // We have to respect the sign of v1_cross_v2 (and therefore t and u) so we apply it now and

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -846,8 +846,8 @@ impl<'l> StrokeBuilder<'l> {
             to: point(normal.x, normal.y)
         };
 
-        let i1 = l1.intersection(&normal_limit_perp).unwrap();
-        let i2 = l2.intersection(&normal_limit_perp).unwrap();
+        let i1 = l1.sample(l1.intersection(&normal_limit_perp).unwrap().0);
+        let i2 = l1.sample(l2.intersection(&normal_limit_perp).unwrap().0);
 
         (vector(i1.x, i1.y), vector(i2.x, i2.y))
     }


### PR DESCRIPTION
This is sort of a prerequisite for #243 and anther breaking change, so might as well put it in the 0.9 train.