### PR TITLE
Implement a monotonic curve intersection algorithm.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "geom_bench"
+version = "0.0.1"
+dependencies = [
+ "bencher 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon 0.8.6",
+]
+
+[[package]]
 name = "gfx"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,6 @@ members = [
     "examples/walk_path",
     "examples/glium_basic",
     "bench/svg_bench",
-    "bench/tess"
+    "bench/tess",
+    "bench/geom"
 ]

--- a/bench/geom/Cargo.toml
+++ b/bench/geom/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "geom_bench"
+version = "0.0.1"
+authors = ["Nicolas Silva <nical@fastmail.com>"]
+workspace = "../.."
+
+[[bin]]
+name = "geom_bench"
+
+[dependencies]
+lyon = { path = "../../" }
+bencher = "0.1.1"

--- a/bench/geom/src/main.rs
+++ b/bench/geom/src/main.rs
@@ -1,0 +1,57 @@
+extern crate lyon;
+#[macro_use]
+extern crate bencher;
+
+use bencher::Bencher;
+
+use lyon::math::*;
+use lyon::geom::{QuadraticBezierSegment, monotonic_segment_intersecion};
+
+const N: usize = 10;
+
+fn monotonic_intersection(bench: &mut Bencher) {
+    // TODO: bench a variety of curves
+    let c1 = QuadraticBezierSegment {
+        from: point(10.0, 0.0),
+        ctrl: point(10.0, 90.0),
+        to: point(100.0, 90.0),
+    }.assume_monotonic();
+    let c2 = QuadraticBezierSegment {
+        from: point(0.0, 10.0),
+        ctrl: point(90.0, 10.0),
+        to: point(90.0, 100.0),
+    }.assume_monotonic();
+
+    bench.iter(|| {
+        for _ in 0..N {
+            monotonic_segment_intersecion(
+                &c1, 0.0..1.0,
+                &c2, 0.0..1.0,
+                0.001,
+            );
+            monotonic_segment_intersecion(
+                &c1, 0.0..0.5,
+                &c2, 0.0..0.5,
+                0.001,
+            );
+            monotonic_segment_intersecion(
+                &c1, 0.5..1.0,
+                &c2, 0.5..1.0,
+                0.001,
+            );
+            monotonic_segment_intersecion(
+                &c1, 0.3..0.7,
+                &c2, 0.3..0.7,
+                0.001,
+            );
+        }
+    });
+}
+
+benchmark_group!(intersections,
+  monotonic_intersection
+);
+
+benchmark_main!(
+    intersections
+);

--- a/geom/src/arc.rs
+++ b/geom/src/arc.rs
@@ -2,6 +2,7 @@
 
 use std::f32::*;
 use std::f32;
+use std::ops::Range;
 
 use Line;
 use math::{Point, point, Vector, vector, Rotation2D, Transform2D, Radians, Rect};
@@ -164,6 +165,22 @@ impl Arc {
     #[inline]
     pub fn to(&self) -> Point {
         self.sample(1.0)
+    }
+
+    /// Return the sub-curve inside a given range of t.
+    ///
+    /// This is equivalent splitting at the range's end points.
+    pub fn split_range(&self, t_range: Range<f32>) -> Self {
+        let angle_1 = Radians::new(self.sweep_angle.get() * t_range.start);
+        let angle_2 = Radians::new(self.sweep_angle.get() * t_range.end);
+
+        Arc {
+            center: self.center,
+            radii: self.radii,
+            start_angle: self.start_angle + angle_1,
+            sweep_angle: angle_2 - angle_1,
+            x_rotation: self.x_rotation,
+        }
     }
 
     /// Split this curve into two sub-curves.
@@ -339,6 +356,7 @@ impl Segment for Arc {
     fn x(&self, t: f32) -> f32 { self.x(t) }
     fn y(&self, t: f32) -> f32 { self.y(t) }
     fn derivative(&self, t: f32) -> Vector { self.sample_tangent(t) }
+    fn split_range(&self, t_range: Range<f32>) -> Self { self.split_range(t_range) }
     fn split(&self, t: f32) -> (Self, Self) { self.split(t) }
     fn before_split(&self, t: f32) -> Self { self.before_split(t) }
     fn after_split(&self, t: f32) -> Self { self.after_split(t) }

--- a/geom/src/cubic_bezier.rs
+++ b/geom/src/cubic_bezier.rs
@@ -8,6 +8,8 @@ use monotonic::Monotonic;
 use utils::cubic_polynomial_roots;
 use segment::{Segment, FlattenedForEach, approximate_length_from_flattening, BoundingRect};
 
+use std::ops::Range;
+
 /// A 2d curve segment defined by four points: the beginning of the segment, two control
 /// points and the end of the segment.
 ///
@@ -91,6 +93,16 @@ impl CubicBezierSegment {
     pub fn dy(&self, t: f32) -> f32 {
         let (c0, c1, c2, c3) = self.derivative_coefficients(t);
         self.from.y * c0 + self.ctrl1.y * c1 + self.ctrl2.y * c2 + self.to.y * c3
+    }
+
+    /// Return the sub-curve inside a given range of t.
+    ///
+    /// This is equivalent splitting at the range's end points.
+    pub fn split_range(&self, t_range: Range<f32>) -> Self {
+        let t1 = t_range.start;
+        let t2 = (t_range.end - t_range.start) / (1.0 - t_range.start);
+
+        self.after_split(t1).before_split(t2)
     }
 
     /// Split this curve into two sub-curves.

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -87,7 +87,10 @@ pub use triangle::{Triangle};
 pub use line::{LineSegment, Line};
 pub use arc::{Arc, SvgArc, ArcFlags};
 pub use segment::Segment;
-pub use monotone::{XMonotone, YMonotone, XMonotoneSegment, YMonotoneSegment};
+pub use monotone::{
+    XMonotone, YMonotone, XMonotoneSegment, YMonotoneSegment,
+    monotone_segment_intersecion
+};
 
 pub mod math {
     //! ## Core geometry types

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -77,7 +77,7 @@ mod flatten_cubic;
 mod cubic_to_quadratic;
 mod triangle;
 mod line;
-mod monotone;
+mod monotonic;
 
 pub use cubic_to_quadratic::cubic_to_quadratic;
 
@@ -87,9 +87,9 @@ pub use triangle::{Triangle};
 pub use line::{LineSegment, Line};
 pub use arc::{Arc, SvgArc, ArcFlags};
 pub use segment::Segment;
-pub use monotone::{
-    XMonotone, YMonotone, XMonotoneSegment, YMonotoneSegment,
-    monotone_segment_intersecion
+pub use monotonic::{
+    Monotonic, MonotonicSegment,
+    monotonic_segment_intersecion
 };
 
 pub mod math {
@@ -140,5 +140,5 @@ pub mod math {
 
 pub mod traits {
     pub use segment::{Segment, FlattenedForEach, FlatteningStep};
-    pub use monotone::{XMonotoneSegment, YMonotoneSegment};
+    pub use monotonic::MonotonicSegment;
 }

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -89,7 +89,8 @@ pub use arc::{Arc, SvgArc, ArcFlags};
 pub use segment::Segment;
 pub use monotonic::{
     Monotonic, MonotonicSegment,
-    monotonic_segment_intersecion
+    monotonic_segment_intersecion,
+    monotonic_segment_intersecions,
 };
 
 pub mod math {

--- a/geom/src/line.rs
+++ b/geom/src/line.rs
@@ -2,6 +2,8 @@ use math::{Point, point, Vector, Rect, Size, Transform2D};
 use segment::{Segment, FlatteningStep, BoundingRect};
 use utils::min_max;
 
+use std::ops::Range;
+
 // TODO: Perhaps it would be better to have LineSegment<T> where T can be f32, f64
 // or some fixed precision number (See comment in the intersection function).
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -29,11 +31,27 @@ impl LineSegment {
         self.from.y * (1.0 - t) + self.to.y * t
     }
 
+    #[inline]
+    pub fn from(&self) -> Point { self.from }
+
+    #[inline]
+    pub fn to(&self) -> Point { self.to }
+
     /// Returns an inverted version of this segment where the beginning and the end
     /// points are swapped.
     #[inline]
     pub fn flip(&self) -> Self {
         LineSegment { from: self.to, to: self.from }
+    }
+
+    /// Return the sub-segment inside a given range of t.
+    ///
+    /// This is equivalent splitting at the range's end points.
+    pub fn split_range(&self, t_range: Range<f32>) -> Self {
+        LineSegment {
+            from: self.from.lerp(self.to, t_range.start),
+            to: self.from.lerp(self.to, t_range.end),
+        }
     }
 
     /// Split this curve into two sub-segments.
@@ -174,6 +192,7 @@ impl Segment for LineSegment {
     fn derivative(&self, _t: f32) -> Vector { self.to_vector() }
     fn dx(&self, _t: f32) -> f32 { self.to.x - self.from.x }
     fn dy(&self, _t: f32) -> f32 { self.to.y - self.from.y }
+    fn split_range(&self, t_range: Range<f32>) -> Self { self.split_range(t_range) }
     fn split(&self, t: f32) -> (Self, Self) { self.split(t) }
     fn before_split(&self, t: f32) -> Self { self.before_split(t) }
     fn after_split(&self, t: f32) -> Self { self.after_split(t) }

--- a/geom/src/monotone.rs
+++ b/geom/src/monotone.rs
@@ -1,20 +1,13 @@
-use segment::Segment;
-use math::{Point, Vector};
+use segment::{Segment, BoundingRect};
+use math::{Point, Vector, Rect};
+use std::ops::Range;
 
-pub trait XMonotoneSegment : Segment + Sized {
-    fn solve_t_for_x(&self, x: f32, tolerance: f32) -> f32;
-
-    fn solve_y_for_x(&self, x: f32, tolerance: f32) -> f32 {
-        self.y(self.solve_t_for_x(x, tolerance))
-    }
+pub trait XMonotoneSegment {
+    fn solve_t_for_x(&self, x: f32, t_range: Range<f32>, tolerance: f32) -> f32;
 }
 
-pub trait YMonotoneSegment : Segment + Sized {
-    fn solve_t_for_y(&self, y: f32, tolerance: f32) -> f32;
-
-    fn solve_x_for_y(&self, y: f32, tolerance: f32) -> f32 {
-        self.x(self.solve_t_for_y(y, tolerance))
-    }
+pub trait YMonotoneSegment {
+    fn solve_t_for_y(&self, y: f32, t_range: Range<f32>, tolerance: f32) -> f32;
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -63,22 +56,43 @@ impl<S: Segment> XMonotone<S> {
         self.segment.approximate_length(tolerance)
     }
 
-    pub fn solve_t_for_x(&self, x: f32, tolerance: f32) -> f32 {
-        self.solve_t(x, tolerance)
+    pub fn solve_t_for_x(&self, x: f32, t_range: Range<f32>, tolerance: f32) -> f32 {
+        self.solve_t(x, t_range, tolerance)
     }
 
-    pub fn solve_y_for_x(&self, x: f32, tolerance: f32) -> f32 {
-        self.y(self.solve_t(x, tolerance))
+    pub fn solve_y_for_x(&self, x: f32, t_range: Range<f32>, tolerance: f32) -> f32 {
+        self.y(self.solve_t(x, t_range, tolerance))
     }
 }
 
 impl<S: Segment> XMonotoneSegment for XMonotone<S> {
-    fn solve_t_for_x(&self, x: f32, tolerance: f32) -> f32 {
-        self.solve_t(x, tolerance)
+    fn solve_t_for_x(&self, x: f32, t_range: Range<f32>, tolerance: f32) -> f32 {
+        self.solve_t(x, t_range, tolerance)
     }
 }
 
 impl<S: Segment> Segment for XMonotone<S> { impl_segment!(); }
+
+impl<S: BoundingRect> BoundingRect for XMonotone<S> {
+    fn bounding_rect(&self) -> Rect {
+        self.segment.bounding_rect()
+    }
+    fn fast_bounding_rect(&self) -> Rect {
+        self.segment.fast_bounding_rect()
+    }
+    fn bounding_range_x(&self) -> (f32, f32) {
+        self.segment.bounding_range_x()
+    }
+    fn bounding_range_y(&self) -> (f32, f32) {
+        self.segment.bounding_range_y()
+    }
+    fn fast_bounding_range_x(&self) -> (f32, f32) {
+        self.segment.fast_bounding_range_x()
+    }
+    fn fast_bounding_range_y(&self) -> (f32, f32) {
+        self.segment.fast_bounding_range_y()
+    }
+}
 
 #[derive(Copy, Clone, Debug)]
 pub struct YMonotone<S> {
@@ -126,20 +140,18 @@ impl<S: Segment> YMonotone<S> {
         self.segment.approximate_length(tolerance)
     }
 
-    pub fn solve_t_for_y(&self, y: f32, tolerance: f32) -> f32 {
-        self.solve_t(y, tolerance)
+    pub fn solve_t_for_y(&self, y: f32, t_range: Range<f32>, tolerance: f32) -> f32 {
+        self.solve_t(y, t_range, tolerance)
     }
 
-    pub fn solve_x_for_y(&self, y: f32, tolerance: f32) -> f32 {
-        self.y(self.solve_t(y, tolerance))
+    pub fn solve_x_for_y(&self, y: f32, t_range: Range<f32>, tolerance: f32) -> f32 {
+        self.y(self.solve_t(y, t_range, tolerance))
     }
 }
 
-
-
 impl<S: Segment> YMonotoneSegment for YMonotone<S> {
-    fn solve_t_for_y(&self, y: f32, tolerance: f32) -> f32 {
-        self.solve_t(y, tolerance)
+    fn solve_t_for_y(&self, y: f32, t_range: Range<f32>, tolerance: f32) -> f32 {
+        self.solve_t(y, t_range, tolerance)
     }
 }
 
@@ -149,9 +161,10 @@ trait MonotoneFunction {
     fn f(&self, t: f32) -> f32;
     fn df(&self, t: f32) -> f32;
 
-    fn solve_t(&self, x: f32, tolerance: f32) -> f32 {
-        let from = self.f(0.0);
-        let to = self.f(1.0);
+    fn solve_t(&self, x: f32, t_range: Range<f32>, tolerance: f32) -> f32 {
+        debug_assert!(t_range.start <= t_range.end);
+        let from = self.f(t_range.start);
+        let to = self.f(t_range.end);
         if x <= from {
             return 0.0;
         }
@@ -178,8 +191,8 @@ trait MonotoneFunction {
         }
 
         // Fall back to binary search.
-        let mut min = 0.0;
-        let mut max = 1.0;
+        let mut min = t_range.start;
+        let mut max = t_range.end;
         let mut t = 0.5;
 
         while min < max {
@@ -210,4 +223,70 @@ impl<S: Segment> MonotoneFunction for XMonotone<S> {
 impl<S: Segment> MonotoneFunction for YMonotone<S> {
     fn f(&self, t: f32) -> f32 { self.y(t) }
     fn df(&self, t: f32) -> f32 { self.dy(t) }
+}
+
+// TODO: This returns at most one intersection but there could be two.
+pub fn monotone_segment_intersecion<A, B>(
+    a: &A,
+    b: &B,
+    tolerance: f32,
+) -> Option<(f32, f32)>
+where
+    A: Segment + XMonotoneSegment + BoundingRect,
+    B: Segment + XMonotoneSegment + BoundingRect,
+{
+    let (a_min, a_max) = a.fast_bounding_range_x();
+    let (b_min, b_max) = b.fast_bounding_range_x();
+
+    if a_min > b_max || a_max < b_min {
+        return None;
+    }
+
+    let mut min_x = f32::max(a_min, b_min);
+    let mut max_x = f32::min(a_max, b_max);
+
+    let mut t_min_a = a.solve_t_for_x(min_x, 0.0..1.0, tolerance);
+    let mut t_max_a = a.solve_t_for_x(max_x, t_min_a..1.0, tolerance);
+    let mut t_min_b = b.solve_t_for_x(min_x, 0.0..1.0, tolerance);
+    let mut t_max_b = b.solve_t_for_x(max_x, t_min_b..1.0, tolerance);
+
+    const MAX_ITERATIONS: u32 = 32;
+    for _ in 0..MAX_ITERATIONS {
+        let mid_x = (min_x + max_x) * 0.5;
+        let t_mid_a = a.solve_t_for_x(mid_x, t_min_a..t_max_a, tolerance);
+        let t_mid_b = b.solve_t_for_x(mid_x, t_min_b..t_max_b, tolerance);
+        let y_mid_a = a.y(t_mid_a);
+        let y_mid_b = b.y(t_mid_b);
+
+        if f32::abs(y_mid_a - y_mid_b) < tolerance * 0.5 {
+            return Some((t_mid_a, t_mid_b));
+        }
+
+        let y_min_a = a.y(t_mid_a);
+        let y_max_a = a.y(t_max_a);
+        let y_min_b = b.y(t_min_b);
+        let y_max_b = b.y(t_max_b);
+
+        let min_sign = f32::signum(y_min_a - y_min_b);
+        let mid_sign = f32::signum(y_mid_a - y_mid_b);
+        let max_sign = f32::signum(y_max_a - y_max_b);
+
+        if min_sign != mid_sign {
+            max_x = mid_x;
+            t_max_a = t_mid_a;
+            t_max_b = t_mid_b;
+        } else if max_sign != mid_sign {
+            min_x = mid_x;
+            t_min_a = t_mid_a;
+            t_min_b = t_mid_b;
+        } else {
+            // TODO: This is not always correct: if the min, max and mid
+            // points are all on the same side, we consider that there is
+            // no intersection, but there could be a pair of intersections
+            // between the min/max and the mid point.
+            break;
+        }
+    }
+
+    None
 }

--- a/geom/src/quadratic_bezier.rs
+++ b/geom/src/quadratic_bezier.rs
@@ -299,13 +299,13 @@ impl QuadraticBezierSegment {
 
     /// Cast this curve into a x-montone curve without checking that the monotonicity
     /// assumption is correct.
-    pub fn assume_x_montone(&self) -> XMonotoneQuadraticBezierSegment {
+    pub fn assume_x_monotone(&self) -> XMonotoneQuadraticBezierSegment {
         XMonotoneQuadraticBezierSegment { segment: *self }
     }
 
     /// Cast this curve into a y-montone curve without checking that the monotonicity
     /// assumption is correct.
-    pub fn assume_y_montone(&self) -> YMonotoneQuadraticBezierSegment {
+    pub fn assume_y_monotone(&self) -> YMonotoneQuadraticBezierSegment {
         YMonotoneQuadraticBezierSegment { segment: *self }
     }
 

--- a/geom/src/segment.rs
+++ b/geom/src/segment.rs
@@ -1,5 +1,7 @@
 use math::{Point, Vector, Rect};
 
+use std::ops::Range;
+
 /// Common APIs to segment types.
 pub trait Segment: Copy + Sized {
     /// Start of the curve.
@@ -34,6 +36,11 @@ pub trait Segment: Copy + Sized {
 
     /// Return the curve after the split point.
     fn after_split(&self, t: f32) -> Self;
+
+    /// Return the curve inside a given range of t.
+    ///
+    /// This is equivalent splitting at the range's end points.
+    fn split_range(&self, t_range: Range<f32>) -> Self;
 
     /// Swap the direction of the segment.
     fn flip(&self) -> Self;
@@ -162,6 +169,7 @@ macro_rules! impl_segment {
         fn split(&self, t: f32) -> (Self, Self) { self.split(t) }
         fn before_split(&self, t: f32) -> Self { self.before_split(t) }
         fn after_split(&self, t: f32) -> Self { self.after_split(t) }
+        fn split_range(&self, t_range: Range<f32>) -> Self { self.split_range(t_range) }
         fn flip(&self) -> Self { self.flip() }
         fn approximate_length(&self, tolerance: f32) -> f32 {
             self.approximate_length(tolerance)


### PR DESCRIPTION
The algorithm is adapted from pathfinder's binary search approach with a few enhancements:
 - solve_t_for_x takes a range of t to search into which makes it converge to the solution faster,
 - the main intersection loop only computes the mid point and reuse the result in future iterations (where the original algorithm re-computes the min and max points each time).

Unfortunately this algorithm makes the assumption that there can be at most one intersection between two monotonic segments (in fact there can be up to two) and may miss intersections when that's not the case. That said, this bug only seem to be possible when the curves cross twice in a way that should not mess up with the sweep line's invariant (it will just produce a few unexpectedly overlapping triangles in rare cases).

I think that the binary search can be made to converge faster by biasing the mid point towards the min or max depending on which has the smallest difference in y.