### PR TITLE
Add FillOptions parameter to basic_shapes tessellators.

### DIFF
--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -1,7 +1,7 @@
 use lyon::math::*;
 use lyon::tessellation::geometry_builder::{VertexConstructor, VertexBuffers, BuffersBuilder};
 use lyon::tessellation::basic_shapes::*;
-use lyon::tessellation::{FillTessellator, StrokeTessellator};
+use lyon::tessellation::{FillTessellator, StrokeTessellator, FillOptions};
 use lyon::tessellation;
 use commands::{TessellateCmd, AntiAliasing, RenderCmd};
 
@@ -44,6 +44,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
     let mut bg_geometry: VertexBuffers<BgVertex> = VertexBuffers::new();
     fill_rectangle(
         &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
+        &FillOptions::default(),
         &mut BuffersBuilder::new(&mut bg_geometry, BgVertexCtor),
     );
 

--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -90,6 +90,7 @@ fn main() {
     let mut bg_geometry: VertexBuffers<BgVertex> = VertexBuffers::new();
     fill_rectangle(
         &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
+        &FillOptions::default(),
         &mut BuffersBuilder::new(&mut bg_geometry, BgVertexCtor),
     );
 

--- a/examples/glium_basic_shapes/src/main.rs
+++ b/examples/glium_basic_shapes/src/main.rs
@@ -6,7 +6,7 @@ use glium::Surface;
 
 use lyon::math::*;
 use lyon::tessellation::geometry_builder::{VertexConstructor, VertexBuffers, BuffersBuilder};
-use lyon::tessellation::StrokeOptions;
+use lyon::tessellation::{StrokeOptions, FillOptions};
 use lyon::tessellation::basic_shapes::*;
 use lyon::tessellation;
 
@@ -36,15 +36,19 @@ fn main() {
 
     let mut mesh = VertexBuffers::new();
 
+    let fill_options = FillOptions::tolerance(0.01);
+
     fill_triangle(
         point(3.0, 1.0),
         point(1.0, 4.0),
         point(5.0, 4.0),
+        &fill_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
     fill_rectangle(
         &rect(6.0, 1.0, 4.0, 3.0),
+        &fill_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
@@ -53,6 +57,7 @@ fn main() {
         point(13.0, 2.0),
         point(14.0, 5.0),
         point(12.0, 4.0),
+        &fill_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
@@ -64,14 +69,14 @@ fn main() {
             bottom_right: 1.0,
             bottom_left: 1.5,
         },
-        0.01,
+        &fill_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
     fill_circle(
         point(22.0, 3.0),
         2.0,
-        0.01,
+        &fill_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
@@ -79,25 +84,25 @@ fn main() {
         point(27.0, 3.0),
         vector(2.2, 1.5),
         Angle::radians(0.6),
-        0.01,
+        &fill_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
 
-    let options = StrokeOptions::tolerance(0.01)
+    let stroke_options = StrokeOptions::tolerance(0.01)
         .with_line_width(0.2);
 
     stroke_triangle(
         point(3.0, 6.0),
         point(1.0, 9.0),
         point(5.0, 9.0),
-        &options,
+        &stroke_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
     stroke_rectangle(
         &rect(6.0, 6.0, 4.0, 3.0),
-        &options,
+        &stroke_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
@@ -106,7 +111,7 @@ fn main() {
         point(13.0, 7.0),
         point(14.0, 10.0),
         point(12.0, 9.0),
-        &options,
+        &stroke_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
@@ -118,14 +123,14 @@ fn main() {
             bottom_right: 1.0,
             bottom_left: 1.5,
         },
-        &options,
+        &stroke_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
     stroke_circle(
         point(22.0, 8.0),
         2.0,
-        &options,
+        &stroke_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 
@@ -133,7 +138,7 @@ fn main() {
         point(27.0, 8.0),
         vector(2.2, 1.5),
         Angle::radians(0.6),
-        &options,
+        &stroke_options,
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     );
 

--- a/examples/intersections/src/main.rs
+++ b/examples/intersections/src/main.rs
@@ -10,7 +10,7 @@ use lyon::geom::{Line, CubicBezierSegment};
 use lyon::math::*;
 use lyon::tessellation::geometry_builder::{VertexConstructor, VertexBuffers, BuffersBuilder};
 use lyon::tessellation::basic_shapes::*;
-use lyon::tessellation::{StrokeTessellator, StrokeOptions};
+use lyon::tessellation::{StrokeTessellator, StrokeOptions, FillOptions};
 use lyon::tessellation;
 use lyon::path::default::Path;
 
@@ -111,7 +111,7 @@ fn main() {
     fill_circle(
         point(0.0, 0.0),
         1.0,
-        0.01,
+        &FillOptions::tolerance(0.01),
         &mut BuffersBuilder::new(
             &mut geometry,
             WithId(point_ids_1)
@@ -121,6 +121,7 @@ fn main() {
     let mut bg_geometry: VertexBuffers<BgVertex> = VertexBuffers::new();
     fill_rectangle(
         &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
+        &FillOptions::default(),
         &mut BuffersBuilder::new(&mut bg_geometry, BgVertexCtor),
     );
 

--- a/examples/walk_path/src/main.rs
+++ b/examples/walk_path/src/main.rs
@@ -66,6 +66,7 @@ fn main() {
     let mut bg_geometry: VertexBuffers<BgVertex> = VertexBuffers::new();
     fill_rectangle(
         &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
+        &FillOptions::default(),
         &mut BuffersBuilder::new(&mut bg_geometry, BgVertexCtor),
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,14 +62,14 @@
 //! ```
 //! extern crate lyon;
 //! use lyon::math::rect;
-//! use lyon::tessellation::VertexBuffers;
+//! use lyon::tessellation::{VertexBuffers, FillOptions};
 //! use lyon::tessellation::basic_shapes::*;
 //! use lyon::tessellation::geometry_builder::simple_builder;
 //!
 //! fn main() {
 //!     let mut geometry = VertexBuffers::new();
 //!
-//!     let tolerance = 0.1;
+//!     let options = FillOptions::tolerance(0.1);
 //!
 //!     fill_rounded_rectangle(
 //!         &rect(0.0, 0.0, 100.0, 50.0),
@@ -79,7 +79,7 @@
 //!             bottom_left: 20.0,
 //!             bottom_right: 25.0,
 //!         },
-//!         tolerance,
+//!         &options,
 //!         &mut simple_builder(&mut geometry),
 //!     );
 //!

--- a/tessellation/src/geometry_builder.rs
+++ b/tessellation/src/geometry_builder.rs
@@ -55,7 +55,7 @@
 //!
 //! ```
 //! extern crate lyon_tessellation as tess;
-//! use tess::{VertexConstructor, VertexBuffers, BuffersBuilder, FillVertex};
+//! use tess::{VertexConstructor, VertexBuffers, BuffersBuilder, FillVertex, FillOptions};
 //! use tess::basic_shapes::fill_circle;
 //! use tess::math::point;
 //!
@@ -89,7 +89,7 @@
 //!     fill_circle(
 //!         point(0.0, 0.0),
 //!         10.0,
-//!         0.05,
+//!         &FillOptions::tolerance(0.05),
 //!         &mut BuffersBuilder::new(
 //!             &mut output,
 //!             WithColor([1.0, 0.0, 0.0, 1.0])
@@ -98,7 +98,7 @@
 //!     fill_circle(
 //!         point(10.0, 0.0),
 //!         5.0,
-//!         0.05,
+//!         &FillOptions::tolerance(0.05),
 //!         &mut BuffersBuilder::new(
 //!             &mut output,
 //!             WithColor([0.0, 1.0, 0.0, 1.0])

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -164,7 +164,7 @@
 //! approximated with sequences of line segments. This approximation depends on a `tolerance` parameter
 //! which represents the maximum distance between a curve and its flattened approximation.
 //!
-//! More explanaion about flattening and tolerance in the [lyon_geom crate](https://docs.rs/lyon_geom/0.7.0/lyon_geom/#flattening).
+//! More explanaion about flattening and tolerance in the [lyon_geom crate](https://docs.rs/lyon_geom/#flattening).
 //!
 //! ## Examples
 //!


### PR DESCRIPTION
Some of them don't use this parameter but it makes the API more consistent and future-proof.