### PR TITLE
Make geom generic over Float

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ version = "0.8.5"
 dependencies = [
  "arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/geom/Cargo.toml
+++ b/geom/Cargo.toml
@@ -15,3 +15,4 @@ name = "lyon_geom"
 [dependencies]
 euclid = "0.16.1"
 arrayvec = "0.4"
+num-traits = "0.1.40"

--- a/geom/src/arc.rs
+++ b/geom/src/arc.rs
@@ -1,38 +1,37 @@
 //! Elliptic arc related maths and tools.
 
-use std::f32::*;
-use std::f32;
 use std::ops::Range;
 
 use Line;
-use math::{Point, point, Vector, vector, Rotation2D, Transform2D, Angle, Rect};
+use scalar::{Float, FloatExt, FloatConst, Trig, ApproxEq, cast};
+use generic_math::{Point, point, Vector, vector, Rotation2D, Transform2D, Angle, Rect};
 use utils::directed_angle;
 use segment::{Segment, FlattenedForEach, FlatteningStep, BoundingRect};
 use segment;
 
 /// A flattening iterator for arc segments.
-pub type Flattened = segment::Flattened<Arc>;
+pub type Flattened<S> = segment::Flattened<S, Arc<S>>;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct SvgArc {
-    pub from: Point,
-    pub to: Point,
-    pub radii: Vector,
-    pub x_rotation: Angle,
+pub struct SvgArc<S: Float> {
+    pub from: Point<S>,
+    pub to: Point<S>,
+    pub radii: Vector<S>,
+    pub x_rotation: Angle<S>,
     pub flags: ArcFlags,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Arc {
-    pub center: Point,
-    pub radii: Vector,
-    pub start_angle: Angle,
-    pub sweep_angle: Angle,
-    pub x_rotation: Angle,
+pub struct Arc<S: Float> {
+    pub center: Point<S>,
+    pub radii: Vector<S>,
+    pub start_angle: Angle<S>,
+    pub sweep_angle: Angle<S>,
+    pub x_rotation: Angle<S>,
 }
 
-impl Arc {
-    pub fn from_svg_arc(arc: &SvgArc) -> Arc {
+impl<S: Float + FloatConst + Trig + ::std::fmt::Debug> Arc<S> {
+    pub fn from_svg_arc(arc: &SvgArc<S>) -> Arc<S> {
         debug_assert!(!arc.from.x.is_nan());
         debug_assert!(!arc.from.y.is_nan());
         debug_assert!(!arc.to.x.is_nan());
@@ -45,16 +44,16 @@ impl Arc {
         let ry = arc.radii.y;
 
         assert_ne!(arc.from, arc.to);
-        assert_ne!(rx, 0.0);
-        assert_ne!(ry, 0.0);
+        assert_ne!(rx, S::zero());
+        assert_ne!(ry, S::zero());
 
-        let xr = arc.x_rotation.get() % (2.0 * consts::PI);
-        let cos_phi = xr.cos();
-        let sin_phi = xr.sin();
-        let hd_x = (arc.from.x - arc.to.x) / 2.0;
-        let hd_y = (arc.from.y - arc.to.y) / 2.0;
-        let hs_x = (arc.from.x + arc.to.x) / 2.0;
-        let hs_y = (arc.from.y + arc.to.y) / 2.0;
+        let xr = arc.x_rotation.get() % (S::c(2.0) * S::PI());
+        let cos_phi = Float::cos(xr);
+        let sin_phi = Float::sin(xr);
+        let hd_x = (arc.from.x - arc.to.x) / S::c(2.0);
+        let hd_y = (arc.from.y - arc.to.y) / S::c(2.0);
+        let hs_x = (arc.from.x + arc.to.x) / S::c(2.0);
+        let hs_y = (arc.from.y + arc.to.y) / S::c(2.0);
         // F6.5.1
         let p = Point::new(
             cos_phi * hd_x + sin_phi * hd_y,
@@ -68,9 +67,9 @@ impl Arc {
         let rypx = ry * p.x;
         let sum_of_sq = rxpy * rxpy + rypx * rypx;
 
-        debug_assert_ne!(sum_of_sq, 0.0);
+        debug_assert_ne!(sum_of_sq, S::zero());
 
-        let sign_coe = if arc.flags.large_arc == arc.flags.sweep {-1.0 } else { 1.0 };
+        let sign_coe = if arc.flags.large_arc == arc.flags.sweep {-S::one() } else { S::one() };
         let coe = sign_coe * ((rxry * rxry - sum_of_sq) / sum_of_sq).abs().sqrt();
 
         let transformed_cx = coe * rxpy / ry;
@@ -92,10 +91,10 @@ impl Arc {
             (-p.y - transformed_cy) / ry,
         );
 
-        let start_angle = Angle::radians(directed_angle(vector(1.0, 0.0), a));
+        let start_angle = Angle::radians(directed_angle(vector(S::one(), S::zero()), a));
 
-        let sign_delta = if arc.flags.sweep { 1.0 } else { -1.0 };
-        let sweep_angle = Angle::radians(sign_delta * (directed_angle(a, b).abs() % (2.0 * consts::PI)));
+        let sign_delta = if arc.flags.sweep { S::one() } else { -S::one() };
+        let sweep_angle = Angle::radians(sign_delta * (directed_angle(a, b).abs() % (S::c(2.0) * S::PI())));
 
         Arc {
             center: center,
@@ -105,13 +104,15 @@ impl Arc {
             x_rotation: arc.x_rotation
         }
     }
+}
 
-    pub fn to_svg_arc(&self) -> SvgArc {
-        let from = self.sample(0.0);
-        let to = self.sample(1.0);
+impl<S: Float + FloatConst + ApproxEq<S>> Arc<S> {
+    pub fn to_svg_arc(&self) -> SvgArc<S> {
+        let from = self.sample(S::zero());
+        let to = self.sample(S::one());
         let flags = ArcFlags {
-            sweep: f32::abs(self.sweep_angle.get()) >= consts::PI,
-            large_arc: self.sweep_angle.get() >= 0.0,
+            sweep: S::abs(self.sweep_angle.get()) >= S::PI(),
+            large_arc: self.sweep_angle.get() >= S::zero(),
         };
         SvgArc {
             from,
@@ -121,56 +122,66 @@ impl Arc {
             flags,
         }
     }
+}
 
+impl<S: Float + FloatConst + ApproxEq<S>> Arc<S> {
     #[inline]
-    pub fn to_quadratic_beziers<F: FnMut(Point, Point)>(&self, cb: &mut F) {
+    pub fn to_quadratic_beziers<F: FnMut(Point<S>, Point<S>)>(&self, cb: &mut F) {
         arc_to_to_quadratic_beziers(self, cb);
     }
+}
 
+impl<S: Float + ApproxEq<S>> Arc<S> {
     /// Sample the curve at t (expecting t between 0 and 1).
     #[inline]
-    pub fn sample(&self, t: f32) -> Point {
+    pub fn sample(&self, t: S) -> Point<S> {
         let angle = self.get_angle(t);
         self.center + sample_ellipse(self.radii, self.x_rotation, angle).to_vector()
     }
 
     #[inline]
-    pub fn x(&self, t: f32) -> f32 { self.sample(t).x }
+    pub fn x(&self, t: S) -> S { self.sample(t).x }
 
     #[inline]
-    pub fn y(&self, t: f32) -> f32 { self.sample(t).y }
+    pub fn y(&self, t: S) -> S { self.sample(t).y }
 
     /// Sample the curve's tangent at t (expecting t between 0 and 1).
     #[inline]
-    pub fn sample_tangent(&self, t: f32) -> Vector {
+    pub fn sample_tangent(&self, t: S) -> Vector<S> {
         self.tangent_at_angle(self.get_angle(t))
     }
+}
 
+impl<S: Float> Arc<S> {
     /// Sample the curve's angle at t (expecting t between 0 and 1).
     #[inline]
-    pub fn get_angle(&self, t: f32) -> Angle {
+    pub fn get_angle(&self, t: S) -> Angle<S> {
         self.start_angle + Angle::radians(self.sweep_angle.get() * t)
     }
 
     #[inline]
-    pub fn end_angle(&self) -> Angle {
+    pub fn end_angle(&self) -> Angle<S> {
         self.start_angle + self.sweep_angle
     }
+}
 
+impl<S: Float + ApproxEq<S>> Arc<S> {
     #[inline]
-    pub fn from(&self) -> Point {
-        self.sample(0.0)
+    pub fn from(&self) -> Point<S> {
+        self.sample(S::zero())
     }
 
     #[inline]
-    pub fn to(&self) -> Point {
-        self.sample(1.0)
+    pub fn to(&self) -> Point<S> {
+        self.sample(S::one())
     }
+}
 
+impl<S: Float> Arc<S> {
     /// Return the sub-curve inside a given range of t.
     ///
     /// This is equivalent splitting at the range's end points.
-    pub fn split_range(&self, t_range: Range<f32>) -> Self {
+    pub fn split_range(&self, t_range: Range<S>) -> Self {
         let angle_1 = Angle::radians(self.sweep_angle.get() * t_range.start);
         let angle_2 = Angle::radians(self.sweep_angle.get() * t_range.end);
 
@@ -184,7 +195,7 @@ impl Arc {
     }
 
     /// Split this curve into two sub-curves.
-    pub fn split(&self, t: f32) -> (Arc, Arc) {
+    pub fn split(&self, t: S) -> (Arc<S>, Arc<S>) {
         let split_angle = Angle::radians(self.sweep_angle.get() * t);
         (
             Arc {
@@ -205,7 +216,7 @@ impl Arc {
     }
 
     /// Return the curve before the split point.
-    pub fn before_split(&self, t: f32) -> Arc {
+    pub fn before_split(&self, t: S) -> Arc<S> {
         let split_angle = Angle::radians(self.sweep_angle.get() * t);
         Arc {
             center: self.center,
@@ -217,7 +228,7 @@ impl Arc {
     }
 
     /// Return the curve after the split point.
-    pub fn after_split(&self, t: f32) -> Arc {
+    pub fn after_split(&self, t: S) -> Arc<S> {
         let split_angle = Angle::radians(self.sweep_angle.get() * t);
         Arc {
             center: self.center,
@@ -236,68 +247,74 @@ impl Arc {
 
         arc
     }
+}
 
+impl<S: Float + ApproxEq<S>> Arc<S> {
     /// Iterates through the curve invoking a callback at each point.
-    pub fn flattened_for_each<F: FnMut(Point)>(&self, tolerance: f32, call_back: &mut F) {
+    pub fn flattened_for_each<F: FnMut(Point<S>)>(&self, tolerance: S, call_back: &mut F) {
         <Self as FlattenedForEach>::flattened_for_each(self, tolerance, call_back);
     }
 
     /// Iterates through the curve invoking a callback at each point.
-    pub fn flattening_step(&self, tolerance: f32) -> f32 {
+    pub fn flattening_step(&self, tolerance: S) -> S {
         // Here we make the approximation that for small tolerance values we consider
         // the radius to be constant over each approximated segment.
         let r = (self.from() - self.center).length();
-        let a = 2.0 * tolerance * r - tolerance * tolerance;
-        f32::acos((a * a) / r)
+        let a = S::c(2.0) * tolerance * r - tolerance * tolerance;
+        S::acos((a * a) / r)
     }
 
     /// Returns the flattened representation of the curve as an iterator, starting *after* the
     /// current point.
-    pub fn flattened(&self, tolerance: f32) -> Flattened {
+    pub fn flattened(&self, tolerance: S) -> Flattened<S> {
         Flattened::new(*self, tolerance)
     }
+}
 
+impl<S: Float + Trig> Arc<S> {
     /// Returns a conservative rectangle that contains the curve.
-    pub fn bounding_rect(&self) -> Rect {
+    pub fn bounding_rect(&self) -> Rect<S> {
         Transform2D::create_rotation(self.x_rotation).transform_rect(
             &Rect::new(
                 self.center - self.radii,
-                self.radii.to_size() * 2.0
+                self.radii.to_size() * S::c(2.0)
             )
         )
     }
 
-    pub fn bounding_range_x(&self) -> (f32, f32) {
+    pub fn bounding_range_x(&self) -> (S, S) {
         let r = self.bounding_rect();
         (r.min_x(), r.max_x())
     }
 
-    pub fn bounding_range_y(&self) -> (f32, f32) {
+    pub fn bounding_range_y(&self) -> (S, S) {
         let r = self.bounding_rect();
         (r.min_y(), r.max_y())
     }
+}
 
-    pub fn approximate_length(&self, tolerance: f32) -> f32 {
+impl<S: Float + ApproxEq<S>> Arc<S> {
+    pub fn approximate_length(&self, tolerance: S) -> S {
         segment::approximate_length_from_flattening(self, tolerance)
     }
 
     #[inline]
-    fn tangent_at_angle(&self, angle: Angle) -> Vector {
+    fn tangent_at_angle(&self, angle: Angle<S>) -> Vector<S> {
         let a = angle.get();
         Rotation2D::new(self.x_rotation).transform_vector(
-            &vector(-self.radii.x * a.sin(), self.radii.y * a.cos())
+            &vector(-self.radii.x * Float::sin(a), self.radii.y * Float::cos(a))
         )
     }
 }
 
-impl Into<Arc> for SvgArc {
-    fn into(self) -> Arc { self.to_arc() }
+impl<S: Float + FloatConst + Trig + ApproxEq<S> + ::std::fmt::Debug> Into<Arc<S>> for SvgArc<S> {
+    fn into(self) -> Arc<S> { self.to_arc() }
 }
 
-impl SvgArc {
-    pub fn to_arc(&self) -> Arc { Arc::from_svg_arc(self) }
+impl<S: Float + FloatConst + Trig + ApproxEq<S> + ::std::fmt::Debug> SvgArc<S> {
+    pub fn to_arc(&self) -> Arc<S> { Arc::from_svg_arc(self) }
 
-    pub fn to_quadratic_beziers<F: FnMut(Point, Point)>(&self, cb: &mut F) {
+    pub fn to_quadratic_beziers<F: FnMut(Point<S>, Point<S>)>(&self, cb: &mut F) {
         Arc::from_svg_arc(self).to_quadratic_beziers(cb);
     }
 }
@@ -318,18 +335,18 @@ impl Default for ArcFlags {
     }
 }
 
-fn arc_to_to_quadratic_beziers<F: FnMut(Point, Point)>(
-    arc: &Arc,
+fn arc_to_to_quadratic_beziers<S: Float + FloatConst + ApproxEq<S>, F: FnMut(Point<S>, Point<S>)>(
+    arc: &Arc<S>,
     call_back: &mut F,
 ) {
-    let sweep_angle = arc.sweep_angle.get().abs().min(consts::PI * 2.0);
+    let sweep_angle = arc.sweep_angle.get().abs().min(S::PI() * S::c(2.0));
 
-    let n_steps = (sweep_angle / consts::FRAC_PI_4).ceil();
+    let n_steps = (sweep_angle / S::FRAC_PI_4()).ceil();
     let step = sweep_angle / n_steps;
 
-    for i in 0..(n_steps as i32) {
-        let a1 = arc.start_angle.get() + step * (i as f32);
-        let a2 = arc.start_angle.get() + step * ((i+1) as f32);
+    for i in 0..cast::<S, i32>(n_steps).unwrap() {
+        let a1 = arc.start_angle.get() + step * cast(i).unwrap();
+        let a2 = arc.start_angle.get() + step * cast(i+1).unwrap();
 
         let v1 = sample_ellipse(arc.radii, arc.x_rotation, Angle::radians(a1)).to_vector();
         let v2 = sample_ellipse(arc.radii, arc.x_rotation, Angle::radians(a2)).to_vector();
@@ -343,40 +360,42 @@ fn arc_to_to_quadratic_beziers<F: FnMut(Point, Point)>(
     }
 }
 
-fn sample_ellipse(radii: Vector, x_rotation: Angle, angle: Angle) -> Point {
+fn sample_ellipse<S: Float + ApproxEq<S>>(radii: Vector<S>, x_rotation: Angle<S>, angle: Angle<S>) -> Point<S> {
     Rotation2D::new(x_rotation).transform_point(
         &point(radii.x * angle.get().cos(), radii.y * angle.get().sin())
     )
 }
 
-impl Segment for Arc {
-    fn from(&self) -> Point { self.from() }
-    fn to(&self) -> Point { self.to() }
-    fn sample(&self, t: f32) -> Point { self.sample(t) }
-    fn x(&self, t: f32) -> f32 { self.x(t) }
-    fn y(&self, t: f32) -> f32 { self.y(t) }
-    fn derivative(&self, t: f32) -> Vector { self.sample_tangent(t) }
-    fn split_range(&self, t_range: Range<f32>) -> Self { self.split_range(t_range) }
-    fn split(&self, t: f32) -> (Self, Self) { self.split(t) }
-    fn before_split(&self, t: f32) -> Self { self.before_split(t) }
-    fn after_split(&self, t: f32) -> Self { self.after_split(t) }
+impl<S: Float + ApproxEq<S>> Segment for Arc<S> {
+    type Scalar = S;
+    fn from(&self) -> Point<S> { self.from() }
+    fn to(&self) -> Point<S> { self.to() }
+    fn sample(&self, t: S) -> Point<S> { self.sample(t) }
+    fn x(&self, t: S) -> S { self.x(t) }
+    fn y(&self, t: S) -> S { self.y(t) }
+    fn derivative(&self, t: S) -> Vector<S> { self.sample_tangent(t) }
+    fn split_range(&self, t_range: Range<S>) -> Self { self.split_range(t_range) }
+    fn split(&self, t: S) -> (Self, Self) { self.split(t) }
+    fn before_split(&self, t: S) -> Self { self.before_split(t) }
+    fn after_split(&self, t: S) -> Self { self.after_split(t) }
     fn flip(&self) -> Self { self.flip() }
-    fn approximate_length(&self, tolerance: f32) -> f32 {
+    fn approximate_length(&self, tolerance: S) -> S {
         self.approximate_length(tolerance)
     }
 }
 
-impl BoundingRect for Arc {
-    fn bounding_rect(&self) -> Rect { self.bounding_rect() }
-    fn fast_bounding_rect(&self) -> Rect { self.bounding_rect() }
-    fn bounding_range_x(&self) -> (f32, f32) { self.bounding_range_x() }
-    fn bounding_range_y(&self) -> (f32, f32) { self.bounding_range_y() }
-    fn fast_bounding_range_x(&self) -> (f32, f32) { self.bounding_range_x() }
-    fn fast_bounding_range_y(&self) -> (f32, f32) { self.bounding_range_y() }
+impl<S: Float + Trig> BoundingRect for Arc<S> {
+    type Scalar = S;
+    fn bounding_rect(&self) -> Rect<S> { self.bounding_rect() }
+    fn fast_bounding_rect(&self) -> Rect<S> { self.bounding_rect() }
+    fn bounding_range_x(&self) -> (S, S) { self.bounding_range_x() }
+    fn bounding_range_y(&self) -> (S, S) { self.bounding_range_y() }
+    fn fast_bounding_range_x(&self) -> (S, S) { self.bounding_range_x() }
+    fn fast_bounding_range_y(&self) -> (S, S) { self.bounding_range_y() }
 }
 
-impl FlatteningStep for Arc {
-    fn flattening_step(&self, tolerance: f32) -> f32 {
+impl<S: Float + ApproxEq<S>> FlatteningStep for Arc<S> {
+    fn flattening_step(&self, tolerance: S) -> S {
         self.flattening_step(tolerance)
     }
 }

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -67,6 +67,7 @@
 
 pub extern crate arrayvec;
 pub extern crate euclid;
+extern crate num_traits;
 
 #[macro_use] mod segment;
 pub mod quadratic_bezier;
@@ -92,6 +93,60 @@ pub use monotonic::{
     monotonic_segment_intersecion,
     monotonic_segment_intersecions,
 };
+
+mod scalar {
+    pub(crate) use num_traits::{Float, FloatConst};
+    pub(crate) use num_traits::One;
+    pub(crate) use num_traits::cast::cast;
+    pub(crate) use euclid::Trig;
+    pub(crate) use euclid::approxeq::ApproxEq; // FIXME: Remove ApproxEq bounds
+
+    pub(crate) trait FloatExt {
+        // Only use for constants
+        fn c(c: f64) -> Self;
+    }
+
+    impl<S: Float> FloatExt for S {
+        fn c(c: f64) -> Self {
+            cast(c).unwrap()
+        }
+    }
+}
+
+mod generic_math {
+    /// Alias for `euclid::Point2D`.
+    pub use euclid::Point2D as Point;
+
+    /// Alias for `euclid::Vector2D`.
+    pub use euclid::Vector2D as Vector;
+
+    /// Alias for `euclid::Size2D`.
+    pub use euclid::Size2D as Size;
+
+    /// Alias for `euclid::Rect`
+    pub use euclid::Rect;
+
+    /// Alias for `euclid::Transform2D`
+    pub use euclid::Transform2D;
+
+    /// Alias for `euclid::Rotation2D`
+    pub use euclid::Rotation2D;
+
+    /// An angle in radians.
+    pub use euclid::Angle;
+
+    /// Shorthand for `Rect::new(Point::new(x, y), Size::new(w, h))`.
+    pub use euclid::rect;
+
+    /// Shorthand for `Vector::new(x, y)`.
+    pub use euclid::vec2 as vector;
+
+    /// Shorthand for `Point::new(x, y)`.
+    pub use euclid::point2 as point;
+
+    /// Shorthand for `Size::new(x, y)`.
+    pub use euclid::size2 as size;
+}
 
 pub mod math {
     //! ## Core geometry types

--- a/geom/src/segment.rs
+++ b/geom/src/segment.rs
@@ -1,91 +1,96 @@
-use math::{Point, Vector, Rect};
+use scalar::{Float, One, ApproxEq};
+use generic_math::{Point, Vector, Rect};
 
 use std::ops::Range;
 
 /// Common APIs to segment types.
 pub trait Segment: Copy + Sized {
+    type Scalar: Float;
+
     /// Start of the curve.
-    fn from(&self) -> Point;
+    fn from(&self) -> Point<Self::Scalar>;
 
     /// End of the curve.
-    fn to(&self) -> Point;
+    fn to(&self) -> Point<Self::Scalar>;
 
     /// Sample the curve at t (expecting t between 0 and 1).
-    fn sample(&self, t: f32) -> Point;
+    fn sample(&self, t: Self::Scalar) -> Point<Self::Scalar>;
 
     /// Sample x at t (expecting t between 0 and 1).
-    fn x(&self, t: f32) -> f32 { self.sample(t).x }
+    fn x(&self, t: Self::Scalar) -> Self::Scalar { self.sample(t).x }
 
     /// Sample y at t (expecting t between 0 and 1).
-    fn y(&self, t: f32) -> f32 { self.sample(t).y }
+    fn y(&self, t: Self::Scalar) -> Self::Scalar { self.sample(t).y }
 
     /// Sample the derivative at t (expecting t between 0 and 1).
-    fn derivative(&self, t: f32) -> Vector;
+    fn derivative(&self, t: Self::Scalar) -> Vector<Self::Scalar>;
 
     /// Sample x derivative at t (expecting t between 0 and 1).
-    fn dx(&self, t: f32) -> f32 { self.derivative(t).x }
+    fn dx(&self, t: Self::Scalar) -> Self::Scalar { self.derivative(t).x }
 
     /// Sample y derivative at t (expecting t between 0 and 1).
-    fn dy(&self, t: f32) -> f32 { self.derivative(t).y }
+    fn dy(&self, t: Self::Scalar) -> Self::Scalar { self.derivative(t).y }
 
     /// Split this curve into two sub-curves.
-    fn split(&self, t: f32) -> (Self, Self);
+    fn split(&self, t: Self::Scalar) -> (Self, Self);
 
     /// Return the curve before the split point.
-    fn before_split(&self, t: f32) -> Self;
+    fn before_split(&self, t: Self::Scalar) -> Self;
 
     /// Return the curve after the split point.
-    fn after_split(&self, t: f32) -> Self;
+    fn after_split(&self, t: Self::Scalar) -> Self;
 
     /// Return the curve inside a given range of t.
     ///
     /// This is equivalent splitting at the range's end points.
-    fn split_range(&self, t_range: Range<f32>) -> Self;
+    fn split_range(&self, t_range: Range<Self::Scalar>) -> Self;
 
     /// Swap the direction of the segment.
     fn flip(&self) -> Self;
 
     /// Compute the length of the segment using a flattened approximation.
-    fn approximate_length(&self, tolerance: f32) -> f32;
+    fn approximate_length(&self, tolerance: Self::Scalar) -> Self::Scalar;
 }
 
 pub trait BoundingRect {
+    type Scalar: Float;
+
     /// Returns a rectangle that contains the curve.
-    fn bounding_rect(&self) -> Rect;
+    fn bounding_rect(&self) -> Rect<Self::Scalar>;
 
     /// Returns a rectangle that contains the curve.
     ///
     /// This does not necessarily return the smallest possible bounding rectangle.
-    fn fast_bounding_rect(&self) -> Rect { self.bounding_rect() }
+    fn fast_bounding_rect(&self) -> Rect<Self::Scalar> { self.bounding_rect() }
 
     /// Returns a range of x values that contains the curve.
-    fn bounding_range_x(&self) -> (f32, f32);
+    fn bounding_range_x(&self) -> (Self::Scalar, Self::Scalar);
 
     /// Returns a range of y values that contains the curve.
-    fn bounding_range_y(&self) -> (f32, f32);
+    fn bounding_range_y(&self) -> (Self::Scalar, Self::Scalar);
 
     /// Returns a range of x values that contains the curve.
-    fn fast_bounding_range_x(&self) -> (f32, f32);
+    fn fast_bounding_range_x(&self) -> (Self::Scalar, Self::Scalar);
 
     /// Returns a range of y values that contains the curve.
-    fn fast_bounding_range_y(&self) -> (f32, f32);
+    fn fast_bounding_range_y(&self) -> (Self::Scalar, Self::Scalar);
 }
 
 /// Types that implement call-back based iteration
 pub trait FlattenedForEach: Segment {
     /// Iterates through the curve invoking a callback at each point.
-    fn flattened_for_each<F: FnMut(Point)>(&self, tolerance: f32, call_back: &mut F);
+    fn flattened_for_each<F: FnMut(Point<Self::Scalar>)>(&self, tolerance: Self::Scalar, call_back: &mut F);
 }
 
 /// Types that implement local flattening approximation at the start of the curve.
 pub trait FlatteningStep: FlattenedForEach {
     /// Find the interval of the begining of the curve that can be approximated with a
     /// line segment.
-    fn flattening_step(&self, tolerance: f32) -> f32;
+    fn flattening_step(&self, tolerance: Self::Scalar) -> Self::Scalar;
 
     /// Returns the flattened representation of the curve as an iterator, starting *after* the
     /// current point.
-    fn flattened(self, tolerance: f32) -> Flattened<Self> {
+    fn flattened(self, tolerance: Self::Scalar) -> Flattened<Self::Scalar, Self> {
         Flattened::new(self, tolerance)
     }
 }
@@ -93,11 +98,11 @@ pub trait FlatteningStep: FlattenedForEach {
 impl<T> FlattenedForEach for T
 where T: FlatteningStep
 {
-    fn flattened_for_each<F: FnMut(Point)>(&self, tolerance: f32, call_back: &mut F) {
+    fn flattened_for_each<F: FnMut(Point<Self::Scalar>)>(&self, tolerance: Self::Scalar, call_back: &mut F) {
         let mut iter = *self;
         loop {
             let t = iter.flattening_step(tolerance);
-            if t == 1.0 {
+            if t == Self::Scalar::one() {
                 call_back(iter.to());
                 break;
             }
@@ -112,15 +117,15 @@ where T: FlatteningStep
 ///
 /// The iterator starts at the first point *after* the origin of the curve and ends at the
 /// destination.
-pub struct Flattened<T> {
+pub struct Flattened<S: Float, T> {
     curve: T,
-    tolerance: f32,
+    tolerance: S,
     done: bool,
 }
 
-impl<T: FlatteningStep> Flattened<T> {
-    pub fn new(curve: T, tolerance: f32) -> Self {
-        assert!(tolerance > 0.0);
+impl<S: Float, T: FlatteningStep> Flattened<S, T> {
+    pub fn new(curve: T, tolerance: S) -> Self {
+        assert!(tolerance > S::zero());
         Flattened {
             curve: curve,
             tolerance: tolerance,
@@ -129,14 +134,15 @@ impl<T: FlatteningStep> Flattened<T> {
     }
 }
 
-impl<T: FlatteningStep> Iterator for Flattened<T> {
-    type Item = Point;
-    fn next(&mut self) -> Option<Point> {
+impl<S: Float, T: FlatteningStep<Scalar=S>> Iterator for Flattened<S, T>
+{
+    type Item = Point<S>;
+    fn next(&mut self) -> Option<Point<S>> {
         if self.done {
             return None;
         }
         let t = self.curve.flattening_step(self.tolerance);
-        if t == 1.0 {
+        if t == S::one() {
             self.done = true;
             return Some(self.curve.to());
         }
@@ -145,33 +151,35 @@ impl<T: FlatteningStep> Iterator for Flattened<T> {
     }
 }
 
-pub(crate) fn approximate_length_from_flattening<T>(curve: &T, tolerance: f32) -> f32
-where T: FlattenedForEach {
+pub(crate) fn approximate_length_from_flattening<S: Float + ApproxEq<S>, T>(curve: &T, tolerance: S) -> S
+where T: FlattenedForEach<Scalar=S>
+{
     let mut start = curve.from();
-    let mut len = 0.0;
+    let mut len = S::zero();
     curve.flattened_for_each(tolerance, &mut|p| {
-        len += (p - start).length();
+        len = len + (p - start).length();
         start = p;
     });
     return len;
 }
 
 macro_rules! impl_segment {
-    () => (
-        fn from(&self) -> Point { self.from() }
-        fn to(&self) -> Point { self.to() }
-        fn sample(&self, t: f32) -> Point { self.sample(t) }
-        fn x(&self, t: f32) -> f32 { self.x(t) }
-        fn y(&self, t: f32) -> f32 { self.y(t) }
-        fn derivative(&self, t: f32) -> Vector { self.derivative(t) }
-        fn dx(&self, t: f32) -> f32 { self.dx(t) }
-        fn dy(&self, t: f32) -> f32 { self.dy(t) }
-        fn split(&self, t: f32) -> (Self, Self) { self.split(t) }
-        fn before_split(&self, t: f32) -> Self { self.before_split(t) }
-        fn after_split(&self, t: f32) -> Self { self.after_split(t) }
-        fn split_range(&self, t_range: Range<f32>) -> Self { self.split_range(t_range) }
+    ($S:ty) => (
+        type Scalar = $S;
+        fn from(&self) -> Point<$S> { self.from() }
+        fn to(&self) -> Point<$S> { self.to() }
+        fn sample(&self, t: $S) -> Point<$S> { self.sample(t) }
+        fn x(&self, t: $S) -> $S { self.x(t) }
+        fn y(&self, t: $S) -> $S { self.y(t) }
+        fn derivative(&self, t: $S) -> Vector<$S> { self.derivative(t) }
+        fn dx(&self, t: $S) -> $S { self.dx(t) }
+        fn dy(&self, t: $S) -> $S { self.dy(t) }
+        fn split(&self, t: $S) -> (Self, Self) { self.split(t) }
+        fn before_split(&self, t: $S) -> Self { self.before_split(t) }
+        fn after_split(&self, t: $S) -> Self { self.after_split(t) }
+        fn split_range(&self, t_range: Range<$S>) -> Self { self.split_range(t_range) }
         fn flip(&self) -> Self { self.flip() }
-        fn approximate_length(&self, tolerance: f32) -> f32 {
+        fn approximate_length(&self, tolerance: $S) -> $S {
             self.approximate_length(tolerance)
         }
     )

--- a/geom/src/triangle.rs
+++ b/geom/src/triangle.rs
@@ -1,15 +1,16 @@
-use math::{Point, Rect, Size, Transform2D};
+use scalar::{Float, Trig};
+use generic_math::{Point, Rect, Size, Transform2D};
 use LineSegment;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Triangle {
-    pub a: Point,
-    pub b: Point,
-    pub c: Point,
+pub struct Triangle<S: Float> {
+    pub a: Point<S>,
+    pub b: Point<S>,
+    pub c: Point<S>,
 }
 
-impl Triangle {
-    pub fn contains_point(&self, point: Point) -> bool {
+impl<S: Float> Triangle<S> {
+    pub fn contains_point(&self, point: Point<S>) -> bool {
         // see http://blackpawn.com/texts/pointinpoly/
         let v0 = self.c - self.a;
         let v1 = self.b - self.a;
@@ -20,16 +21,16 @@ impl Triangle {
         let dot02 = v0.dot(v2);
         let dot11 = v1.dot(v1);
         let dot12 = v1.dot(v2);
-        let inv = 1.0 / (dot00 * dot11 - dot01 * dot01);
+        let inv = S::one() / (dot00 * dot11 - dot01 * dot01);
         let u = (dot11 * dot02 - dot01 * dot12) * inv;
         let v = (dot11 * dot12 - dot01 * dot02) * inv;
 
-        return u > 0.0 && v > 0.0 && u + v < 1.0;
+        return u > S::zero() && v > S::zero() && u + v < S::one();
     }
 
     /// Return the minimum bounding rectangle
     #[inline]
-    pub fn bounding_rect(&self) -> Rect {
+    pub fn bounding_rect(&self) -> Rect<S> {
         let max_x = self.a.x.max(self.b.x).max(self.c.x);
         let min_x = self.a.x.min(self.b.x).min(self.c.x);
         let max_y = self.a.y.max(self.b.y).max(self.c.y);
@@ -41,45 +42,49 @@ impl Triangle {
     }
 
     #[inline]
-    pub fn ab(&self) -> LineSegment {
+    pub fn ab(&self) -> LineSegment<S> {
         LineSegment { from: self.a, to: self.b }
     }
 
     #[inline]
-    pub fn ba(&self) -> LineSegment {
+    pub fn ba(&self) -> LineSegment<S> {
         LineSegment { from: self.b, to: self.a }
     }
 
     #[inline]
-    pub fn bc(&self) -> LineSegment {
+    pub fn bc(&self) -> LineSegment<S> {
         LineSegment { from: self.b, to: self.c }
     }
 
     #[inline]
-    pub fn cb(&self) -> LineSegment {
+    pub fn cb(&self) -> LineSegment<S> {
         LineSegment { from: self.c, to: self.b }
     }
 
     #[inline]
-    pub fn ca(&self) -> LineSegment {
+    pub fn ca(&self) -> LineSegment<S> {
         LineSegment { from: self.c, to: self.a }
     }
 
     #[inline]
-    pub fn ac(&self) -> LineSegment {
+    pub fn ac(&self) -> LineSegment<S> {
         LineSegment { from: self.a, to: self.c }
     }
+}
 
+impl<S: Float + Trig> Triangle<S> {
     /// [Not implemented] Applies the transform to this triangle and returns the results.
     #[inline]
-    pub fn transform(&self, transform: &Transform2D) -> Self {
+    pub fn transform(&self, transform: &Transform2D<S>) -> Self {
         Triangle {
             a: transform.transform_point(&self.a),
             b: transform.transform_point(&self.b),
             c: transform.transform_point(&self.c)
         }
     }
+}
 
+impl<S: Float> Triangle<S> {
     /// Test for triangle-triangle intersection.
     pub fn intersects(&self, other: &Self) -> bool {
         // TODO: This should be optimized.
@@ -102,7 +107,7 @@ impl Triangle {
 
     /// Test for triangle-segment intersection.
     #[inline]
-    pub fn intersects_line_segment(&self, segment: &LineSegment) -> bool {
+    pub fn intersects_line_segment(&self, segment: &LineSegment<S>) -> bool {
         return self.ab().intersects(segment)
             || self.bc().intersects(segment)
             || self.ac().intersects(segment)

--- a/path/src/iterator.rs
+++ b/path/src/iterator.rs
@@ -199,9 +199,9 @@ pub struct Flattened<Iter> {
 }
 
 enum TmpFlatteningIter {
-    Quadratic(quadratic_bezier::Flattened),
-    Cubic(cubic_bezier::Flattened),
-    Arc(arc::Flattened),
+    Quadratic(quadratic_bezier::Flattened<f32>),
+    Cubic(cubic_bezier::Flattened<f32>),
+    Arc(arc::Flattened<f32>),
     None,
 }
 

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -27,9 +27,8 @@ use sid::{Id, IdVec};
 
 use FillVertex as Vertex;
 use {FillOptions, FillRule, Side};
-use geom::utils::fast_atan2;
 use geom::math::*;
-use geom::euclid;
+use geom::euclid::{self, Trig};
 use math_utils::*;
 use geometry_builder::{GeometryBuilder, Count, VertexId};
 use path::PathEvent;
@@ -1354,7 +1353,7 @@ fn to_f32_vector(v: TessVector) -> Vector { vector(v.x.to_f32(), v.y.to_f32()) }
 
 #[inline]
 fn edge_angle(v: TessVector) -> f32 {
-    return -fast_atan2(v.y.to_f32(), v.x.to_f32());
+    return -Trig::fast_atan2(v.y.to_f32(), v.x.to_f32());
 }
 
 /// A sequence of edges sorted from top to bottom, to be used as the tessellator's input.

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -1,7 +1,8 @@
 use math_utils::compute_normal;
 use geom::math::*;
 use geom::{QuadraticBezierSegment, CubicBezierSegment, LineSegment, Arc};
-use geom::utils::{normalized_tangent, directed_angle, fast_atan2, vector_angle};
+use geom::utils::{normalized_tangent, directed_angle, vector_angle};
+use geom::euclid::Trig;
 use geometry_builder::{VertexId, GeometryBuilder, Count};
 use basic_shapes::circle_flattening_step;
 use path::builder::{FlatPathBuilder, PathBuilder};
@@ -860,7 +861,7 @@ fn compute_max_radius_segment_angle(radius: f32, tolerance: f32) -> f32 {
 }
 
 fn get_join_angle(prev_tangent: Vector, next_tangent: Vector) -> f32 {
-    let mut join_angle = fast_atan2(prev_tangent.y, prev_tangent.x) - fast_atan2(next_tangent.y, next_tangent.x);
+    let mut join_angle = Trig::fast_atan2(prev_tangent.y, prev_tangent.x) - Trig::fast_atan2(next_tangent.y, next_tangent.x);
 
     // Make sure to stay within the [-Pi, Pi] range.
     if join_angle > PI {


### PR DESCRIPTION
This PR makes the geom crate generic over Float (plus some other traits when needed).

There is one small FIXME in the code, but this will need changes in euclid. Also, I removed util::fast_atan2() and used the version from euclid::Trig.