### PR TITLE
Add option --precision to CLI tessellate command

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -7,7 +7,7 @@ pub struct TessellateCmd {
     pub path: Path,
     pub fill: Option<FillOptions>,
     pub stroke: Option<StrokeOptions>,
-    pub precision: Option<usize>,
+    pub float_precision: Option<usize>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -7,6 +7,7 @@ pub struct TessellateCmd {
     pub path: Path,
     pub fill: Option<FillOptions>,
     pub stroke: Option<StrokeOptions>,
+    pub precision: Option<usize>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -50,11 +50,10 @@ fn main() {
                 .takes_value(true)
                 .required(false)
             )
-            .arg(Arg::with_name("PRECISION")
-                .short("p")
-                .long("precision")
+            .arg(Arg::with_name("FLOAT_PRECISION")
+                .long("float-precision")
                 .help("Sets the floating point precision for the output")
-                .value_name("PRECISION")
+                .value_name("FLOAT_PRECISION")
                 .takes_value(true)
                 .required(false)
             )
@@ -129,7 +128,7 @@ fn main() {
         let output = get_output(&command);
         let cmd = get_tess_command(&command);
         let cmd_copy = cmd.clone();
-        let precision = cmd.precision;
+        let float_precision = cmd.float_precision;
 
         let res = ::std::panic::catch_unwind(|| {
             tessellate::tessellate_path(cmd)
@@ -139,7 +138,7 @@ fn main() {
             Ok(Ok(buffers)) => {
                 tessellate::write_output(buffers,
                                          command.is_present("COUNT"),
-                                         precision,
+                                         float_precision,
                                          output).unwrap();
             }
             _ => {
@@ -304,8 +303,8 @@ fn get_tess_command(command: &ArgMatches) -> TessellateCmd {
         None
     };
 
-    let precision = if let Some(precision) = command.value_of("PRECISION") {
-        Some(precision.parse::<usize>().expect("Precision must be an integer").min(7))
+    let float_precision = if let Some(fp) = command.value_of("FLOAT_PRECISION") {
+        Some(fp.parse::<usize>().expect("Precision must be an integer").min(7))
     } else {
         None
     };
@@ -314,7 +313,7 @@ fn get_tess_command(command: &ArgMatches) -> TessellateCmd {
         path: path.clone(),
         fill: fill,
         stroke: stroke_cmd,
-        precision: precision,
+        float_precision: float_precision,
     }
 }
 

--- a/cli/src/tessellate.rs
+++ b/cli/src/tessellate.rs
@@ -17,6 +17,14 @@ impl ::std::convert::From<::std::io::Error> for TessError {
     fn from(err: io::Error) -> Self { TessError::Io(err) }
 }
 
+fn format_float(value: f32, precision: Option<usize>) -> String {
+    if let Some(p) = precision {
+        format!("{0:.1$}", value, p)
+    } else {
+        format!("{}", value)
+    }
+}
+
 pub fn tessellate_path(cmd: TessellateCmd) -> Result<VertexBuffers<Point>, TessError> {
 
     let mut buffers: VertexBuffers<Point> = VertexBuffers::new();
@@ -45,8 +53,9 @@ pub fn tessellate_path(cmd: TessellateCmd) -> Result<VertexBuffers<Point>, TessE
 pub fn write_output(
     buffers: VertexBuffers<Point>,
     count: bool,
+    precision: Option<usize>,
     mut output: Box<io::Write>
-) -> Result<(), io::Error>{
+) -> Result<(), io::Error> {
 
     if count {
         try!{ writeln!(&mut *output, "vertices: {}", buffers.vertices.len()) };
@@ -62,7 +71,8 @@ pub fn write_output(
         if !is_first {
             try!{ write!(&mut *output, ", ") };
         }
-        try!{ write!(&mut *output, "({}, {})", vertex.x, vertex.y) };
+        try!{ write!(&mut *output, "({}, {})", format_float(vertex.x, precision),
+                                               format_float(vertex.y, precision)) };
         is_first = false;
     }
     try!{ writeln!(&mut *output, "]") };

--- a/cli/src/tessellate.rs
+++ b/cli/src/tessellate.rs
@@ -53,7 +53,7 @@ pub fn tessellate_path(cmd: TessellateCmd) -> Result<VertexBuffers<Point>, TessE
 pub fn write_output(
     buffers: VertexBuffers<Point>,
     count: bool,
-    precision: Option<usize>,
+    float_precision: Option<usize>,
     mut output: Box<io::Write>
 ) -> Result<(), io::Error> {
 
@@ -71,8 +71,8 @@ pub fn write_output(
         if !is_first {
             try!{ write!(&mut *output, ", ") };
         }
-        try!{ write!(&mut *output, "({}, {})", format_float(vertex.x, precision),
-                                               format_float(vertex.y, precision)) };
+        try!{ write!(&mut *output, "({}, {})", format_float(vertex.x, float_precision),
+                                               format_float(vertex.y, float_precision)) };
         is_first = false;
     }
     try!{ writeln!(&mut *output, "]") };


### PR DESCRIPTION
Allows to specifiy the output floating point precision.
If no precision flag is specified, the output is identical
to the previous version.