### PR TITLE
Add a fall-back tessellator using libtess2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon 0.9.0",
  "lyon_extra 0.9.0",
+ "lyon_tess2 0.9.0",
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -835,6 +836,14 @@ dependencies = [
  "lyon 0.9.0",
  "lyon_svg 0.9.0",
  "rayon 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lyon_tess2"
+version = "0.9.0"
+dependencies = [
+ "lyon_tessellation 0.9.0",
+ "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,14 +10,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "android_glue"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,14 +25,6 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aster"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -94,26 +78,6 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "bindgen"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bitflags"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,14 +123,6 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cexpr"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,17 +143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gleam 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "clang-sys"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "libloading 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -404,15 +349,6 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "env_logger"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "error-chain"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +403,11 @@ dependencies = [
 [[package]]
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gcc"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -648,11 +589,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "glutin"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,14 +684,6 @@ dependencies = [
 [[package]]
 name = "itertools"
 version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "itertools"
-version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -927,22 +855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "memchr"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "memmap"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,14 +891,6 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "nom"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,11 +918,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "shared_library 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "phf"
@@ -1060,26 +959,6 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "quasi"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quasi_codegen"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,30 +997,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1237,48 +1094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syntex"
-version = "0.58.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syntex_errors"
-version = "0.58.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syntex_pos"
-version = "0.58.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syntex_syntax"
-version = "0.58.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "target_build_utils"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,15 +1116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,12 +1126,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "tess2"
-version = "0.1.0"
-source = "git+https://github.com/turnage/tess2.git#4c78529696d322b6f0fce3564e0984132fcd6de8"
+name = "tess2-sys"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bindgen 0.26.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1334,7 +1139,7 @@ version = "0.0.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon 0.9.0",
- "tess2 0.1.0 (git+https://github.com/turnage/tess2.git)",
+ "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1343,15 +1148,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1370,14 +1166,6 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "user32-sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,18 +1175,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8-ranges"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "vec_map"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "void"
-version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1700,17 +1478,14 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
 "checksum arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0ef4a9820019a0c91d918918c93dc71d469f581a49b47ddc1d285d4270bbe2"
-"checksum aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfdf7355d9db158df68f976ed030ab0f6578af811f5a7bb6dcf221ec24e0e0"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
-"checksum bindgen 0.26.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c57d6c0f6e31f8dcf4d12720a3c2a9ffb70638772a5784976cf4fce52145f22a"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
@@ -1720,11 +1495,9 @@ dependencies = [
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
-"checksum cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cdbb21df6ff3497a61df5059994297f746267020ba38ce237aad9c875f7b4313"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cgl 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8bdd78cca65a739cb5475dbf6b6bbb49373e327f4a6f2b499c0f98632df38c10"
 "checksum cgl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86765cb42c2a2c497e142af72517c1b4d7ae5bb2f25dfa77a5c69642f2342d89"
-"checksum clang-sys 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "611ec2e3a7623afd8a8c0d027887b6b55759d894abbf5fe11b9dc11b50d5b49a"
 "checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
 "checksum cocoa 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bdd6fd6ca4d1c1452648bd43203e65ef65bf60087abb5d4378e19ec9f3d98612"
 "checksum cocoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3afe4613f57a171039a98db1773f5840b5743cf85aaf03afb65ddfade4f4a9db"
@@ -1748,7 +1521,6 @@ dependencies = [
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum dwmapi-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b44b6442aeab12e609aee505bd1066bdfd36b79c3fe5aad604aae91537623e76"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
-"checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum euclid 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1bb8335618a5dace6c5654a0945c4f29ac09039878fd8f3d36953950e9a363ce"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1757,6 +1529,7 @@ dependencies = [
 "checksum fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bcd414e5a1a979b931bb92f41b7a54106d3f6d2e6c253e9ce943b7cd468251ef"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum gdi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e3eb92c1107527888f86b6ebb0b7f82794777dbf172a932998660a0a2e26c11"
 "checksum gfx 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5f21df412363e606c7c055c8b0444a81b17cd69b795a0c8619620b6fca74d093"
 "checksum gfx_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb99b721c3b5c30585d5bb33283c21bcd7c8feb29f0791b7372c3b006822c9b"
@@ -1770,12 +1543,10 @@ dependencies = [
 "checksum gleam 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4f9148004bdc641f47173769e2625d8dec7aafd3f8d808309aab8f2d7c5ee0"
 "checksum glium 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30bfe6ac8600d25f7f2a1e3203566b156d66e7c2f358f6bb79b5419ddaecd671"
 "checksum glium 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9d76f3917e51f743c472abde1f8c0bbd289daffa1ada9f62f8deb02eacd558f"
-"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5d459b91c4aac4c5aee285f1ac55d7b8cc85aa5d2ffd1bdac3b2707b6ab95e4a"
 "checksum glutin 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3069192081fef59b783f0fbf824a9d2320169cb435f31fb2c91df88dc18f11ae"
 "checksum glutin 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "06786fae66e7aa8464b3d8d3fb7a7c470f89d62ae511f9613ea7fbbeef61d680"
 "checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
-"checksum itertools 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a3f195c9c60b8d747d73357694c3ebcaeb229ea574bd92999260954f851d59c2"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum khronos_api 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d5a08e2a31d665af8f1ca437eab6d00a93c9d62a549f73f9ed8fc2e55b5a91a7"
@@ -1789,34 +1560,25 @@ dependencies = [
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memmap 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f20f72ed93291a72e22e8b16bb18762183bb4943f0f483da5b8be1a9e8192752"
 "checksum memmap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "69253224aa10070855ea8fe9dbe94a03fc2b1d7930bb340c9e586a7513716fea"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
-"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "cacfcab5eb48250ee7d0c7896b51a2c5eec99c1feea5f32025635f5ae4b00070"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
-"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
 "checksum phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d62594c0bb54c464f633175d502038177e90309daf2e0158be42ed5f023ce88f"
 "checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"
 "checksum phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "07e24b0ca9643bdecd0632f2b3da6b1b89bbb0030e0b992afc1113b23a7bc2f2"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
-"checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"
-"checksum quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9e25fa23c044c1803f43ca59c98dac608976dd04ce799411edd58ece776d4"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
 "checksum rayon 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0783f5880c56f5a308e219ac9309dbe781e064741dd5def4c617c440890305"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
-"checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0e0732aa8ec4267f61815a396a942ba3525062e3bd5520aa8419927cfc0a92"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
@@ -1830,25 +1592,16 @@ dependencies = [
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum svgparser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2081030712e7f0351b8c7700fbaf345e7afaa480fff4b63c065499e47252c717"
 "checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
-"checksum syntex 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a8f5e3aaa79319573d19938ea38d068056b826db9883a5d47f86c1cecc688f0e"
-"checksum syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "867cc5c2d7140ae7eaad2ae9e8bf39cb18a67ca651b7834f88d46ca98faadb9c"
-"checksum syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13ad4762fe52abc9f4008e85c4fb1b1fe3aa91ccb99ff4826a439c7c598e1047"
-"checksum syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e0e4dbae163dd98989464c23dd503161b338790640e11537686f2ef0f25c791"
 "checksum target_build_utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "013d134ae4a25ee744ad6129db589018558f620ddfa44043887cdd45fa08e75c"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
-"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum tess2 0.1.0 (git+https://github.com/turnage/tess2.git)" = "<none>"
+"checksum tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8690740ac57b47ae3e73668f7f84e0ecb1287a11344df878ae46a4771e9016d9"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
-"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum token_store 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a686838375fc11103b9c1529c6508320b7bd5e2401cd62831ca51b3e82e61849"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum user32-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6b719983b952c04198829b51653c06af36f0e44c967fcc1a2bb397ceafbf80a"
-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wayland-client 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2b90adf943117ee4930d7944fe103dcb6f36ba05421f46521cb5adbf6bf0fbc8"
 "checksum wayland-client 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ced3094c157b5cc0a08d40530e1a627d9f88b9a436971338d2646439128a559e"
 "checksum wayland-client 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "9b10f2880f3dedaa496609a0aa7117bc6824490a48309dfbbf26258e5acc5a9d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ lyon_svg = { version = "0.9.0", path = "svg/" }
 members = [
     "path",
     "tessellation",
+    "tess2",
     "geom",
     "extra",
     "svg",

--- a/bench/tess/Cargo.toml
+++ b/bench/tess/Cargo.toml
@@ -8,9 +8,9 @@ workspace = "../.."
 name = "tess_bench"
 
 [features]
-libtess2 = ["tess2"]
+libtess2 = ["tess2-sys"]
 
 [dependencies]
 lyon = { path = "../../" }
 bencher = "0.1.1"
-tess2 = { git = "https://github.com/turnage/tess2.git", optional = true }
+tess2-sys = { version = "0.0.1", optional = true }

--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -2,7 +2,7 @@ extern crate lyon;
 #[macro_use]
 extern crate bencher;
 #[cfg(feature = "libtess2")]
-extern crate tess2;
+extern crate tess2_sys as tess2;
 
 use lyon::path::default::Path;
 use lyon::path::builder::*;
@@ -191,8 +191,8 @@ fn cmp_01_libtess2_rust_logo(bench: &mut Bencher) {
                     );
                 }
                 let res = tessTesselate(tess,
-                    TessWindingRule::TESS_WINDING_NONZERO as i32,
-                    TessElementType::TESS_POLYGONS as i32,
+                    TessWindingRule::TESS_WINDING_NONZERO,
+                    TessElementType::TESS_POLYGONS,
                     3,
                     2,
                     0 as *mut TESSreal

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 lyon = { path = "../" }
 lyon_extra = { path = "../extra" }
+lyon_tess2 = { path = "../tess2" }
 clap = "2.19.2"
 rand = "0.3"
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2,12 +2,19 @@ use std::io;
 use lyon::path::default::Path;
 use lyon::tessellation::{FillOptions, StrokeOptions};
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Tessellator {
+    Default,
+    Tess2,
+}
+
 #[derive(Clone, Debug)]
 pub struct TessellateCmd {
     pub path: Path,
     pub fill: Option<FillOptions>,
     pub stroke: Option<StrokeOptions>,
     pub float_precision: Option<usize>,
+    pub tessellator: Tessellator,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,11 @@
 //! * [![crate](http://meritbadge.herokuapp.com/lyon_extra)](https://crates.io/crates/lyon_extra)
 //!   [![doc](https://docs.rs/lyon_extra/badge.svg)](https://docs.rs/lyon_extra) -
 //!   **lyon_extra** - Additional testing and debugging tools.
+//! * [![crate](http://meritbadge.herokuapp.com/lyon_tess2)](https://crates.io/crates/lyon_extra)
+//!   [![doc](https://docs.rs/lyon_tess2/badge.svg)](https://docs.rs/lyon_extra) -
+//!   **lyon_tess2** - Alternative fill tessellation implementation using [libtess2](https://github.com/memononen/libtess2).
 //!
-//! Each `lyon_<name>` crate is reexported as a `<name>` module in `lyon`. For example:
+//! Most `lyon_<name>` crate is reexported as a `<name>` module in `lyon`. For example:
 //!
 //! ```ignore
 //! extern crate lyon_tessellation;

--- a/tess2/Cargo.toml
+++ b/tess2/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+
+name = "lyon_tess2"
+version = "0.9.0"
+description = "An additional path tessellator for lyon using libtess2."
+authors = [ "Nicolas Silva <nical@fastmail.com>" ]
+repository = "https://github.com/nical/lyon"
+documentation = "https://docs.rs/lyon_tess2/"
+keywords = ["2d", "graphics", "tessellation", "svg"]
+license = "MIT/Apache-2.0"
+workspace = ".."
+
+[lib]
+name = "lyon_tess2"
+path = "src/lib.rs"
+
+[dependencies]
+
+lyon_tessellation = { version = "0.9.0", path = "../tessellation" }
+tess2-sys = "0.0.1"

--- a/tess2/src/flattened_path.rs
+++ b/tess2/src/flattened_path.rs
@@ -1,0 +1,209 @@
+use path::builder::*;
+use math::*;
+
+use std::ops::Range;
+use std::mem;
+
+#[derive(Clone, Debug)]
+struct SubPathInfo {
+    range: Range<usize>,
+    is_closed: bool,
+}
+
+pub struct FlattenedPath {
+    points: Vec<Point>,
+    sub_paths: Vec<SubPathInfo>,
+}
+
+impl FlattenedPath {
+    pub fn new() -> Self {
+        FlattenedPath {
+            points: Vec::new(),
+            sub_paths: Vec::new(),
+        }
+    }
+
+    pub fn builder() -> Builder {
+        Builder::new()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.points.is_empty()
+    }
+
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    pub fn sub_paths(&self) -> SubPaths {
+        SubPaths {
+            points: &self.points,
+            sub_paths: &self.sub_paths,
+        }
+    }
+
+    pub fn sub_path(&self, index: usize) -> SubPath {
+        SubPath {
+            points: &self.points[self.sub_paths[index].range.clone()],
+            is_closed: self.sub_paths[index].is_closed,
+        }
+    }
+
+    pub fn num_sub_paths(&self) -> usize {
+        self.sub_paths.len()
+    }
+}
+
+pub struct SubPaths<'l> {
+    points: &'l[Point],
+    sub_paths: &'l[SubPathInfo],
+}
+
+impl<'l> SubPaths<'l> {
+    pub fn all_points(&self) -> &[Point] {
+        &self.points[self.sub_paths[0].range.clone()]
+    }
+
+    pub fn sub_path(&self, index: usize) -> SubPath<'l> {
+        SubPath {
+            points: &self.points[self.sub_paths[index].range.clone()],
+            is_closed: self.sub_paths[index].is_closed,
+        }
+    }
+
+    pub fn num_sub_paths(&self) -> usize {
+        self.sub_paths.len()
+    }
+}
+
+impl<'l> Iterator for SubPaths<'l> {
+    type Item = SubPath<'l>;
+    fn next(&mut self) -> Option<SubPath<'l>> {
+        if self.sub_paths.is_empty() {
+            return None;
+        }
+
+        let sp = self.sub_paths[0].clone();
+        self.sub_paths = &self.sub_paths[1..];
+
+        Some(SubPath{
+            points: &self.points[sp.range],
+            is_closed: sp.is_closed,
+        })
+    }
+}
+
+pub struct SubPath<'l> {
+    points: &'l[Point],
+    is_closed: bool,
+}
+
+impl<'l> SubPath<'l> {
+    pub fn points(&self) -> &'l[Point] {
+        self.points
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.is_closed
+    }
+}
+
+pub struct Builder {
+    points: Vec<Point>,
+    sub_paths: Vec<SubPathInfo>,
+    sp_start: usize,
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Builder {
+            points: Vec::new(),
+            sub_paths: Vec::new(),
+            sp_start: 0,
+        }
+    }
+
+    pub fn build(self) -> FlattenedPath {
+        FlattenedPath {
+            points: self.points,
+            sub_paths: self.sub_paths,
+        }
+    }
+
+    pub fn with_svg(self, tolerance: f32) -> SvgPathBuilder<FlatteningBuilder<Self>> {
+        SvgPathBuilder::new(FlatteningBuilder::new(self, tolerance))
+    }
+
+    pub fn polygon(&mut self, points: &[Point]) {
+        if points.is_empty() {
+            return;
+        }
+
+        let start = self.points.len();
+        self.points.extend_from_slice(points);
+        let end = self.points.len();
+
+        self.sub_paths.push(SubPathInfo {
+            range: start..end,
+            is_closed: true,
+        });
+    }
+}
+
+impl FlatPathBuilder for Builder {
+    type PathType = FlattenedPath;
+
+    fn move_to(&mut self, to: Point) {
+        nan_check(to);
+        let sp_end = self.points.len();
+        if self.sp_start != sp_end {
+            self.sub_paths.push(SubPathInfo {
+                range: self.sp_start..sp_end,
+                is_closed: false,
+            });
+        }
+        self.sp_start = sp_end;
+        self.points.push(to);
+    }
+
+    fn line_to(&mut self, to: Point) {
+        nan_check(to);
+        self.points.push(to);
+    }
+
+    fn close(&mut self) {
+        let sp_end = self.points.len();
+        if self.sp_start != sp_end {
+            self.sub_paths.push(SubPathInfo {
+                range: self.sp_start..sp_end,
+                is_closed: true,
+            });
+        }
+        self.sp_start = sp_end;
+    }
+
+    fn current_position(&self) -> Point {
+        self.points.last().cloned().unwrap_or(Point::new(0.0, 0.0))
+    }
+
+    fn build(self) -> FlattenedPath {
+        FlattenedPath {
+            points: self.points,
+            sub_paths: self.sub_paths,
+        }
+    }
+
+    fn build_and_reset(&mut self) -> FlattenedPath {
+        self.sp_start = 0;
+        FlattenedPath {
+            points: mem::replace(&mut self.points, Vec::new()),
+            sub_paths: mem::replace(&mut self.sub_paths, Vec::new()),
+        }
+    }
+}
+
+#[inline]
+fn nan_check(p: Point) {
+    debug_assert!(!p.x.is_nan());
+    debug_assert!(!p.y.is_nan());
+}

--- a/tess2/src/flattened_path.rs
+++ b/tess2/src/flattened_path.rs
@@ -10,12 +10,15 @@ struct SubPathInfo {
     is_closed: bool,
 }
 
+/// A path data structure for pre-flattened paths and polygons.
+#[derive(Clone)]
 pub struct FlattenedPath {
     points: Vec<Point>,
     sub_paths: Vec<SubPathInfo>,
 }
 
 impl FlattenedPath {
+    /// Creates an empty path.
     pub fn new() -> Self {
         FlattenedPath {
             points: Vec::new(),
@@ -23,18 +26,22 @@ impl FlattenedPath {
         }
     }
 
+    /// Creates a builder for flattened paths.
     pub fn builder() -> Builder {
         Builder::new()
     }
 
+    /// Returns whether the path is empty.
     pub fn is_empty(&self) -> bool {
         self.points.is_empty()
     }
 
+    /// Returns a slice of all the points in the path.
     pub fn points(&self) -> &[Point] {
         &self.points
     }
 
+    /// Returns an iterator over the sub-paths.
     pub fn sub_paths(&self) -> SubPaths {
         SubPaths {
             points: &self.points,
@@ -42,6 +49,7 @@ impl FlattenedPath {
         }
     }
 
+    /// Returns the nth sub-paths.
     pub fn sub_path(&self, index: usize) -> SubPath {
         SubPath {
             points: &self.points[self.sub_paths[index].range.clone()],
@@ -49,11 +57,13 @@ impl FlattenedPath {
         }
     }
 
+    /// The number of sub-paths.
     pub fn num_sub_paths(&self) -> usize {
         self.sub_paths.len()
     }
 }
 
+/// An iterator of the sub paths of a flattened path.
 pub struct SubPaths<'l> {
     points: &'l[Point],
     sub_paths: &'l[SubPathInfo],
@@ -93,21 +103,25 @@ impl<'l> Iterator for SubPaths<'l> {
     }
 }
 
+/// An iterator over the points of a sub-path.
 pub struct SubPath<'l> {
     points: &'l[Point],
     is_closed: bool,
 }
 
 impl<'l> SubPath<'l> {
+    /// Returns a slice of the points of this sub-path.
     pub fn points(&self) -> &'l[Point] {
         self.points
     }
 
+    /// Returns whether this sub-path is closed.
     pub fn is_closed(&self) -> bool {
         self.is_closed
     }
 }
 
+/// A builder for flattened paths.
 pub struct Builder {
     points: Vec<Point>,
     sub_paths: Vec<SubPathInfo>,
@@ -134,6 +148,7 @@ impl Builder {
         SvgPathBuilder::new(FlatteningBuilder::new(self, tolerance))
     }
 
+    /// Add a closed polygon to the path.
     pub fn polygon(&mut self, points: &[Point]) {
         if points.is_empty() {
             return;

--- a/tess2/src/lib.rs
+++ b/tess2/src/lib.rs
@@ -1,3 +1,85 @@
+#![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
+
+//! Alternative fill tessellation implementation using
+//! [libtess2](https://github.com/memononen/libtess2).
+//!
+//! # Lyon libtess2 wrapper
+//!
+//! This crate provides an alternative path fill tessellator implemented
+//! as a wrapper of the [libtess2](https://github.com/memononen/libtess2)
+//! C library.
+//!
+//! The goal of this crate is to provide an alternative tessellator for
+//! the potential cases where lyon_tessellation::FillTessellator is lacking
+//! in features or robustness, and have something to compare the latter
+//! against.
+//!
+//! ## Comparison with [lyon_tessellation::FillTessellator](https://docs.rs/lyon_tessellation/)
+//!
+//! Advantages:
+//!
+//! - Supports the `NonZero` fill rule.
+//! - More robust against precision errors when paths have many self
+//!   intersections very close to each other.
+//!
+//! Disdvantages:
+//!
+//! - About twice slower than lyon_tessellation's fill tessellator.
+//! - Does not support computing vertex normals.
+//! - Wrapper around a C library (as opposed to pure rust with no
+//!   unsafe code).
+//!
+//! ## API
+//!
+//! In order to avoid any overhead, this crate introduces the
+//! FlattenedPath type which stores already-flattened paths
+//! in the memory layout expected by libtess2.
+//! Instead of working with a `GeometryBuilder` like the tessellators
+//! in `lyon_tessellation`, this tessellator uses a `GeometryReceiver`
+//! trait that corresponds to the way libtess2 exposes its output.
+//!
+//! ## Example
+//!
+//! ```
+//! extern crate lyon_tess2 as tess2;
+//! use tess2::{FillTessellator, FillOptions};
+//! use tess2::math::{Point, point};
+//! use tess2::path::default::Path;
+//! use tess2::path::builder::*;
+//! use tess2::path::iterator::*;
+//! use tess2::flattened_path::FlattenedPath;
+//! use tess2::tessellation::geometry_builder::*;
+//!
+//! fn main() {
+//!     // Create a simple path.
+//!     let mut path_builder = Path::builder();
+//!     path_builder.move_to(point(0.0, 0.0));
+//!     path_builder.line_to(point(1.0, 2.0));
+//!     path_builder.line_to(point(2.0, 0.0));
+//!     path_builder.line_to(point(1.0, 1.0));
+//!     path_builder.close();
+//!     let path = path_builder.build();
+//!
+//!     // Create the destination vertex and index buffers.
+//!     let mut buffers: VertexBuffers<Point> = VertexBuffers::new();
+//!
+//!     {
+//!         // Create the tessellator.
+//!         let mut tessellator = FillTessellator::new();
+//!
+//!         // Compute the tessellation.
+//!         let result = tessellator.tessellate_path(
+//!             path.path_iter(),
+//!             &FillOptions::default(),
+//!             &mut simple_builder(&mut buffers)
+//!         );
+//!         assert!(result.is_ok());
+//!     }
+//!     println!("The generated vertices are: {:?}.", &buffers.vertices[..]);
+//!     println!("The generated indices are: {:?}.", &buffers.indices[..]);
+//!
+//! }
+//! ```
 
 pub extern crate tess2_sys;
 pub extern crate lyon_tessellation as tessellation;
@@ -9,3 +91,4 @@ mod tessellator;
 pub mod flattened_path;
 
 pub use tessellator::FillTessellator;
+pub use tessellation::FillOptions;

--- a/tess2/src/lib.rs
+++ b/tess2/src/lib.rs
@@ -1,0 +1,11 @@
+
+pub extern crate tess2_sys;
+pub extern crate lyon_tessellation as tessellation;
+pub use tessellation::path;
+pub use tessellation::geom;
+pub use tessellation::math;
+
+mod tessellator;
+pub mod flattened_path;
+
+pub use tessellator::FillTessellator;

--- a/tess2/src/tessellator.rs
+++ b/tess2/src/tessellator.rs
@@ -9,6 +9,12 @@ use path::builder::*;
 use std::slice;
 use std::os::raw::c_void;
 
+/// A fill tessellator implemented on top of [libtess2](https://github.com/memononen/libtess2).
+///
+/// When in doubt it is usually preferable to use
+/// [lyon_tessellation](https://docs.rs/lyon_tessellation/)'s `FillTessellator`.
+/// However in some cases, for example when the `NonZero` fill rule
+/// is needed, This tessellator provides a good fallback.
 pub struct FillTessellator {
     tess: *mut TESStesselator,
 }
@@ -47,6 +53,7 @@ impl FillTessellator {
         )
     }
 
+    /// Compute the tessellation from a pre-flattened path.
     pub fn tessellate_flattened_path(
         &mut self,
         path: &FlattenedPath,

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -208,7 +208,7 @@ pub use path_fill::*;
 pub use path_stroke::*;
 
 #[doc(inline)]
-pub use geometry_builder::{GeometryBuilder, VertexBuffers, BuffersBuilder, VertexConstructor, Count};
+pub use geometry_builder::{GeometryBuilder, GeometryReceiver, VertexBuffers, BuffersBuilder, VertexConstructor, Count};
 
 /// Left or right.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -232,7 +232,6 @@ enum PointType { In, Out, OnEdge(Side) }
 /// let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
 ///
 /// {
-///     // Create the destination vertex and index buffers.
 ///     let mut vertex_builder = simple_builder(&mut buffers);
 ///
 ///     // Create the tessellator.


### PR DESCRIPTION
It will be useful to have another tessellator to compare the first one with, and offer an alternative for cases where the primary tessellator falls down.

## Advantages of libtess2

 - seems to be more robust when dealing with paths with a lot of self-intersections at the same place (will confirm that when I have it integrated with the fuzzer),
 - supports more fill rules,

## Disadvantages

 - about twice slower,
 - doesn't support computing normals,
 - wrapper around unsafe C library (vs pure rust and no unsafe blocks).
