### PR TITLE
Use the even-odd fill rule in tess2's benchmark.

### DIFF
--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -191,7 +191,7 @@ fn cmp_01_libtess2_rust_logo(bench: &mut Bencher) {
                     );
                 }
                 let res = tessTesselate(tess,
-                    TessWindingRule::TESS_WINDING_NONZERO,
+                    TessWindingRule::TESS_WINDING_ODD,
                     TessElementType::TESS_POLYGONS,
                     3,
                     2,


### PR DESCRIPTION
The benchmark was setting libtess2 up with the non-zero fill rule which lyon's tessellator doesn't support yet, not great when comparing scores. That said, the performance didn't change.