### PR TITLE
Begin improving the error handling story.

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -43,4 +43,5 @@ pub struct FuzzCmd {
     pub min_points: Option<u32>,
     pub max_points: Option<u32>,
     pub tessellator: Tessellator,
+    pub ignore_errors: bool,
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -118,6 +118,10 @@ fn main() {
                 .value_name("TESSELLATOR")
                 .takes_value(true)
             )
+            .arg(Arg::with_name("IGNORE_ERRORS")
+                .long("ignore-errors")
+                .help("Try to continue when encoutering errors unless it is a panic.")
+            )
         )
         .subcommand(
             declare_tess_params(SubCommand::with_name("show"))
@@ -187,6 +191,7 @@ fn main() {
             min_points: fuzz_matches.value_of("MIN_POINTS").and_then(|str_val| str_val.parse::<u32>().ok()),
             max_points: fuzz_matches.value_of("MAX_POINTS").and_then(|str_val| str_val.parse::<u32>().ok()),
             tessellator: get_tessellator(fuzz_matches),
+            ignore_errors: fuzz_matches.is_present("IGNORE_ERRORS"),
         });
     }
 

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -498,6 +498,9 @@ pub struct FillOptions {
     /// Default value: `false`.
     pub assume_no_intersections: bool,
 
+    /// What to do if the tessellator detects an error.
+    pub on_error: OnError,
+
     // To be able to add fields without making it a breaking change, add an empty private field
     // which makes it impossible to create a FillOptions without the calling constructor.
     _private: (),
@@ -518,6 +521,7 @@ impl FillOptions {
         fill_rule: FillOptions::DEFAULT_FILL_RULE,
         compute_normals: true,
         assume_no_intersections: false,
+        on_error: OnError::DEFAULT,
         _private: (),
     };
 
@@ -536,13 +540,13 @@ impl FillOptions {
     pub fn non_zero() -> Self {
         let mut options = FillOptions::DEFAULT;
         options.fill_rule = FillRule::NonZero;
-        return options;
+        options
     }
 
     #[inline]
     pub fn with_tolerance(mut self, tolerance: f32) -> Self {
         self.tolerance = tolerance;
-        return self;
+        self
     }
 
     #[inline]
@@ -554,13 +558,47 @@ impl FillOptions {
     #[inline]
     pub fn assume_no_intersections(mut self) -> Self {
         self.assume_no_intersections = true;
-        return self;
+        self
+    }
+
+    #[inline]
+    pub fn on_error(mut self, policy: OnError) -> Self {
+        self.on_error = policy;
+        self
     }
 }
 
 impl Default for FillOptions {
     fn default() -> Self { FillOptions::DEFAULT }
 }
+
+/// Defines the tessellator the should try to behave when detecting
+/// an error.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum OnError {
+    /// Panic as soon as the error is detected.
+    ///
+    /// Most suitabke for testing.
+    Panic,
+    /// Interrupt tesselation and return an error.
+    Stop,
+    /// Attempt to continue if possible, stop otherwise.
+    ///
+    /// The resulting tessellation may be locallt incorrect.
+    Recover,
+}
+
+impl OnError {
+    #[cfg(test)]
+    const DEFAULT: Self = OnError::Panic;
+    #[cfg(not(test))]
+    const DEFAULT: Self = OnError::Stop;
+}
+
+impl Default for OnError {
+    fn default() -> Self { OnError::DEFAULT }
+}
+
 
 #[test]
 fn test_without_miter_limit(){


### PR DESCRIPTION
This adds an `OnError` setting that controls how the tessellator should behave when detecting an error. This can be set to:

- `Panic` to panic as early as possible, ideal for debugging the tessellator.
- `Stop` to interrupt the tessellation and return an error.
- `Recover` to attempt to continue the tessellation with the risk that the output might be locally incorrect, and also return an error at the end.

Most users will go with either `Stop` or `Recover` depending on their needs, while people working on the tessellator itself will prefer `Panic`.