### PR TITLE
Avoid direct use of Float whenever possible

### DIFF
--- a/geom/src/cubic_bezier.rs
+++ b/geom/src/cubic_bezier.rs
@@ -1,5 +1,5 @@
 use {Line, LineSegment, LineEquation};
-use scalar::{Scalar, Float};
+use scalar::Scalar;
 use generic_math::{Point, Vector, Rect, rect, Transform2D};
 use arrayvec::ArrayVec;
 use flatten_cubic::{flatten_cubic_bezier, find_cubic_bezier_inflection_points};
@@ -187,8 +187,8 @@ impl<S: Scalar> CubicBezierSegment<S> {
             baseline.signed_distance_to_point(&self.ctrl2),
         );
 
-        d1 = Float::min(d1, S::zero());
-        d2 = Float::max(d2, S::zero());
+        d1 = S::min(d1, S::zero());
+        d2 = S::max(d2, S::zero());
 
         let frac_3_4 = S::constant(3.0/4.0);
 
@@ -775,7 +775,7 @@ fn is_linear() {
     for _ in 0..100 {
         for i in 0..10 {
             for j in 0..10 {
-                let (sin, cos) = Float::sin_cos(angle);
+                let (sin, cos) = f64::sin_cos(angle);
                 let endpoint = Vector::new(cos * 100.0, sin * 100.0);
                 let curve = CubicBezierSegment {
                     from: center - endpoint,

--- a/geom/src/line.rs
+++ b/geom/src/line.rs
@@ -1,4 +1,4 @@
-use scalar::{Scalar, Float};
+use scalar::Scalar;
 use generic_math::{Point, point, Vector, vector, Rect, Size, Transform2D};
 use segment::{Segment, FlatteningStep, BoundingRect};
 use monotonic::MonotonicSegment;
@@ -189,7 +189,7 @@ impl<S: Scalar> LineSegment<S> {
         }
 
         let sign_v1_cross_v2 = v1_cross_v2.signum();
-        let abs_v1_cross_v2 = Float::abs(v1_cross_v2);
+        let abs_v1_cross_v2 = v1_cross_v2.abs();
 
         let v3 = other.from - self.from;
 
@@ -321,7 +321,7 @@ pub struct LineEquation<S> {
 impl<S: Scalar> LineEquation<S> {
     pub fn new(a: S, b: S, c: S) -> Self {
         debug_assert!(a != S::zero() || b != S::zero());
-        let div = S::one() / Float::sqrt(a * a + b * b);
+        let div = S::one() / (a * a + b * b).sqrt();
         LineEquation { a: a * div, b: b * div, c: c * div }
     }
 
@@ -348,7 +348,7 @@ impl<S: Scalar> LineEquation<S> {
 
     #[inline]
     pub fn distance_to_point(&self, p: &Point<S>) -> S {
-        Float::abs(self.signed_distance_to_point(p))
+        self.signed_distance_to_point(p).abs()
     }
 
     #[inline]
@@ -588,7 +588,7 @@ fn solve_y_for_x() {
 
     let mut angle = 0.1;
     for _ in 0..100 {
-        let (sin, cos) = Float::sin_cos(angle);
+        let (sin, cos) = f64::sin_cos(angle);
         let line = Line {
             point: Point::new(-1000.0, 600.0),
             vector: Vector::new(cos * 100.0, sin * 100.0),

--- a/geom/src/monotonic.rs
+++ b/geom/src/monotonic.rs
@@ -1,5 +1,5 @@
 use segment::{Segment, BoundingRect};
-use scalar::{Scalar, Float, NumCast};
+use scalar::{Scalar, NumCast};
 use generic_math::{Point, Vector, Rect};
 use std::ops::Range;
 use arrayvec::ArrayVec;
@@ -8,7 +8,7 @@ use {QuadraticBezierSegment, CubicBezierSegment};
 use std::f64;
 
 pub(crate) trait MonotonicSegment {
-    type Scalar: Float;
+    type Scalar: Scalar;
     fn solve_t_for_x(&self, x: Self::Scalar, t_range: Range<Self::Scalar>, tolerance: Self::Scalar) -> Self::Scalar;
 }
 

--- a/geom/src/quadratic_bezier.rs
+++ b/geom/src/quadratic_bezier.rs
@@ -653,13 +653,11 @@ fn fat_line() {
 
 #[test]
 fn is_linear() {
-    use scalar::Float;
-
     let mut angle = 0.0;
     let center = Point::new(1000.0, -700.0);
     for _ in 0..100 {
         for i in 0..10 {
-            let (sin, cos) = Float::sin_cos(angle);
+            let (sin, cos) = f64::sin_cos(angle);
             let endpoint = Vector::new(cos * 100.0, sin * 100.0);
             let curve = QuadraticBezierSegment {
                 from: center - endpoint,

--- a/geom/src/segment.rs
+++ b/geom/src/segment.rs
@@ -1,11 +1,11 @@
-use scalar::{Float, One};
+use scalar::{Scalar, One};
 use generic_math::{Point, Vector, Rect};
 
 use std::ops::Range;
 
 /// Common APIs to segment types.
 pub trait Segment: Copy + Sized {
-    type Scalar: Float;
+    type Scalar: Scalar;
 
     /// Start of the curve.
     fn from(&self) -> Point<Self::Scalar>;
@@ -53,7 +53,7 @@ pub trait Segment: Copy + Sized {
 }
 
 pub trait BoundingRect {
-    type Scalar: Float;
+    type Scalar: Scalar;
 
     /// Returns a rectangle that contains the curve.
     fn bounding_rect(&self) -> Rect<Self::Scalar>;
@@ -117,13 +117,13 @@ where T: FlatteningStep
 ///
 /// The iterator starts at the first point *after* the origin of the curve and ends at the
 /// destination.
-pub struct Flattened<S: Float, T> {
+pub struct Flattened<S, T> {
     curve: T,
     tolerance: S,
     done: bool,
 }
 
-impl<S: Float, T: FlatteningStep> Flattened<S, T> {
+impl<S: Scalar, T: FlatteningStep> Flattened<S, T> {
     pub fn new(curve: T, tolerance: S) -> Self {
         assert!(tolerance > S::zero());
         Flattened {
@@ -134,7 +134,7 @@ impl<S: Float, T: FlatteningStep> Flattened<S, T> {
     }
 }
 
-impl<S: Float, T: FlatteningStep<Scalar=S>> Iterator for Flattened<S, T>
+impl<S: Scalar, T: FlatteningStep<Scalar=S>> Iterator for Flattened<S, T>
 {
     type Item = Point<S>;
     fn next(&mut self) -> Option<Point<S>> {
@@ -151,7 +151,7 @@ impl<S: Float, T: FlatteningStep<Scalar=S>> Iterator for Flattened<S, T>
     }
 }
 
-pub(crate) fn approximate_length_from_flattening<S: Float, T>(curve: &T, tolerance: S) -> S
+pub(crate) fn approximate_length_from_flattening<S: Scalar, T>(curve: &T, tolerance: S) -> S
 where T: FlattenedForEach<Scalar=S>
 {
     let mut start = curve.from();

--- a/geom/src/utils.rs
+++ b/geom/src/utils.rs
@@ -3,12 +3,12 @@ use generic_math::{Point, Vector, vector, Angle};
 use arrayvec::ArrayVec;
 
 #[inline]
-pub fn min_max<S: Float>(a: S, b: S) -> (S, S) {
+pub fn min_max<S: Scalar>(a: S, b: S) -> (S, S) {
     if a < b { (a, b) } else { (b, a) }
 }
 
 #[inline]
-pub fn tangent<S: Float>(v: Vector<S>) -> Vector<S> {
+pub fn tangent<S: Scalar>(v: Vector<S>) -> Vector<S> {
     vector(-v.y, v.x)
 }
 
@@ -93,7 +93,7 @@ pub fn cubic_polynomial_roots<S: Scalar>(a: S, b: S, c: S, d: S) -> ArrayVec<[S;
         }
     } else {
         let theta = (delta1 / (-delta0 * delta0 * delta0).sqrt()).acos();
-        let two_sqrt_delta0 = S::TWO * Float::sqrt(-delta0);
+        let two_sqrt_delta0 = S::TWO * (-delta0).sqrt();
         result.push(two_sqrt_delta0 * Float::cos(theta * frac_1_3) - bn * frac_1_3);
         result.push(two_sqrt_delta0 * Float::cos((theta + S::TWO * S::PI()) * frac_1_3) - bn * frac_1_3);
         result.push(two_sqrt_delta0 * Float::cos((theta + S::FOUR * S::PI()) * frac_1_3) - bn * frac_1_3);


### PR DESCRIPTION
Since we have our own `Scalar` trait now, I think we should try to use it everywhere.
(In some cases its not possible due to name conflicts, i.e. `cos()`.)