### PR TITLE
Add more feature flags and some missing serialization.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,10 +355,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "euclid"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -776,6 +775,7 @@ version = "0.9.1"
 dependencies = [
  "lyon_extra 0.9.0",
  "lyon_svg 0.9.0",
+ "lyon_tess2 0.9.1",
  "lyon_tessellation 0.9.1",
 ]
 
@@ -789,8 +789,6 @@ dependencies = [
  "gfx_window_glutin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon 0.9.1",
- "lyon_extra 0.9.0",
- "lyon_tess2 0.9.1",
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -807,7 +805,7 @@ name = "lyon_geom"
 version = "0.9.0"
 dependencies = [
  "arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.16.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1575,7 +1573,7 @@ dependencies = [
 "checksum dwmapi-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b44b6442aeab12e609aee505bd1066bdfd36b79c3fe5aad604aae91537623e76"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
-"checksum euclid 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3555d2929527adbdf8011bc8091a06c9091a72f00fcc67d22b3a3799c2a757"
+"checksum euclid 0.16.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d33ed9630f5f7a86abb0849e96a585922cc5a640478a36f05f74d96a22655f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,16 @@ path = "src/lib.rs"
 
 [features]
 serialization = ["lyon_tessellation/serialization"]
+svg = ["lyon_svg"]
+extra = ["lyon_extra"]
+libtess2 = ["lyon_tess2"]
 
 [dependencies]
 
 lyon_tessellation = { version = "0.9.1", path = "tessellation/" }
-lyon_extra = { version = "0.9.0", path = "extra/" }
-lyon_svg = { version = "0.9.0", path = "svg/" }
+lyon_extra = { version = "0.9.0", optional = true, path = "extra/" }
+lyon_svg = { version = "0.9.0", optional = true, path = "svg/" }
+lyon_tess2 = { version = "0.9.1", optional = true, path = "tess2/" }
 
 [workspace]
 members = [

--- a/bench/tess/Cargo.toml
+++ b/bench/tess/Cargo.toml
@@ -11,6 +11,6 @@ name = "tess_bench"
 libtess2 = ["tess2-sys"]
 
 [dependencies]
-lyon = { path = "../../" }
+lyon = { path = "../../", features = ["extra"] }
 bencher = "0.1.1"
 tess2-sys = { version = "0.0.1", optional = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,9 +9,7 @@ name = "lyon"
 path = "src/main.rs"
 
 [dependencies]
-lyon = { path = "../" }
-lyon_extra = { path = "../extra" }
-lyon_tess2 = { path = "../tess2" }
+lyon = { path = "../", features = ["svg", "extra", "libtess2"]}
 clap = "2.19.2"
 rand = "0.3"
 

--- a/cli/src/fuzzing.rs
+++ b/cli/src/fuzzing.rs
@@ -7,11 +7,11 @@ use lyon::tessellation::{
     FillOptions, FillTessellator,
     OnError,
 };
-use lyon_extra::debugging::find_reduced_test_case;
+use lyon::extra::debugging::find_reduced_test_case;
 use rand;
 use commands::{FuzzCmd, Tessellator};
 use std::cmp::{min, max};
-use tess2;
+use lyon::tess2;
 
 fn random_point() -> Point {
     point(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,5 @@
 extern crate clap;
 extern crate lyon;
-extern crate lyon_extra;
-extern crate lyon_tess2 as tess2;
 extern crate rand;
 #[macro_use]
 extern crate gfx;
@@ -23,7 +21,7 @@ use std::io::{Read, Write, stdout, stderr};
 use lyon::svg::path_utils::build_path;
 use lyon::path::default::Path;
 use lyon::tessellation::{FillOptions, StrokeOptions, LineJoin, LineCap};
-use lyon_extra::debugging::find_reduced_test_case;
+use lyon::extra::debugging::find_reduced_test_case;
 
 fn main() {
     let matches = App::new("Lyon command-line interface")

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -4,7 +4,7 @@ use lyon::tessellation::basic_shapes::*;
 use lyon::tessellation::{FillTessellator, StrokeTessellator, FillOptions};
 use lyon::tessellation;
 use commands::{TessellateCmd, AntiAliasing, RenderCmd, Tessellator};
-use tess2;
+use lyon::tess2;
 
 use gfx;
 use gfx_window_glutin;

--- a/cli/src/tessellate.rs
+++ b/cli/src/tessellate.rs
@@ -5,7 +5,7 @@ use lyon::tessellation::{
     FillVertex, StrokeVertex,
     StrokeTessellator, FillTessellator
 };
-use tess2;
+use lyon::tess2;
 use std::io;
 
 #[derive(Debug)]

--- a/geom/Cargo.toml
+++ b/geom/Cargo.toml
@@ -16,7 +16,7 @@ name = "lyon_geom"
 serialization = ["serde"]
 
 [dependencies]
-euclid = "0.16.2"
+euclid = "0.16.4"
 arrayvec = "0.4"
 num-traits = "0.1.40"
 serde = {version = "1.0", optional = true, features = ["serde_derive"] }

--- a/geom/src/arc.rs
+++ b/geom/src/arc.rs
@@ -14,7 +14,7 @@ pub type Flattened<S> = segment::Flattened<S, Arc<S>>;
 
 /// An ellipic arc curve segment using the SVG notation.
 #[derive(Copy, Clone, Debug, PartialEq)]
-//#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct SvgArc<S> {
     pub from: Point<S>,
     pub to: Point<S>,
@@ -25,7 +25,7 @@ pub struct SvgArc<S> {
 
 /// An ellipic arc curve segment.
 #[derive(Copy, Clone, Debug, PartialEq)]
-//#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct Arc<S> {
     pub center: Point<S>,
     pub radii: Vector<S>,

--- a/path/src/events.rs
+++ b/path/src/events.rs
@@ -3,6 +3,7 @@ use ArcFlags;
 use geom::{LineSegment, QuadraticBezierSegment, CubicBezierSegment, Arc};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum SvgEvent {
     MoveTo(Point),
     RelativeMoveTo(Vector),
@@ -26,6 +27,7 @@ pub enum SvgEvent {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum PathEvent {
     MoveTo(Point),
     LineTo(Point),
@@ -35,6 +37,7 @@ pub enum PathEvent {
     Close,
 }
 
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum QuadraticEvent {
     MoveTo(Point),
@@ -43,6 +46,7 @@ pub enum QuadraticEvent {
     Close,
 }
 
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum FlattenedEvent {
     MoveTo(Point),
@@ -96,6 +100,7 @@ impl QuadraticEvent {
     }
 }
 
+// TODO: serialization
 #[derive(Copy, Clone, Debug)]
 pub enum Segment {
     Line(LineSegment<f32>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,15 @@
 //! use lyon::tessellation::FillTessellator;
 //! ```
 //!
+//! # Feature flags
+//!
+//! serialization using serde can be enabled on each crate using the
+//! `serialization` feature flag (disabled by default).
+//!
+//! When using the main crate `lyon`, the `lyon_svg`, `lyon_tess2` and
+//! `lyon_extra` dependencies are disabled by default. They can be added
+//! with the feature flags `svg`, `tess2` and `extra`.
+//!
 //! # Additional documentation and links
 //!
 //! * [very basic gfx-rs example](https://github.com/nical/lyon/tree/master/examples/gfx_basic).
@@ -166,13 +175,15 @@
 //!
 
 pub extern crate lyon_tessellation;
-pub extern crate lyon_extra;
-pub extern crate lyon_svg;
+#[cfg(feature = "extra")] pub extern crate lyon_extra;
+#[cfg(feature = "svg")] pub extern crate lyon_svg;
+#[cfg(feature = "libtess2")] pub extern crate lyon_tess2;
 
 pub use lyon_tessellation as tessellation;
 pub use tessellation::path as path;
 pub use tessellation::geom as geom;
-pub use lyon_extra as extra;
-pub use lyon_svg as svg;
+#[cfg(feature = "svg")] pub use lyon_svg as svg;
+#[cfg(feature = "extra")] pub use lyon_extra as extra;
+#[cfg(feature = "libtess2")] pub use lyon_tess2 as tess2;
 
 pub use geom::math;

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -216,6 +216,7 @@ pub use geometry_builder::{GeometryBuilder, GeometryReceiver, VertexBuffers, Buf
 
 /// Left or right.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum Side {
     Left,
     Right,
@@ -236,6 +237,7 @@ impl Side {
 
 /// Vertex produced by the stroke tessellators.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct StrokeVertex {
     /// Position of the vertex (on the path, the consumer should move the point along
     /// the provided normal in order to give the stroke a width).
@@ -251,6 +253,7 @@ pub struct StrokeVertex {
 
 /// Vertex produced by the fill tessellators.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct FillVertex {
     /// Position of the vertex (on the path).
     pub position: math::Point,
@@ -286,6 +289,7 @@ pub struct FillVertex {
 ///   </g>
 /// </svg>
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum LineCap {
     /// The stroke for each subpath does not extend beyond its two endpoints.
     /// A zero length subpath will therefore not have any stroke.
@@ -308,6 +312,7 @@ pub enum LineCap {
 ///
 /// See: https://svgwg.org/specs/strokes/#StrokeLinejoinProperty
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum LineJoin {
     /// A sharp corner is to be used to join path segments.
     Miter,
@@ -325,6 +330,7 @@ pub enum LineJoin {
 
 /// Parameters for the tessellator.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct StrokeOptions {
     /// What cap to use at the start of each sub-path.
     ///
@@ -460,13 +466,15 @@ impl StrokeOptions {
 ///
 /// See the SVG specification.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum FillRule {
     EvenOdd,
     NonZero,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
 /// Parameters for the fill tessellator.
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct FillOptions {
     /// Maximum allowed distance to the path when building an approximation.
     ///
@@ -579,6 +587,7 @@ impl Default for FillOptions {
 /// Defines the tessellator the should try to behave when detecting
 /// an error.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum OnError {
     /// Panic as soon as the error is detected.
     ///


### PR DESCRIPTION
This makes `lyon::svg`, `lyon::extra` and `lyon::tess2` accessible behind feature flags. This removes the burden of choosing what is or is not critical to include in the root crate, and uses get to choose.
The PR also adds a few missing serde derives.