### PR TITLE
Fix incorrect arc conversion from endpoint to center notation.

### DIFF
--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -110,6 +110,7 @@ mod scalar {
     pub(crate) use euclid::Trig;
 
     use std::fmt::{Display, Debug};
+    use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
 
     pub trait Scalar
         : Float
@@ -119,6 +120,10 @@ mod scalar {
         + Display
         + Debug
         + Trig
+        + AddAssign
+        + SubAssign
+        + MulAssign
+        + DivAssign
     {
         const HALF: Self;
         const ZERO: Self;


### PR DESCRIPTION
The problem was found while investigating issue #318. The arc conversion math was wrong which badly messed some combinations of parameters up but not some others, and since most of the code relies on the center notation, it messed a lot of SVG import up. 