### PR TITLE
Add svg_render example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,11 @@ members = [
     "cli",
     "examples/gfx_advanced",
     "examples/gfx_basic",
-    "examples/intersections",
-    "examples/walk_path",
     "examples/glium_basic",
     "examples/glium_basic_shapes",
+    "examples/intersections",
+    "examples/svg_render",
+    "examples/walk_path",
     "bench/svg_bench",
     "bench/tess",
     "bench/geom"

--- a/examples/svg_render/Cargo.toml
+++ b/examples/svg_render/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "svg_render"
+description = "A simple svg renderer based on resvg"
+version = "0.1.0"
+authors = ["Roland Kovacs <zen3ger@gmail.com>"]
+workspace = "../.."
+
+[[bin]]
+name = "svg_render"
+path = "src/main.rs"
+
+[dependencies]
+lyon = { path = "../../", features = ["extra"] }
+resvg = { git = "https://github.com/RazrFalcon/resvg.git" }
+
+cgmath = "0.16.0"
+gfx = "0.16.1"
+gfx_device_gl = "0.14.4"
+gfx_window_glutin = "0.18.0"
+glutin = "0.10.0"

--- a/examples/svg_render/src/lib.rs
+++ b/examples/svg_render/src/lib.rs
@@ -1,0 +1,23 @@
+extern crate cgmath;
+#[macro_use]
+extern crate gfx;
+extern crate gfx_device_gl;
+extern crate gfx_window_glutin;
+extern crate glutin;
+extern crate lyon;
+extern crate resvg;
+
+use resvg::tree::Color;
+
+mod path_convert;
+mod stroke_convert;
+pub mod render;
+
+pub use self::path_convert::convert_path;
+pub use self::stroke_convert::convert_stroke;
+
+pub const FALLBACK_COLOR: Color = Color {
+    red: 0,
+    green: 0,
+    blue: 0,
+};

--- a/examples/svg_render/src/main.rs
+++ b/examples/svg_render/src/main.rs
@@ -1,0 +1,243 @@
+extern crate cgmath;
+extern crate gfx;
+extern crate gfx_window_glutin;
+extern crate glutin;
+extern crate lyon;
+extern crate resvg;
+
+extern crate svg_render;
+
+use gfx::traits::{Device, FactoryExt};
+use glutin::GlContext;
+use lyon::tessellation::geometry_builder::{BuffersBuilder, VertexBuffers};
+use lyon::tessellation::{FillOptions, FillTessellator, StrokeTessellator};
+use resvg::tree::TreeExt;
+
+use svg_render::FALLBACK_COLOR;
+use svg_render::render::{self, fill_pipeline, ColorFormat, DepthFormat, Scene, VertexCtor};
+use svg_render::{convert_path, convert_stroke};
+
+const WINDOW_SIZE: f32 = 800.0;
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.len() != 2 {
+        println!("Usage:\n\tsvg_render <file-name>");
+        return;
+    }
+
+    let mut fill_tess = FillTessellator::new();
+    let mut stroke_tess = StrokeTessellator::new();
+    let mut mesh = VertexBuffers::new();
+
+    let opt = resvg::Options::default();
+    let rtree = resvg::parse_rtree_from_file(&args[1], &opt).unwrap();
+
+    let view_box = rtree.svg_node().view_box;
+    let mut transform = None;
+    for node in rtree.root().descendants() {
+        if let resvg::tree::NodeKind::Path(ref p) = *node.value() {
+            // use the first transform component
+            if transform == None {
+                transform = Some(node.value().transform());
+            }
+
+            // get paint or create default one
+            let (paint, opacity) = match p.fill {
+                Some(f) => (f.paint, f.opacity),
+                None => (resvg::tree::Paint::Color(FALLBACK_COLOR), 1.0),
+            };
+
+            // fall back to always use color fill
+            // no gradients (yet?)
+            let color = match paint {
+                resvg::tree::Paint::Color(c) => c,
+                _ => FALLBACK_COLOR,
+            };
+
+            let _ = fill_tess
+                .tessellate_path(
+                    convert_path(p).path_iter(),
+                    &FillOptions::tolerance(0.01),
+                    &mut BuffersBuilder::new(&mut mesh, VertexCtor::new(color, opacity)),
+                )
+                .expect("Error during tesselation!");
+
+            if let Some(ref stroke) = p.stroke {
+                let (stroke_color, stroke_opts) = convert_stroke(stroke);
+                let opacity = stroke.opacity;
+                let _ = stroke_tess.tessellate_path(
+                    convert_path(p).path_iter(),
+                    &stroke_opts.with_tolerance(0.01),
+                    &mut BuffersBuilder::new(&mut mesh, VertexCtor::new(stroke_color, opacity)),
+                );
+            }
+        }
+    }
+
+    println!(
+        "Finished tesselation: {} vertices, {} indices",
+        mesh.vertices.len(),
+        mesh.indices.len()
+    );
+    println!("Use arrow keys to pan, quare brackes to zoom.");
+
+    // get svg view box parameters
+    let vb_width = view_box.size.width as f32;
+    let vb_height = view_box.size.height as f32;
+    let scale = vb_width / vb_height;
+
+    // get x and y translation
+    let (x_trans, y_trans) = if let Some(transform) = transform {
+        (transform.e as f32, transform.f as f32)
+    } else {
+        (0.0, 0.0)
+    };
+
+    // set window scale
+    let (width, height) = if scale < 1.0 {
+        (WINDOW_SIZE, WINDOW_SIZE * scale)
+    } else {
+        (WINDOW_SIZE, WINDOW_SIZE / scale)
+    };
+
+    // init the scene object
+    // use the viewBox, if available, to set the initial zoom and pan
+    let pan = [vb_width / -2.0 + x_trans, vb_height / -2.0 + y_trans];
+    let zoom = 2.0 / f32::max(vb_width, vb_height);
+    let proj = cgmath::ortho(-scale, scale, -1.0, 1.0, -1.0, 1.0);
+    let mut scene = Scene::new(zoom, pan, proj);
+
+    println!("Original {:?}", scene);
+
+    // set up event processing and rendering
+    let mut event_loop = glutin::EventsLoop::new();
+    let glutin_builder = glutin::WindowBuilder::new()
+        .with_dimensions(width as u32, height as u32)
+        .with_decorations(true)
+        .with_title("SVG Renderer");
+
+    let context = glutin::ContextBuilder::new().with_vsync(true);
+
+    let (window, mut device, mut factory, mut main_fbo, mut main_depth) =
+        gfx_window_glutin::init::<ColorFormat, DepthFormat>(glutin_builder, context, &event_loop);
+
+    let shader = factory
+        .link_program(
+            render::VERTEX_SHADER.as_bytes(),
+            render::FRAGMENT_SHADER.as_bytes(),
+        )
+        .unwrap();
+
+    let pso = factory
+        .create_pipeline_from_program(
+            &shader,
+            gfx::Primitive::TriangleList,
+            gfx::state::Rasterizer::new_fill(),
+            fill_pipeline::new(),
+        )
+        .unwrap();
+
+    let (vbo, ibo) = factory.create_vertex_buffer_with_slice(&mesh.vertices[..], &mesh.indices[..]);
+
+    let mut cmd_queue: gfx::Encoder<_, _> = factory.create_command_buffer().into();
+
+    let constants = factory.create_constant_buffer(1);
+
+    loop {
+        if !update_inputs(&mut scene, &mut event_loop) {
+            break;
+        }
+
+        gfx_window_glutin::update_views(&window, &mut main_fbo, &mut main_depth);
+
+        cmd_queue.clear(&main_fbo.clone(), [1.0, 1.0, 1.0, 1.0]);
+
+        cmd_queue.update_constant_buffer(&constants, &scene.into());
+        cmd_queue.draw(
+            &ibo,
+            &pso,
+            &fill_pipeline::Data {
+                vbo: vbo.clone(),
+                out_color: main_fbo.clone(),
+                constants: constants.clone(),
+            },
+        );
+        cmd_queue.flush(&mut device);
+
+        window.swap_buffers().unwrap();
+
+        device.cleanup();
+    }
+}
+
+fn update_inputs(scene: &mut Scene, event_loop: &mut glutin::EventsLoop) -> bool {
+    use glutin::Event;
+    use glutin::VirtualKeyCode;
+    use glutin::ElementState::Pressed;
+
+    let mut status = true;
+
+    event_loop.poll_events(|event| match event {
+        Event::WindowEvent {
+            event: glutin::WindowEvent::Closed,
+            ..
+        } => {
+            println!("Window Closed!");
+            status = false;
+        }
+        Event::WindowEvent {
+            event: glutin::WindowEvent::Resized(w, h),
+            ..
+        } => {
+            let scl = w as f32 / h as f32;
+            scene.update_proj(cgmath::ortho(-scl, scl, -1.0, 1.0, -1.0, 1.0));
+        }
+        Event::WindowEvent {
+            event:
+                glutin::WindowEvent::KeyboardInput {
+                    input:
+                        glutin::KeyboardInput {
+                            state: Pressed,
+                            virtual_keycode: Some(key),
+                            ..
+                        },
+                    ..
+                },
+            ..
+        } => {
+            println!("Preparing to update {:?}", scene);
+
+            match key {
+                VirtualKeyCode::Escape => {
+                    println!("Closing");
+                    status = false;
+                }
+                VirtualKeyCode::LBracket => {
+                    scene.zoom *= 0.8;
+                }
+                VirtualKeyCode::RBracket => {
+                    scene.zoom *= 1.2;
+                }
+                VirtualKeyCode::Left => {
+                    scene.pan[0] -= 0.2 / scene.zoom;
+                }
+                VirtualKeyCode::Right => {
+                    scene.pan[0] += 0.2 / scene.zoom;
+                }
+                VirtualKeyCode::Up => {
+                    scene.pan[1] -= 0.2 / scene.zoom;
+                }
+                VirtualKeyCode::Down => {
+                    scene.pan[1] += 0.2 / scene.zoom;
+                }
+                _key => {}
+            };
+
+            println!("Updated {:?}", scene);
+        }
+        _ => {}
+    });
+
+    status
+}

--- a/examples/svg_render/src/path_convert.rs
+++ b/examples/svg_render/src/path_convert.rs
@@ -1,0 +1,49 @@
+use std::iter;
+use std::slice;
+
+use lyon::path::PathEvent;
+use lyon::path::iterator::PathIter;
+use lyon::geom::euclid::{TypedPoint2D, UnknownUnit};
+
+use resvg::tree::{Path, PathSegment};
+
+fn point(x: f64, y: f64) -> TypedPoint2D<f32, UnknownUnit> {
+    TypedPoint2D::new(x as f32, y as f32)
+}
+
+// map resvg::tree::PathSegment to lyon::path::PathEvent
+fn as_event(ps: &PathSegment) -> PathEvent {
+    match *ps {
+        PathSegment::MoveTo { x, y } => PathEvent::MoveTo(point(x, y)),
+        PathSegment::LineTo { x, y } => PathEvent::LineTo(point(x, y)),
+        PathSegment::CurveTo {
+            x1,
+            y1,
+            x2,
+            y2,
+            x,
+            y,
+        } => PathEvent::CubicTo(point(x1, y1), point(x2, y2), point(x, y)),
+        PathSegment::ClosePath => PathEvent::Close,
+    }
+}
+
+pub struct PathConv<'a>(SegmentIter<'a>);
+
+// alias for the iterator returned by resvg::tree::Path::iter()
+type SegmentIter<'a> = slice::Iter<'a, PathSegment>;
+
+// alias for our `interface` iterator
+type PathConvIter<'a> = iter::Map<SegmentIter<'a>, fn(&PathSegment) -> PathEvent>;
+
+// provide a function which gives back a PathIter which is compatible with
+// tesselators, so we don't have to implement the PathIterator trait
+impl<'a> PathConv<'a> {
+    pub fn path_iter(self) -> PathIter<PathConvIter<'a>> {
+        PathIter::new(self.0.map(as_event))
+    }
+}
+
+pub fn convert_path<'a>(p: &'a Path) -> PathConv<'a> {
+    PathConv(p.segments.iter())
+}

--- a/examples/svg_render/src/render.rs
+++ b/examples/svg_render/src/render.rs
@@ -1,0 +1,153 @@
+use cgmath;
+use gfx;
+
+use lyon::tessellation::geometry_builder::VertexConstructor;
+use lyon::tessellation;
+use resvg::tree::Color;
+
+pub type ColorFormat = gfx::format::Rgba8;
+pub type DepthFormat = gfx::format::DepthStencil;
+
+gfx_defines!{
+    vertex GpuFillVertex {
+        position: [f32; 2] = "a_position",
+        color: [f32; 4] = "a_color",
+    }
+
+    constant Globals {
+        zoom: [f32; 2] = "u_zoom",
+        pan: [f32; 2] = "u_pan",
+        proj: [[f32;4];4] = "u_proj",
+    }
+
+    pipeline fill_pipeline {
+        vbo: gfx::VertexBuffer<GpuFillVertex> = (),
+        out_color: gfx::RenderTarget<ColorFormat> = "out_color",
+        constants: gfx::ConstantBuffer<Globals> = "Globals",
+    }
+}
+
+fn gpu_color(color: Color, opacity: f32) -> [f32; 4] {
+    [
+        f32::from(color.red) / 255.0,
+        f32::from(color.green) / 255.0,
+        f32::from(color.blue) / 255.0,
+        opacity,
+    ]
+}
+
+// This struct carries the data for each vertex
+pub struct VertexCtor {
+    fill: Color,
+    opacity: f32,
+}
+
+impl VertexCtor {
+    pub fn new(c: Color, o: f64) -> Self {
+        Self {
+            fill: c,
+            opacity: o as f32,
+        }
+    }
+}
+
+// handle conversions to the gfx vertex format
+impl VertexConstructor<tessellation::FillVertex, GpuFillVertex> for VertexCtor {
+    fn new_vertex(&mut self, vertex: tessellation::FillVertex) -> GpuFillVertex {
+        assert!(!vertex.position.x.is_nan());
+        assert!(!vertex.position.y.is_nan());
+
+        GpuFillVertex {
+            position: vertex.position.to_array(),
+            color: gpu_color(self.fill, self.opacity),
+        }
+    }
+}
+
+impl VertexConstructor<tessellation::StrokeVertex, GpuFillVertex> for VertexCtor {
+    fn new_vertex(&mut self, vertex: tessellation::StrokeVertex) -> GpuFillVertex {
+        assert!(!vertex.position.x.is_nan());
+        assert!(!vertex.position.y.is_nan());
+
+        GpuFillVertex {
+            position: vertex.position.to_array(),
+            color: gpu_color(self.fill, self.opacity),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+// default scene has all values set to zero
+pub struct Scene {
+    pub zoom: f32,
+    pub pan: [f32; 2],
+    pub proj: [[f32; 4]; 4],
+}
+
+impl Scene {
+    pub fn new(zoom: f32, pan: [f32; 2], proj: cgmath::Matrix4<f32>) -> Self {
+        let proj = Self::convert_mat4(proj);
+        Self {
+            zoom: zoom,
+            pan: pan,
+            proj: proj,
+        }
+    }
+    pub fn update_proj(&mut self, proj: cgmath::Matrix4<f32>) {
+        self.proj = Self::convert_mat4(proj);
+    }
+    fn convert_mat4(m: cgmath::Matrix4<f32>) -> [[f32; 4]; 4] {
+        [
+            [m.x.x, m.x.y, m.x.z, m.x.w],
+            [m.y.x, m.y.y, m.y.z, m.y.w],
+            [m.z.x, m.z.y, m.z.z, m.z.w],
+            [m.w.x, m.w.y, m.w.z, m.w.w],
+        ]
+    }
+}
+
+// extract the relevant globals from the scene struct
+impl From<Scene> for Globals {
+    fn from(scene: Scene) -> Self {
+        Globals {
+            zoom: [scene.zoom, scene.zoom],
+            pan: scene.pan,
+            proj: scene.proj,
+        }
+    }
+}
+
+pub static VERTEX_SHADER: &'static str = "
+    #version 150
+    #line 266
+
+    uniform Globals {
+        vec2 u_zoom;
+        vec2 u_pan;
+        mat4 u_proj;
+    };
+
+    in vec2 a_position;
+    in vec4 a_color;
+
+    out vec4 v_color;
+
+    void main() {
+        gl_Position = u_proj * vec4((a_position + u_pan) * u_zoom, 0.0, 1.0);
+        gl_Position.y *= -1.0;
+        v_color = a_color;
+    }
+";
+
+// The fragment shader is dead simple. It just applies the color computed in the vertex shader.
+// A more advanced renderer would probably compute texture coordinates in the vertex shader and
+// sample the color from a texture here.
+pub static FRAGMENT_SHADER: &'static str = "
+    #version 150
+    in vec4 v_color;
+    out vec4 out_color;
+
+    void main() {
+        out_color = v_color;
+    }
+";

--- a/examples/svg_render/src/stroke_convert.rs
+++ b/examples/svg_render/src/stroke_convert.rs
@@ -1,0 +1,28 @@
+use resvg::tree::{self, Color, Paint, Stroke};
+use lyon::tessellation::{self, StrokeOptions};
+
+use super::FALLBACK_COLOR;
+
+pub fn convert_stroke(s: &Stroke) -> (Color, StrokeOptions) {
+    let color = match s.paint {
+        Paint::Color(c) => c,
+        _ => FALLBACK_COLOR,
+    };
+    let linecap = match s.linecap {
+        tree::LineCap::Butt => tessellation::LineCap::Butt,
+        tree::LineCap::Square => tessellation::LineCap::Square,
+        tree::LineCap::Round => tessellation::LineCap::Round,
+    };
+    let linejoin = match s.linejoin {
+        tree::LineJoin::Miter => tessellation::LineJoin::Miter,
+        tree::LineJoin::Bevel => tessellation::LineJoin::Bevel,
+        tree::LineJoin::Round => tessellation::LineJoin::Round,
+    };
+
+    let opt = StrokeOptions::tolerance(0.01)
+        .with_line_width(s.width as f32)
+        .with_line_cap(linecap)
+        .with_line_join(linejoin);
+
+    (color, opt)
+}

--- a/examples/svg_render/test.svg
+++ b/examples/svg_render/test.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="437.6221"
+   height="405.85663"
+   viewBox="0 0 115.78751 107.3829"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
+   sodipodi:docname="test.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2"
+     inkscape:cx="57.344022"
+     inkscape:cy="251.12355"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="3200"
+     inkscape:window-height="1688"
+     inkscape:window-x="0"
+     inkscape:window-y="56"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-47.020246,-94.435636)">
+    <circle
+       style="fill:#0050ff;fill-opacity:1;stroke:#000000;stroke-width:2.64583325;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path10"
+       cx="80.093163"
+       cy="127.50855"
+       r="31.75" />
+    <rect
+       style="fill:#ff004d;fill-opacity:1;stroke:#000000;stroke-width:2.64583325;stroke-miterlimit:4;stroke-dasharray:5.29166673, 2.64583336;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect822"
+       width="49.136902"
+       height="49.136902"
+       x="105.79553"
+       y="103.99844"
+       rx="0.70004249"
+       ry="0.70004249" />
+    <path
+       sodipodi:type="star"
+       style="fill:#00ff4d;fill-opacity:1;stroke:none;stroke-width:2.64583302;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path956"
+       sodipodi:sides="3"
+       sodipodi:cx="81.789864"
+       sodipodi:cy="169.38155"
+       sodipodi:r1="39.231239"
+       sodipodi:r2="0.39231238"
+       sodipodi:arg1="2.1917024"
+       sodipodi:arg2="3.2389"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 58.966213,201.29034 6.60165,-67.62905 55.267647,39.53172 z"
+       inkscape:transform-center-x="-3.1555462"
+       inkscape:transform-center-y="-2.0813023" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffb84d;fill-opacity:1;stroke:#ffe100;stroke-width:1.32291663;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1556"
+       sodipodi:sides="20"
+       sodipodi:cx="123.11636"
+       sodipodi:cy="162.12714"
+       sodipodi:r1="39.031433"
+       sodipodi:r2="19.515717"
+       sodipodi:arg1="0.95007403"
+       sodipodi:arg2="1.1071537"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 145.81794,193.87759 -13.97397,-14.29502 3.05144,19.75621 -8.87262,-17.91356 -3.20292,19.73222 -2.90277,-19.7786 -9.14374,17.7767 3.35122,-19.70758 -14.18952,14.08109 9.27718,-17.70744 -17.84633,9.0071 14.29502,-13.97397 -19.756214,3.05145 17.913564,-8.87263 -19.732223,-3.20291 19.778603,-2.90278 -17.776704,-9.14374 19.707584,3.35122 -14.081086,-14.18952 17.707436,9.27718 -9.0071,-17.84633 13.97397,14.29503 -3.05145,-19.75622 8.87263,17.91357 3.20291,-19.73223 2.90278,19.77861 9.14374,-17.77671 -3.35122,19.70758 14.18952,-14.08108 -9.27718,17.70743 17.84633,-9.0071 -14.29503,13.97397 19.75622,-3.05144 -17.91357,8.87262 19.73223,3.20292 -19.77861,2.90277 17.77671,9.14374 -19.70758,-3.35122 14.08108,14.18952 -17.70743,-9.27718 z"
+       inkscape:transform-center-x="8.0729474"
+       inkscape:transform-center-y="-1.8924511" />
+  </g>
+</svg>


### PR DESCRIPTION
Based on the suggestions in #215 I've made an `svg_render` example.
It renders both shapes and strokes.

I couldn't figure out how to pass stroke styles from `resvg` to `lyon`. If someone knows, I'd be happy to add that too.