### PR TITLE
Remove extra path fills in the svg render example.

### DIFF
--- a/examples/svg_render/src/main.rs
+++ b/examples/svg_render/src/main.rs
@@ -57,26 +57,23 @@ fn main() {
                 transform = Some(node.value().transform());
             }
 
-            // get paint or create default one
-            let (paint, opacity) = match p.fill {
-                Some(f) => (f.paint, f.opacity),
-                None => (resvg::tree::Paint::Color(FALLBACK_COLOR), 1.0),
-            };
+            if let Some(fill) = p.fill {
+                // fall back to always use color fill
+                // no gradients (yet?)
+                let color = match fill.paint {
+                    resvg::tree::Paint::Color(c) => c,
+                    _ => FALLBACK_COLOR,
+                };
 
-            // fall back to always use color fill
-            // no gradients (yet?)
-            let color = match paint {
-                resvg::tree::Paint::Color(c) => c,
-                _ => FALLBACK_COLOR,
-            };
-
-            let _ = fill_tess
-                .tessellate_path(
+                fill_tess.tessellate_path(
                     convert_path(p).path_iter(),
                     &FillOptions::tolerance(0.01),
-                    &mut BuffersBuilder::new(&mut mesh, VertexCtor::new(color, opacity)),
-                )
-                .expect("Error during tesselation!");
+                    &mut BuffersBuilder::new(
+                        &mut mesh,
+                        VertexCtor::new(color, fill.opacity)
+                    ),
+                ).expect("Error during tesselation!");
+            }
 
             if let Some(ref stroke) = p.stroke {
                 let (stroke_color, stroke_opts) = convert_stroke(stroke);


### PR DESCRIPTION
The svg render example was filling every paths even those that had a stroke and not fill. With this the ghostscript tiger renders properly.