### PR TITLE
Use usvg instead of resvg, minor fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,18 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "resvg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "euclid 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon_geom 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "usvg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,12 +1071,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "svg_render"
 version = "0.1.0"
 dependencies = [
+ "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_device_gl 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_window_glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon 0.10.0",
- "resvg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "usvg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1570,7 +1559,6 @@ dependencies = [
 "checksum rctree 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1817e0f0056f95bce0d6ab1a5be62ca24bd756b5547c20637ef47cc9a2065f4b"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum resvg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa42b13bb57ff9f3ea7cdb6e1a57a084642ed3b43196cb50a21cb71cb591963a"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"

--- a/examples/svg_render/Cargo.toml
+++ b/examples/svg_render/Cargo.toml
@@ -12,8 +12,9 @@ path = "src/main.rs"
 [dependencies]
 lyon = { path = "../../", features = ["extra"] }
 
+clap = "2.19.2"
 gfx = "0.17.1"
 gfx_device_gl = "0.15.0"
 gfx_window_glutin = "0.20.0"
 glutin = "0.12.0"
-resvg = "0.2"
+usvg = "0.1.1"

--- a/examples/svg_render/src/path_convert.rs
+++ b/examples/svg_render/src/path_convert.rs
@@ -5,13 +5,13 @@ use lyon::math::Point;
 use lyon::path::PathEvent;
 use lyon::path::iterator::PathIter;
 
-use resvg::tree::{Path, PathSegment};
+use usvg::tree::{Path, PathSegment};
 
 fn point(x: f64, y: f64) -> Point {
     Point::new(x as f32, y as f32)
 }
 
-// Map resvg::tree::PathSegment to lyon::path::PathEvent
+// Map usvg::tree::PathSegment to lyon::path::PathEvent
 fn as_event(ps: &PathSegment) -> PathEvent {
     match *ps {
         PathSegment::MoveTo { x, y } => PathEvent::MoveTo(point(x, y)),
@@ -25,7 +25,7 @@ fn as_event(ps: &PathSegment) -> PathEvent {
 
 pub struct PathConv<'a>(SegmentIter<'a>);
 
-// Alias for the iterator returned by resvg::tree::Path::iter()
+// Alias for the iterator returned by usvg::tree::Path::iter()
 type SegmentIter<'a> = slice::Iter<'a, PathSegment>;
 
 // Alias for our `interface` iterator

--- a/examples/svg_render/src/render.rs
+++ b/examples/svg_render/src/render.rs
@@ -2,7 +2,7 @@ use gfx;
 
 use lyon::tessellation::geometry_builder::VertexConstructor;
 use lyon::tessellation;
-use resvg::tree::Color;
+use usvg::tree::Color;
 use Transform3D;
 
 pub type ColorFormat = gfx::format::Rgba8;
@@ -51,7 +51,7 @@ impl VertexCtor {
     }
 }
 
-// handle conversions to the gfx vertex format
+// Handle conversions to the gfx vertex format
 impl VertexConstructor<tessellation::FillVertex, GpuFillVertex> for VertexCtor {
     fn new_vertex(&mut self, vertex: tessellation::FillVertex) -> GpuFillVertex {
         assert!(!vertex.position.x.is_nan());
@@ -76,8 +76,8 @@ impl VertexConstructor<tessellation::StrokeVertex, GpuFillVertex> for VertexCtor
     }
 }
 
+// Default scene has all values set to zero
 #[derive(Copy, Clone, Debug, Default)]
-// default scene has all values set to zero
 pub struct Scene {
     pub zoom: f32,
     pub pan: [f32; 2],
@@ -99,7 +99,7 @@ impl Scene {
     }
 }
 
-// extract the relevant globals from the scene struct
+// Extract the relevant globals from the scene struct
 impl From<Scene> for Globals {
     fn from(scene: Scene) -> Self {
         Globals {

--- a/examples/svg_render/src/stroke_convert.rs
+++ b/examples/svg_render/src/stroke_convert.rs
@@ -1,4 +1,4 @@
-use resvg::tree::{self, Color, Paint, Stroke};
+use usvg::tree::{self, Color, Paint, Stroke};
 use lyon::tessellation::{self, StrokeOptions};
 
 use super::FALLBACK_COLOR;


### PR DESCRIPTION
Typo and zoom control char fixes.
Added option to set msaa from commandline.
Replace resvg with usvg.

Closes #349