### PR TITLE
Avoid unwrap when the option depends on floating point arithmetic.

### DIFF
--- a/geom/src/arc.rs
+++ b/geom/src/arc.rs
@@ -401,7 +401,7 @@ where
         let to = arc.center + v2;
         let l1 = Line { point: from, vector: arc.tangent_at_angle(a1) };
         let l2 = Line { point: to, vector: arc.tangent_at_angle(a2) };
-        let ctrl = l2.intersection(&l1).unwrap();
+        let ctrl = l2.intersection(&l1).unwrap_or(from);
 
         callback(&QuadraticBezierSegment { from , ctrl, to });
     }

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -838,19 +838,17 @@ impl<'l> StrokeBuilder<'l> {
             to: point(normal_limit.x + normal_limit.y, normal_limit.y - normal_limit.x)
         };
 
-        let l1 = LineSegment{
-            from : point(prev_normal.x, prev_normal.y),
-            to: point(normal.x, normal.y)
-        };
-        let l2 = LineSegment{
-            from: point(next_normal.x, next_normal.y),
-            to: point(normal.x, normal.y)
-        };
+        let prev_normal = prev_normal.to_point();
+        let next_normal = next_normal.to_point();
+        let normal = normal.to_point();
 
-        let i1 = l1.intersection(&normal_limit_perp).unwrap();
-        let i2 = l2.intersection(&normal_limit_perp).unwrap();
+        let l1 = LineSegment{ from : prev_normal, to: normal };
+        let l2 = LineSegment{ from: next_normal, to: normal };
 
-        (vector(i1.x, i1.y), vector(i2.x, i2.y))
+        let i1 = l1.intersection(&normal_limit_perp).unwrap_or(prev_normal).to_vector();
+        let i2 = l2.intersection(&normal_limit_perp).unwrap_or(next_normal).to_vector();
+
+        (i1, i2)
     }
 }
 


### PR DESCRIPTION
There are a few places in the code where we assume that there exist an intersection between lines but whether this intersection is really found relies on floating point arithmetic and computations with epsilon thresholds which is dangerous as shown by issue #351.

This removes the two places where we unconditionally `unwrap()` the result of some float math and provides a sensible default when the option is `None`.

Fixes #351.