### PR TITLE
Don't skip intersection checks when filling ellipses.

### DIFF
--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -686,9 +686,13 @@ pub fn fill_ellipse(
 
     let events = path.build();
 
+    // TODO: We could avoid checking for intersections, however the way we
+    // generate the path is a little silly and because of finite float precision,
+    // it will somtimes produce an intersection where the end of ellipse meets
+    // the beginning, which confuses the fill tessellator.
     FillTessellator::new().tessellate_events(
         &events,
-        &options.clone().assume_no_intersections(),
+        &options,
         output,
     ).unwrap()
 }
@@ -837,3 +841,15 @@ pub(crate) fn circle_flattening_step(radius:f32, tolerance: f32) -> f32 {
     2.0 * (2.0 * tolerance * radius - tolerance * tolerance).sqrt()
 }
 
+#[test]
+fn issue_358() {
+    use geometry_builder::NoOutput;
+
+    fill_ellipse(
+        point(25218.9902, 25669.6738),
+        vector(2.0, 2.0),
+        Angle { radians: 0.0 },
+        &FillOptions::tolerance(1.0),
+        &mut NoOutput::new(),
+    );
+}


### PR DESCRIPTION
The code to generate the tessellation of an ellipse is a bit silly: it first approximates the ellipse with quadratic bézier segments and then flattens it. This way we don't have to implement the math to flatten ellipses against a specific tolerance threshold. But as a result the flattened polygon can sometime have a very very small edge that causes an intersection/overlap where the beginning and end of the ellipse meet. This intersection is confusing the tessellator which is configured to not check for intersections.

The simple fix (what this PR does) is to re-enable handling intersections when tessellating ellipses but the proper fix would be to write a dedicated implementation of ellipse flattening that doesn't have this overlapping edge problem (someday maybe).

Fixes #358.