### PR TITLE
Don't start module documentation with a title.

### DIFF
--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -1,8 +1,10 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 
+//! Simple 2D geometric primitives on top of euclid.
+//!
 //! # Overview.
 //!
-//! This crate implements simple 2D geometric primitives on top of euclid:
+//! This crate implements some of the maths to work with:
 //!
 //! - lines and line segments,
 //! - quadratic and cubic bézier curves,

--- a/path/src/lib.rs
+++ b/path/src/lib.rs
@@ -1,9 +1,8 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 
-//! # Lyon path
+//! Data structures and traits to work with paths (vector graphics).
 //!
-//! A simple path data structure implementing the traits provided in the
-//! [builder](builder/index.html) and
+//! To build and consume paths, see the [builder](builder/index.html) and
 //! [iterator](iterator/index.html) modules.
 //!
 //! # Examples

--- a/svg/src/lib.rs
+++ b/svg/src/lib.rs
@@ -1,8 +1,7 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 
-//! #Lyon SVG
+//! Utilities to facilitate interfacing lyon with SVG.
 //!
-//! Utilities to facilitate interfacing with SVG.
 //! At the moment this is mostly a wrapper around the [svgparser](https://crates.io/crates/svgparser)
 //! crate.
 

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -1,8 +1,6 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 
-//! # Lyon Tessellation
-//!
-//! This crate implements tools to compute the tessellation of 2d paths fill and stroke operations, in order to render them efficiently on the GPU.
+//! Tessellation of 2D fill and stroke operations.
 //!
 //! <svg viewBox="0 0 600.0 300.0" height="300" width="600">
 //!   <g transform="translate(0,-752.36216)">


### PR DESCRIPTION
It confuses rustdoc.

Fixes #353.