### PR TITLE
Represent VertexId with u32 instead of u16

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ fn main() {
     struct MyVertex { position: [f32; 2], normal: [f32; 2] };
 
     // Will contain the result of the tessellation.
-    let mut geometry = VertexBuffers::new();
+    let mut geometry: VertexBuffers<MyVertex, u16> = VertexBuffers::new();
 
     let mut tessellator = FillTessellator::new();
 

--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -74,7 +74,7 @@ fn fill_tess_01_logo(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::with_capacity(512, 1450);
+            let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::with_capacity(512, 1450);
             tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
@@ -91,7 +91,7 @@ fn fill_tess_02_logo_no_normals(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::with_capacity(512, 1450);
+            let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::with_capacity(512, 1450);
             tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
@@ -108,7 +108,7 @@ fn fill_tess_03_logo_no_intersections(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
+            let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::new();
             tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
@@ -127,7 +127,7 @@ fn fill_tess_04_logo_no_normals_no_intersections(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::with_capacity(512, 1450);
+            let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::with_capacity(512, 1450);
             tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
@@ -144,7 +144,7 @@ fn fill_tess_05_logo_no_curve(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
+            let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::new();
             tess.tessellate_events(&events, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
@@ -227,7 +227,7 @@ fn cmp_02_lyon_rust_logo(bench: &mut Bencher) {
     bench.iter(|| {
         for _ in 0..N {
             let mut tess = FillTessellator::new();
-            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
+            let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::new();
             tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
@@ -267,7 +267,7 @@ fn fill_events_03_logo_with_tess(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
+            let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::new();
             tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
@@ -283,7 +283,7 @@ fn stroke_01_logo_miter(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let mut buffers: VertexBuffers<StrokeVertex> = VertexBuffers::with_capacity(1024, 3000);
+            let mut buffers: VertexBuffers<StrokeVertex, u16> = VertexBuffers::with_capacity(1024, 3000);
             tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers));
         }
     })
@@ -299,7 +299,7 @@ fn stroke_02_logo_bevel(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let mut buffers: VertexBuffers<StrokeVertex> = VertexBuffers::with_capacity(1024, 3000);
+            let mut buffers: VertexBuffers<StrokeVertex, u16> = VertexBuffers::with_capacity(1024, 3000);
             tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers));
         }
     })
@@ -315,7 +315,7 @@ fn stroke_03_logo_round(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let mut buffers: VertexBuffers<StrokeVertex> = VertexBuffers::with_capacity(1024, 3000);
+            let mut buffers: VertexBuffers<StrokeVertex, u16> = VertexBuffers::with_capacity(1024, 3000);
             tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers));
         }
     })

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -41,7 +41,7 @@ impl HatchBuilder for StrokeHatches {
 }
 
 pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
-    let mut geometry: VertexBuffers<GpuVertex> = VertexBuffers::new();
+    let mut geometry: VertexBuffers<GpuVertex, u16> = VertexBuffers::new();
     let mut stroke_width = 1.0;
     if let Some(options) = cmd.stroke {
         stroke_width = options.line_width;
@@ -97,7 +97,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         return;
     }
 
-    let mut bg_geometry: VertexBuffers<BgVertex> = VertexBuffers::new();
+    let mut bg_geometry: VertexBuffers<BgVertex, u16> = VertexBuffers::new();
     fill_rectangle(
         &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
         &FillOptions::default(),

--- a/cli/src/tessellate/format.rs
+++ b/cli/src/tessellate/format.rs
@@ -9,7 +9,7 @@ const DEFAULT_FMT: &str = "vertices: [@vertices{sep=, }{fmt=({position.x}, {posi
 pub fn format_output(
     fmt_string: Option<&str>,
     precision: Option<usize>,
-    buffers: &VertexBuffers<Point>,
+    buffers: &VertexBuffers<Point, u16>,
 ) -> String {
     let fmt = fmt_string.unwrap_or(DEFAULT_FMT).split('@');
     let extract = Regex::new(r"^(.*)\{sep=(.+?)\}\{fmt=(.*)\}$").unwrap();

--- a/cli/src/tessellate/mod.rs
+++ b/cli/src/tessellate/mod.rs
@@ -21,9 +21,9 @@ impl ::std::convert::From<::std::io::Error> for TessError {
     fn from(err: io::Error) -> Self { TessError::Io(err) }
 }
 
-pub fn tessellate_path(cmd: TessellateCmd) -> Result<VertexBuffers<Point>, TessError> {
+pub fn tessellate_path(cmd: TessellateCmd) -> Result<VertexBuffers<Point, u16>, TessError> {
 
-    let mut buffers: VertexBuffers<Point> = VertexBuffers::new();
+    let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
 
     if let Some(options) = cmd.fill {
 
@@ -62,7 +62,7 @@ pub fn tessellate_path(cmd: TessellateCmd) -> Result<VertexBuffers<Point>, TessE
 }
 
 pub fn write_output(
-    buffers: VertexBuffers<Point>,
+    buffers: VertexBuffers<Point, u16>,
     count: bool,
     fmt_string: Option<&str>,
     float_precision: Option<usize>,

--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
     build_logo_path(&mut builder);
     let path = builder.build();
 
-    let mut geometry: VertexBuffers<GpuVertex> = VertexBuffers::new();
+    let mut geometry: VertexBuffers<GpuVertex, u16> = VertexBuffers::new();
 
     let stroke_prim_id = 0;
     let fill_prim_id = 1;
@@ -87,7 +87,7 @@ fn main() {
         &mut BuffersBuilder::new(&mut geometry, WithId(stroke_prim_id as i32))
     );
 
-    let mut bg_geometry: VertexBuffers<BgVertex> = VertexBuffers::new();
+    let mut bg_geometry: VertexBuffers<BgVertex, u16> = VertexBuffers::new();
     fill_rectangle(
         &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
         &FillOptions::default(),

--- a/examples/gfx_basic/src/main.rs
+++ b/examples/gfx_basic/src/main.rs
@@ -53,7 +53,7 @@ fn main() {
 
     let mut tessellator = FillTessellator::new();
 
-    let mut mesh = VertexBuffers::new();
+    let mut mesh: VertexBuffers<GpuFillVertex, u16> = VertexBuffers::new();
 
     tessellator.tessellate_path(
         path.path_iter(),

--- a/examples/glium_basic/src/main.rs
+++ b/examples/glium_basic/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
     let path = builder.build();
 
     let mut tessellator = FillTessellator::new();
-    let mut mesh = VertexBuffers::new();
+    let mut mesh: VertexBuffers<Vertex, u16> = VertexBuffers::new();
     tessellator
         .tessellate_path(
             path.path_iter(),

--- a/examples/glium_basic_shapes/src/main.rs
+++ b/examples/glium_basic_shapes/src/main.rs
@@ -34,7 +34,7 @@ impl VertexConstructor<tessellation::StrokeVertex, Vertex> for VertexCtor {
 fn main() {
 
 
-    let mut mesh = VertexBuffers::new();
+    let mut mesh: VertexBuffers<Vertex, u16> = VertexBuffers::new();
 
     let fill_options = FillOptions::tolerance(0.01);
 

--- a/examples/intersections/src/main.rs
+++ b/examples/intersections/src/main.rs
@@ -80,7 +80,7 @@ fn main() {
     builder.relative_line_to(line.vector);
     let line_path = builder.build();
 
-    let mut geometry: VertexBuffers<GpuVertex> = VertexBuffers::new();
+    let mut geometry: VertexBuffers<GpuVertex, u16> = VertexBuffers::new();
 
     let line_id = 0;
     let bezier_id = 1;
@@ -118,7 +118,7 @@ fn main() {
         ),
     );
 
-    let mut bg_geometry: VertexBuffers<BgVertex> = VertexBuffers::new();
+    let mut bg_geometry: VertexBuffers<BgVertex, u16> = VertexBuffers::new();
     fill_rectangle(
         &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
         &FillOptions::default(),

--- a/examples/svg_render/src/main.rs
+++ b/examples/svg_render/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
 
     let mut fill_tess = FillTessellator::new();
     let mut stroke_tess = StrokeTessellator::new();
-    let mut mesh = VertexBuffers::new();
+    let mut mesh: VertexBuffers<_, u16> = VertexBuffers::new();
 
     let opt = usvg::Options::default();
     let rtree = usvg::Tree::from_file(&filename, &opt).unwrap();

--- a/examples/walk_path/src/main.rs
+++ b/examples/walk_path/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
 
     let arrow_path = builder.build();
 
-    let mut geometry: VertexBuffers<GpuVertex> = VertexBuffers::new();
+    let mut geometry: VertexBuffers<GpuVertex, u16> = VertexBuffers::new();
 
     FillTessellator::new().tessellate_path(
         arrow_path.path_iter(),
@@ -63,7 +63,7 @@ fn main() {
         &mut BuffersBuilder::new(&mut geometry, WithId(0))
     ).unwrap();
 
-    let mut bg_geometry: VertexBuffers<BgVertex> = VertexBuffers::new();
+    let mut bg_geometry: VertexBuffers<BgVertex, u16> = VertexBuffers::new();
     fill_rectangle(
         &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
         &FillOptions::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,12 +74,12 @@
 //! ```
 //! extern crate lyon;
 //! use lyon::math::rect;
-//! use lyon::tessellation::{VertexBuffers, FillOptions};
+//! use lyon::tessellation::{VertexBuffers, FillOptions, FillVertex};
 //! use lyon::tessellation::basic_shapes::*;
 //! use lyon::tessellation::geometry_builder::simple_builder;
 //!
 //! fn main() {
-//!     let mut geometry = VertexBuffers::new();
+//!     let mut geometry: VertexBuffers<FillVertex, u16> = VertexBuffers::new();
 //!
 //!     let options = FillOptions::tolerance(0.1);
 //!
@@ -128,7 +128,7 @@
 //!     struct MyVertex { position: [f32; 2], normal: [f32; 2] };
 //!
 //!     // Will contain the result of the tessellation.
-//!     let mut geometry = VertexBuffers::new();
+//!     let mut geometry: VertexBuffers<MyVertex, u16> = VertexBuffers::new();
 //!
 //!     let mut tessellator = FillTessellator::new();
 //!

--- a/tess2/src/lib.rs
+++ b/tess2/src/lib.rs
@@ -61,7 +61,7 @@
 //!     let path = path_builder.build();
 //!
 //!     // Create the destination vertex and index buffers.
-//!     let mut buffers: VertexBuffers<Point> = VertexBuffers::new();
+//!     let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
 //!
 //!     {
 //!         // Create the tessellator.

--- a/tess2/src/tessellator.rs
+++ b/tess2/src/tessellator.rs
@@ -34,7 +34,7 @@ impl FillTessellator {
         &mut self,
         it: Iter,
         options: &FillOptions,
-        output: &mut GeometryReceiver<Point, i32>,
+        output: &mut GeometryReceiver<Point>,
     ) -> Result<Count, ()>
     where
         Iter: PathIterator,
@@ -59,7 +59,7 @@ impl FillTessellator {
         &mut self,
         path: &FlattenedPath,
         options: &FillOptions,
-        output: &mut GeometryReceiver<Point, i32>,
+        output: &mut GeometryReceiver<Point>,
     ) -> Result<Count, ()> {
         self.prepare_path(path);
 
@@ -109,7 +109,7 @@ impl FillTessellator {
         }
     }
 
-    fn process_output(&mut self, output: &mut GeometryReceiver<Point, i32>) -> Count {
+    fn process_output(&mut self, output: &mut GeometryReceiver<Point>) -> Count {
         unsafe {
             let num_indices = tessGetElementCount(self.tess) as usize * 3;
             let num_vertices = tessGetElementCount(self.tess) as usize;
@@ -119,7 +119,7 @@ impl FillTessellator {
                 num_vertices
             );
             let indices = slice::from_raw_parts(
-                tessGetElements(self.tess),
+                tessGetElements(self.tess) as *const u32,
                 num_indices,
             );
 

--- a/tessellation/src/earcut_tests.rs
+++ b/tessellation/src/earcut_tests.rs
@@ -1306,7 +1306,7 @@ fn earcut_test_f32(path: &[&[[f32; 2]]]) {
 
 #[cfg(test)]
 fn tessellate_path(path: PathSlice, log: bool) -> Result<usize, FillError> {
-    let mut buffers: VertexBuffers<Vertex> = VertexBuffers::new();
+    let mut buffers: VertexBuffers<Vertex, u16> = VertexBuffers::new();
     {
         let mut vertex_builder = simple_builder(&mut buffers);
         let mut tess = FillTessellator::new();

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -9,7 +9,7 @@ use {FillTessellator, FillError, FillOptions, FillVertex};
 type Vertex = FillVertex;
 
 fn tessellate_path(path: PathSlice, log: bool) -> Result<usize, FillError> {
-    let mut buffers: VertexBuffers<Vertex> = VertexBuffers::new();
+    let mut buffers: VertexBuffers<Vertex, u16> = VertexBuffers::new();
     {
         let mut vertex_builder = simple_builder(&mut buffers);
         let mut tess = FillTessellator::new();

--- a/tessellation/src/fuzz_tests.rs
+++ b/tessellation/src/fuzz_tests.rs
@@ -8,7 +8,7 @@ use FillOptions;
 use OnError;
 
 fn tessellate_path(path: PathSlice, log: bool, on_error: OnError) -> Result<usize, FillError> {
-    let mut buffers: VertexBuffers<Vertex> = VertexBuffers::new();
+    let mut buffers: VertexBuffers<Vertex, u16> = VertexBuffers::new();
     {
         let mut vertex_builder = simple_builder(&mut buffers);
         let mut tess = FillTessellator::new();

--- a/tessellation/src/geometry_builder.rs
+++ b/tessellation/src/geometry_builder.rs
@@ -305,12 +305,12 @@ pub trait GeometryBuilder<Input> {
 ///
 /// This is primarily intended for efficient interaction with the libtess2 tessellator
 /// from the `lyon_tess2` crate.
-pub trait GeometryReceiver<Vertex, Index> {
+pub trait GeometryReceiver<Vertex> {
 
     fn set_geometry(
         &mut self,
         vertices: &[Vertex],
-        indices: &[Index]
+        indices: &[u32]
     );
 }
 
@@ -479,19 +479,18 @@ where
     }
 }
 
-impl<'l, VertexType, IndexType, InputVertex, InputIndex, Ctor> GeometryReceiver<InputVertex, InputIndex>
+impl<'l, VertexType, IndexType, InputVertex, Ctor> GeometryReceiver<InputVertex>
     for BuffersBuilder<'l, VertexType, IndexType, InputVertex, Ctor>
 where
     VertexType: 'l + Clone,
     IndexType: From<VertexId>,
     Ctor: VertexConstructor<InputVertex, VertexType>,
     InputVertex: Clone,
-    InputIndex: Into<VertexId> + Clone,
 {
     fn set_geometry(
         &mut self,
         vertices: &[InputVertex],
-        indices: &[InputIndex]
+        indices: &[u32]
     ) {
         for v in vertices {
             let vertex = self.vertex_constructor.new_vertex(v.clone());
@@ -539,8 +538,8 @@ impl<T> GeometryBuilder<T> for NoOutput
     fn abort_geometry(&mut self) {}
 }
 
-impl<V, I> GeometryReceiver<V, I> for NoOutput {
-    fn set_geometry(&mut self, _vertices: &[V], _indices: &[I]) {}
+impl<V> GeometryReceiver<V> for NoOutput {
+    fn set_geometry(&mut self, _vertices: &[V], _indices: &[u32]) {}
 }
 
 // /// An extension to GeometryBuilder that can handle quadratic bézier segments.

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -238,7 +238,7 @@ enum PointType { In, Out, OnEdge(Side) }
 /// let path = path_builder.build();
 ///
 /// // Create the destination vertex and index buffers.
-/// let mut buffers: VertexBuffers<FillVertex> = VertexBuffers::new();
+/// let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::new();
 ///
 /// {
 ///     let mut vertex_builder = simple_builder(&mut buffers);
@@ -1765,7 +1765,7 @@ fn test_monotone_tess() {
 
 #[cfg(test)]
 fn tessellate_path(path: PathSlice, log: bool) -> Result<usize, FillError> {
-    let mut buffers: VertexBuffers<Vertex> = VertexBuffers::new();
+    let mut buffers: VertexBuffers<Vertex, u16> = VertexBuffers::new();
     {
         let mut vertex_builder = simple_builder(&mut buffers);
         let mut tess = FillTessellator::new();

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -60,7 +60,7 @@ use std::f32::consts::PI;
 /// let path = path_builder.build();
 ///
 /// // Create the destination vertex and index buffers.
-/// let mut buffers: VertexBuffers<StrokeVertex> = VertexBuffers::new();
+/// let mut buffers: VertexBuffers<StrokeVertex, u16> = VertexBuffers::new();
 ///
 /// {
 ///     // Create the destination vertex and index buffers.
@@ -985,7 +985,7 @@ fn test_path(
         }
     }
 
-    let mut buffers: VertexBuffers<Vertex> = VertexBuffers::new();
+    let mut buffers: VertexBuffers<Vertex, u16> = VertexBuffers::new();
 
     let mut tess = StrokeTessellator::new();
     let count = tess.tessellate_path(


### PR DESCRIPTION
One of the most noticeable breaking change in the next version. A lot of users will probably want to keep using u16 index buffers, so the `VertexBuffers` and BuffersBuilder` helper types have an extra type parameter and will do the conversion under the hood.
To preserve the previous behavior, use `VertexBuffers<Vertex, u16>` where `VertexBuffers<Vertex>` was previously used.