### PR TITLE
Version 0.11.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,29 @@
 ## Change log
 
+### v0.11.0 (2018-07-05)
+  - [tessellation] Move the VertexId representation from u16 to u32.
+  - [tessellation] Fix a circle tessellation bug with large tolerance values.
+  - [tessellation] Add a fast path for ellipses when the radii are equal.
+  - [algorithms] Added the lyon_algorithms crate.
+  - [algorithms] Implement a hatching pattern fill algorithm.
+  - [algorithms] Implement a dotted pattern fill algorithm.
+  - [algorithms] Implement path bounding rectangles.
+  - [algorithms] Implement rectangle fitting transform computation.
+  - [algorithms] Move path walking to the algorithms crate.
+  - [geom] Implement callback based iteration over the monotonic parts of an arc.
+  - [geom] Add LineSegment::set_length.
+  - [geom] Fix an elliptic arc bug.
+  - [geom] Implement precise elliptic arc bounding rectangle.
+  - [cli] Add support for custom formatting in the tessellate command.
+  - [cli] Allow changing the background in the show command.
+  - [cli] Automatically position the view in the show command.
+  - [examples] Add a simple SVG rendering example.
+  - [misc] Update usvg and euclid dependencies.
+
 ### v0.10.0 (2018-02-28)
   - [geom] Fix several arc bugs.
   - [geom] Implement a much better cubic to quadratic bézier approximation.
-  - [geom] Implement iteating over the monotonic parts of a bézier curve.
+  - [geom] Implement iterating over the monotonic parts of a bézier curve.
   - [geom] A few API changes.
   - [lyon] Make serde optional for all crates ("serialization" feature flags).
   - [tessellation] Implement better error handling.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "gfx_device_gl 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_window_glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
 ]
 
 [[package]]
@@ -446,7 +446,7 @@ name = "geom_bench"
 version = "0.0.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
 ]
 
 [[package]]
@@ -468,7 +468,7 @@ dependencies = [
  "gfx_device_gl 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_window_glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
 ]
 
 [[package]]
@@ -479,7 +479,7 @@ dependencies = [
  "gfx_device_gl 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_window_glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
 ]
 
 [[package]]
@@ -590,7 +590,7 @@ name = "glium_basic"
 version = "0.1.0"
 dependencies = [
  "glium 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
 ]
 
 [[package]]
@@ -598,7 +598,7 @@ name = "glium_basic_shapes"
 version = "0.1.0"
 dependencies = [
  "glium 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
 ]
 
 [[package]]
@@ -658,7 +658,7 @@ dependencies = [
  "gfx_device_gl 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_window_glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
 ]
 
 [[package]]
@@ -760,20 +760,20 @@ dependencies = [
 
 [[package]]
 name = "lyon"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lyon_algorithms 0.11.0",
- "lyon_extra 0.10.0",
- "lyon_svg 0.10.0",
- "lyon_tess2 0.10.0",
- "lyon_tessellation 0.10.0",
+ "lyon_extra 0.11.0",
+ "lyon_svg 0.11.0",
+ "lyon_tess2 0.11.0",
+ "lyon_tessellation 0.11.0",
 ]
 
 [[package]]
 name = "lyon_algorithms"
 version = "0.11.0"
 dependencies = [
- "lyon_path 0.10.0",
+ "lyon_path 0.11.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -787,27 +787,17 @@ dependencies = [
  "gfx_window_glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_extra"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
- "lyon_path 0.10.0",
- "lyon_svg 0.10.0",
-]
-
-[[package]]
-name = "lyon_geom"
-version = "0.10.0"
-dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon_path 0.11.0",
+ "lyon_svg 0.11.0",
 ]
 
 [[package]]
@@ -821,36 +811,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "lyon_path"
-version = "0.10.0"
+name = "lyon_geom"
+version = "0.11.0"
 dependencies = [
- "lyon_geom 0.10.0",
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lyon_path"
+version = "0.11.0"
+dependencies = [
+ "lyon_geom 0.11.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_svg"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
- "lyon_path 0.10.0",
+ "lyon_path 0.11.0",
  "svgparser 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_tess2"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
- "lyon_tessellation 0.10.0",
+ "lyon_tessellation 0.11.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
- "lyon_extra 0.10.0",
- "lyon_path 0.10.0",
+ "lyon_extra 0.11.0",
+ "lyon_path 0.11.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "sid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1139,7 +1139,7 @@ dependencies = [
  "gfx_device_gl 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_window_glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
  "usvg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1259,7 +1259,7 @@ name = "tess_bench"
 version = "0.0.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.10.0",
+ "lyon 0.11.0",
  "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon"
-version = "0.10.0"
+version = "0.11.0"
 description = "2D Graphics rendering on the GPU using tessellation."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"
@@ -34,11 +34,11 @@ libtess2 = ["lyon_tess2"]
 
 [dependencies]
 
-lyon_tessellation = { version = "0.10.0", path = "tessellation/" }
+lyon_tessellation = { version = "0.11.0", path = "tessellation/" }
 lyon_algorithms = { version = "0.11.0", path = "algorithms/" }
-lyon_extra = { version = "0.10.0", optional = true, path = "extra/" }
-lyon_svg = { version = "0.10.0", optional = true, path = "svg/" }
-lyon_tess2 = { version = "0.10.0", optional = true, path = "tess2/" }
+lyon_extra = { version = "0.11.0", optional = true, path = "extra/" }
+lyon_svg = { version = "0.11.0", optional = true, path = "svg/" }
+lyon_tess2 = { version = "0.11.0", optional = true, path = "tess2/" }
 
 [workspace]
 members = [

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -19,5 +19,5 @@ serialization = ["serde", "lyon_path/serialization"]
 
 [dependencies]
 
-lyon_path = { version = "0.10.0", path = "../path" }
+lyon_path = { version = "0.11.0", path = "../path" }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }

--- a/algorithms/src/lib.rs
+++ b/algorithms/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 
-//! 2D Path transformation and manipulation algorithms.
+//! 2d Path transformation and manipulation algorithms.
 //!
 
 // TODO doc!

--- a/extra/Cargo.toml
+++ b/extra/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_extra"
-version = "0.10.0"
+version = "0.11.0"
 description = "Various optional utilities for the lyon crate."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"
@@ -14,5 +14,5 @@ name = "lyon_extra"
 
 [dependencies]
 
-lyon_path = { version = "0.10.0", path = "../path" }
-lyon_svg = { version = "0.10.0", path = "../svg" }
+lyon_path = { version = "0.11.0", path = "../path" }
+lyon_svg = { version = "0.11.0", path = "../svg" }

--- a/geom/Cargo.toml
+++ b/geom/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lyon_geom"
-version = "0.10.0"
-description = "2D quadratic and cubic bezier arcs and line segment math on top of euclid."
+version = "0.11.0"
+description = "2D quadratic and cubic bézier arcs and line segment math on top of euclid."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"
 documentation = "https://docs.rs/lyon_geom/"

--- a/path/Cargo.toml
+++ b/path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_path"
-version = "0.10.0"
+version = "0.11.0"
 description = "Types and utilities to store, build and iterate over 2D paths."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"
@@ -15,5 +15,5 @@ name = "lyon_path"
 serialization = ["serde", "lyon_geom/serialization"]
 
 [dependencies]
-lyon_geom = { version = "0.10.0", path = "../geom" }
+lyon_geom = { version = "0.11.0", path = "../geom" }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,11 @@
 //! * [![crate](http://meritbadge.herokuapp.com/lyon_path)](https://crates.io/crates/lyon_path)
 //!   [![doc](https://docs.rs/lyon_path/badge.svg)](https://docs.rs/lyon_path) -
 //!   **lyon_path** - Tools to build and iterate over paths.
-//! * [![crate](http://meritbadge.herokuapp.com/lyon_geom)](https://crates.io/crates/lyon_geom)
-//!   [![doc](https://docs.rs/lyon_geom/badge.svg)](https://docs.rs/lyon_geom) -
+//! * [![crate](http://meritbadge.herokuapp.com/lyon_svg)](https://crates.io/crates/lyon_svg)
+//!   [![doc](https://docs.rs/lyon_svg/badge.svg)](https://docs.rs/lyon_svg) -
+//!   **lyon_algorithms** - Various 2d path related algorithms.
+//! * [![crate](http://meritbadge.herokuapp.com/lyon_algorithms)](https://crates.io/crates/lyon_algorithms)
+//!   [![doc](https://docs.rs/lyon_algorithms/badge.svg)](https://docs.rs/lyon_algorithms) -
 //!   **lyon_geom** - 2d utilities for cubic and quadratic bézier curves, arcs and more.
 //! * [![crate](http://meritbadge.herokuapp.com/lyon_svg)](https://crates.io/crates/lyon_svg)
 //!   [![doc](https://docs.rs/lyon_svg/badge.svg)](https://docs.rs/lyon_svg) -

--- a/svg/Cargo.toml
+++ b/svg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_svg"
-version = "0.10.0"
+version = "0.11.0"
 description = "SVG helpers for the lyon crates."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"
@@ -13,6 +13,6 @@ path = "src/lib.rs"
 
 [dependencies]
 
-lyon_path = { version = "0.10.0", path = "../path" }
+lyon_path = { version = "0.11.0", path = "../path" }
 
 svgparser = "0.6"

--- a/tess2/Cargo.toml
+++ b/tess2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_tess2"
-version = "0.10.0"
+version = "0.11.0"
 description = "An additional path tessellator for lyon using libtess2."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"
@@ -19,6 +19,6 @@ serialization = ["serde", "lyon_tessellation/serialization"]
 
 [dependencies]
 
-lyon_tessellation = { version = "0.10.0", path = "../tessellation" }
+lyon_tessellation = { version = "0.11.0", path = "../tessellation" }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 tess2-sys = "0.0.1"

--- a/tessellation/Cargo.toml
+++ b/tessellation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_tessellation"
-version = "0.10.0"
+version = "0.11.0"
 description = "A low level path tessellation library."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"
@@ -19,9 +19,9 @@ serialization = ["serde", "lyon_path/serialization"]
 
 [dependencies]
 
-lyon_path = { version = "0.10.0", path = "../path" }
+lyon_path = { version = "0.11.0", path = "../path" }
 sid = "0.5"
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 
 [dev-dependencies]
-lyon_extra = { version = "0.10.0", path = "../extra" }
+lyon_extra = { version = "0.11.0", path = "../extra" }


### PR DESCRIPTION
Change log:

  - [tessellation] Move the VertexId representation from u16 to u32.
  - [tessellation] Fix a circle tessellation bug with large tolerance values.
  - [tessellation] Add a fast path for ellipses when the radii are equal.
  - [algorithms] Added the lyon_algorithms crate.
  - [algorithms] Implement a hatching pattern fill algorithm.
  - [algorithms] Implement a dotted pattern fill algorithm.
  - [algorithms] Implement path bounding rectangles.
  - [algorithms] Implement rectangle fitting transform computation.
  - [algorithms] Move path walking to the algorithms crate.
  - [geom] Implement callback based iteration over the monotonic parts of an arc.
  - [geom] Add LineSegment::set_length.
  - [geom] Fix an elliptic arc bug.
  - [geom] Implement precise elliptic arc bounding rectangle.
  - [cli] Add support for custom formatting in the tessellate command.
  - [cli] Allow changing the background in the show command.
  - [cli] Automatically position the view in the show command.
  - [examples] Add a simple SVG rendering example.
  - [misc] Update usvg and euclid dependencies.