### PR TITLE
Sort the active edge list after finding intersections to compensate for precision issues.

### DIFF
--- a/tessellation/src/fuzz_tests.rs
+++ b/tessellation/src/fuzz_tests.rs
@@ -702,9 +702,10 @@ fn fuzzing_test_case_17() {
 }
 
 #[test]
-#[ignore]
 fn fuzzing_test_case_18() {
     let mut builder = Path::builder();
+
+    // This was fixed by re-sorting the active edges when finding intersections.
 
     builder.move_to(point(447.85165, 671.4307));
     builder.line_to(point(37.19008, 311.777));


### PR DESCRIPTION
This fixes one of the remaining classes of bugs where imprecise intersection causes split active edges to be wrongly ordered in the active edge list.

I checked that this doesn't affect the performance of the common case (when there's no or few self-intersections), although cases with many self-intersections (such the ones produced by the fuzzer) take a fairly large hit. In my opinion the extra robustness is worth the perf hit in edge cases. It wouldn't hurt to optimize it a bit though.