### PR TITLE
lyon_geom version 0.12.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,11 +813,11 @@ dependencies = [
 
 [[package]]
 name = "lyon_geom"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -825,7 +825,7 @@ dependencies = [
 name = "lyon_path"
 version = "0.11.0"
 dependencies = [
- "lyon_geom 0.11.0",
+ "lyon_geom 0.12.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/geom/Cargo.toml
+++ b/geom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_geom"
-version = "0.11.0"
+version = "0.12.0"
 description = "2D quadratic and cubic bézier arcs and line segment math on top of euclid."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"
@@ -18,5 +18,5 @@ serialization = ["serde", "euclid/serde"]
 [dependencies]
 euclid = "0.19.0"
 arrayvec = "0.4"
-num-traits = "0.1.40"
+num-traits = "0.2"
 serde = {version = "1.0", optional = true, features = ["serde_derive"] }

--- a/path/Cargo.toml
+++ b/path/Cargo.toml
@@ -15,5 +15,5 @@ name = "lyon_path"
 serialization = ["serde", "lyon_geom/serialization"]
 
 [dependencies]
-lyon_geom = { version = "0.11.0", path = "../geom" }
+lyon_geom = { version = "0.12.0", path = "../geom" }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }


### PR DESCRIPTION
Update num-traits to 0.2 to match euclid and publish lyon_geom 0.12. 