### PR TITLE
Fix the splitter when the split line passes through a vertex.

### DIFF
--- a/algorithms/src/advanced_path.rs
+++ b/algorithms/src/advanced_path.rs
@@ -123,6 +123,10 @@ impl AdvancedPath {
         self.points.as_slice()
     }
 
+    pub fn edge_from(&self, id: EdgeId) -> VertexId {
+        self.edges[id].vertex
+    }
+
     pub fn edge(&self, id: EdgeId) -> Edge {
         let from = self.edges[id].vertex;
         let to = self.edges[self.edges[id].next].vertex;
@@ -279,6 +283,9 @@ pub struct EdgeLoop<'l> {
     path: &'l AdvancedPath
 }
 
+// TODO: EdgeLoop should ignore the last edge for a non closed, path or provide
+// the information that it's not a real edge.
+
 impl<'l> EdgeLoop<'l> {
     pub fn move_forward(&mut self) -> bool {
         self.current = self.path.edges[self.current].next;
@@ -305,11 +312,21 @@ impl<'l> EdgeLoop<'l> {
     }
 
     pub fn for_each(&mut self, callback: &mut dyn FnMut(EdgeId)) {
-        while self.move_forward() { callback(self.current()); }
+        loop {
+            callback(self.current());
+            if !self.move_forward() {
+                break;
+            }
+        }
     }
 
     pub fn reverse_for_each(&mut self, callback: &mut dyn FnMut(EdgeId)) {
-        while self.move_backward() { callback(self.current()); }
+        loop {
+            callback(self.current());
+            if !self.move_backward() {
+                break;
+            }
+        }
     }
 
     pub fn path_iter(&self) ->  SubPathIter {
@@ -347,11 +364,21 @@ impl<'l> MutEdgeLoop<'l> {
     pub fn path(&mut self) -> &mut AdvancedPath { self.path }
 
     pub fn for_each(&mut self, callback: &mut dyn FnMut(EdgeId)) {
-        while self.move_forward() { callback(self.current()); }
+        loop {
+            callback(self.current());
+            if !self.move_forward() {
+                break;
+            }
+        }
     }
 
     pub fn reverse_for_each(&mut self, callback: &mut dyn FnMut(EdgeId)) {
-        while self.move_backward() { callback(self.current()); }
+        loop {
+            callback(self.current());
+            if !self.move_backward() {
+                break;
+            }
+        }
     }
 }
 

--- a/algorithms/src/splitter.rs
+++ b/algorithms/src/splitter.rs
@@ -1,5 +1,5 @@
 use math::*;
-use geom::LineSegment;
+use geom::{Line, LineSegment};
 use std::cmp::PartialOrd;
 use advanced_path::*;
 
@@ -8,6 +8,7 @@ struct IntersectingEdge {
     intersection: Point,
     id: EdgeId,
     d: f32,
+    t: f32,
 }
 
 pub struct Splitter {
@@ -25,6 +26,7 @@ impl Splitter {
         selection: &dyn SubPathSelection,
         segment: &LineSegment<f32>
     ) -> Vec<SubPathId> {
+        let line = segment.to_line();
         self.intersecting_edges.clear();
 
         let v = segment.to_vector();
@@ -37,36 +39,87 @@ impl Splitter {
                 to: path[edge.to],
             };
 
-            if let Some(intersection) = segment.intersection(&edge_segment) {
-                self.intersecting_edges.push(IntersectingEdge {
-                    intersection,
-                    id: edge_id,
-                    d: v.dot(intersection - segment.from),
-                });
+            if let Some((t, _)) = edge_segment.intersection_t(&segment) {
+                if t < 1.0 {
+                    let intersection = edge_segment.sample(t);
+                    self.intersecting_edges.push(IntersectingEdge {
+                        intersection,
+                        id: edge_id,
+                        d: v.dot(intersection - segment.from),
+                        t,
+                    });
+                }
             }
         });
 
         // Sort the intersecting edges along the segment.
         self.intersecting_edges.sort_by(|a, b| { a.d.partial_cmp(&b.d).unwrap() });
 
-        // Split the intersecting edges by pair to avoid splitting an edge if
-        // we aren't going to be able to connect it.
-        for i in 0..(self.intersecting_edges.len() / 2) {
-            let e1 = &self.intersecting_edges[i];
-            let e2 = &self.intersecting_edges[i+1];
-            path.split_edge(e1.id, e1.intersection);
-            path.split_edge(e2.id, e2.intersection);
-        }
-
-        // Connect the split edges.
         let mut new_sub_paths = Vec::new();
-        for i in 0..(self.intersecting_edges.len() / 2) {
-            let i = i * 2;
-            let e1 = self.intersecting_edges[i].id;
-            let e2 = path.next_edge_id(self.intersecting_edges[i+1].id);
 
-            if let Some(sub_path) = path.connect_edges(e1, e2) {
-                new_sub_paths.push(sub_path);
+        let mut edge_in = None;
+        for i in 0..self.intersecting_edges.len() {
+            let e = &self.intersecting_edges[i];
+            if e.t == 0.0 {
+                let prev = path.edge_from(path.previous_edge_id(e.id));
+                let next = path.edge_from(path.next_edge_id(e.id));
+                let d1 = signed_pseudo_distance(&line, &path[prev]);
+                let d2 = signed_pseudo_distance(&line, &path[next]);
+                let same_side = d1.signum() == d2.signum();
+                match (same_side, edge_in) {
+                    (true, Some(e_in)) => {
+                        // .\   /.
+                        // ..\ /..
+                        // ---x---
+                        //
+                        // Inside of the shape.
+                        // Connect both left and right.
+                        if let Some(sub_path) = path.connect_edges(e_in, e.id) {
+                            new_sub_paths.push(sub_path);
+                        }
+
+                        edge_in = Some(path.previous_edge_id(e.id));
+                    }
+                    (true, None) => {
+                        //  \.../
+                        //   \./
+                        // ---x---
+                        //
+                        // Outside of the shape, nothing to do.
+                    }
+                    (false, Some(e_in)) => {
+                        // ..\
+                        // ---x---
+                        // ../
+                        if let Some(sub_path) = path.connect_edges(e_in, e.id) {
+                            new_sub_paths.push(sub_path);
+                        }
+                        edge_in = None;
+                    }
+                    (false, None) => {
+                        //   \....
+                        // ---x---
+                        //   /....
+                        edge_in = Some(path.previous_edge_id(e.id));
+                    }
+                }
+            } else {
+                path.split_edge(e.id, e.intersection);
+                if let Some(e_in) = edge_in {
+                    // ..\
+                    // ---\---
+                    // ....\
+                    let e_out = path.next_edge_id(e.id);
+                    if let Some(sub_path) = path.connect_edges(e_in, e_out) {
+                        new_sub_paths.push(sub_path);
+                    }
+                    edge_in = None;
+                } else {
+                    //   \....
+                    // ---\---
+                    //     \..
+                    edge_in = Some(e.id);
+                }
             }
         }
 
@@ -74,8 +127,14 @@ impl Splitter {
     }
 }
 
+fn signed_pseudo_distance(line: &Line<f32>, p: &Point) -> f32 {
+    let v1 = line.point.to_vector();
+    let v2 = v1 + line.vector;
+    line.vector.cross(p.to_vector()) + v1.cross(v2)
+}
+
 #[test]
-fn segment_split() {
+fn segment_split_1() {
     use geom::euclid::approxeq::ApproxEq;
     use path::PathEvent;
 
@@ -89,13 +148,6 @@ fn segment_split() {
         ],
         true,
     );
-
-    let mut edge_id = None;
-    for id in path.sub_path_edge_id_loop(sp) {
-        if path[path.edge(id).from] == point(1.0, 0.0) {
-            edge_id = Some(id);
-        }
-    }
 
     let mut splitter = Splitter::new();
     let new_sub_paths = splitter.segment_split(
@@ -143,4 +195,186 @@ fn segment_split() {
     assert_eq!(events2[3], PathEvent::LineTo(point(1.0, 0.0)));
     assert_eq!(events2[4], PathEvent::Close);
     assert_eq!(events2.len(), 5);
+}
+
+#[test]
+fn segment_split_2() {
+    use geom::euclid::approxeq::ApproxEq;
+    use path::PathEvent;
+
+    //  ________
+    // |   __   |
+    // |  |  |  |
+    //------------
+    // |__|  |__|
+    //
+
+    let mut path = AdvancedPath::new();
+    let sp = path.add_polyline(
+        &[
+            point(0.0, 0.0),
+            point(3.0, 0.0),
+            point(3.0, 3.0),
+            point(2.0, 3.0),
+            point(2.0, 1.0),
+            point(1.0, 1.0),
+            point(1.0, 3.0),
+            point(0.0, 3.0),
+        ],
+        true,
+    );
+
+    let mut splitter = Splitter::new();
+    let new_sub_paths = splitter.segment_split(
+        &mut path,
+        &AllSubPaths,
+        &LineSegment {
+            from: point(-1.0, 2.0),
+            to: point(4.0, 2.0),
+        },
+    );
+
+    assert_eq!(new_sub_paths.len(), 2);
+    let sp2 = new_sub_paths[0];
+    let sp3 = new_sub_paths[1];
+
+    let events1: Vec<PathEvent> = path.sub_path_edges(sp).path_iter().collect();
+
+    assert_eq!(events1[0], PathEvent::MoveTo(point(2.0, 2.0)));
+    assert_eq!(events1[1], PathEvent::LineTo(point(3.0, 2.0)));
+    assert_eq!(events1[2], PathEvent::LineTo(point(3.0, 3.0)));
+    assert_eq!(events1[3], PathEvent::LineTo(point(2.0, 3.0)));
+    assert_eq!(events1[4], PathEvent::Close);
+
+    let events2: Vec<PathEvent> = path.sub_path_edges(sp2).path_iter().collect();
+
+    assert_eq!(events2[0], PathEvent::MoveTo(point(1.0, 2.0)));
+    if let PathEvent::LineTo(p) = events2[1] {
+        assert!(p.approx_eq(&point(0.0, 2.0)))
+    } else {
+        panic!("unexpected event {:?}", events2[1]);
+    }
+    assert_eq!(events2[2], PathEvent::LineTo(point(0.0, 0.0)));
+    assert_eq!(events2[3], PathEvent::LineTo(point(3.0, 0.0)));
+    assert_eq!(events2[4], PathEvent::LineTo(point(3.0, 2.0)));
+    assert_eq!(events2[5], PathEvent::LineTo(point(2.0, 2.0)));
+    assert_eq!(events2[6], PathEvent::LineTo(point(2.0, 1.0)));
+    assert_eq!(events2[7], PathEvent::LineTo(point(1.0, 1.0)));
+    assert_eq!(events2[8], PathEvent::Close);
+
+    let events3: Vec<PathEvent> = path.sub_path_edges(sp3).path_iter().collect();
+
+    assert_eq!(events3[0], PathEvent::MoveTo(point(3.0, 2.0)));
+    assert_eq!(events3[1], PathEvent::LineTo(point(2.0, 2.0)));
+    assert_eq!(events3[2], PathEvent::LineTo(point(2.0, 1.0)));
+    assert_eq!(events3[3], PathEvent::LineTo(point(1.0, 1.0)));
+    assert_eq!(events3[4], PathEvent::LineTo(point(1.0, 2.0)));
+    if let PathEvent::LineTo(p) = events3[5] {
+        assert!(p.approx_eq(&point(0.0, 2.0)))
+    } else {
+        panic!("unexpected event {:?}", events2[1]);
+    }
+    assert_eq!(events3[6], PathEvent::LineTo(point(0.0, 0.0)));
+    assert_eq!(events3[7], PathEvent::LineTo(point(3.0, 0.0)));
+    assert_eq!(events3[8], PathEvent::Close);
+}
+
+#[test]
+fn segment_split_3() {
+    use path::PathEvent;
+
+    //  \____
+    //  |\   |
+    //  |_\__|
+    //     \
+
+    let mut path = AdvancedPath::new();
+    let sp = path.add_polyline(
+        &[
+            point(0.0, 0.0),
+            point(2.0, 0.0),
+            point(2.0, 2.0),
+            point(0.0, 2.0),
+        ],
+        true,
+    );
+
+
+
+    let mut splitter = Splitter::new();
+    let new_sub_paths = splitter.segment_split(
+        &mut path,
+        &AllSubPaths,
+        &LineSegment {
+            from: point(-1.0, -2.0),
+            to: point(2.0, 4.0),
+        },
+    );
+
+
+    let events1: Vec<PathEvent> = path.sub_path_edges(sp).path_iter().collect();
+
+    assert_eq!(events1[0], PathEvent::MoveTo(point(0.0, 0.0)));
+    assert_eq!(events1[1], PathEvent::LineTo(point(1.0, 2.0)));
+    assert_eq!(events1[2], PathEvent::LineTo(point(0.0, 2.0)));
+    assert_eq!(events1[3], PathEvent::Close);
+
+    let sp2 = new_sub_paths[0];
+    let events2: Vec<PathEvent> = path.sub_path_edges(sp2).path_iter().collect();
+
+    assert_eq!(events2[0], PathEvent::MoveTo(point(1.0, 2.0)));
+    assert_eq!(events2[1], PathEvent::LineTo(point(0.0, 0.0)));
+    assert_eq!(events2[2], PathEvent::LineTo(point(2.0, 0.0)));
+    assert_eq!(events2[3], PathEvent::LineTo(point(2.0, 2.0)));
+    assert_eq!(events2[4], PathEvent::Close);
+}
+
+#[test]
+#[ignore]
+fn segment_split_4() {
+    use path::PathEvent;
+
+    //  ________
+    // |        |
+    //-+--+--+--+-
+    // |  |  |  |
+    // |__|  |__|
+    //
+
+    let mut path = AdvancedPath::new();
+    let sp = path.add_polyline(
+        &[
+            point(0.0, 0.0),
+            point(3.0, 0.0),
+            point(3.0, 3.0),
+            point(2.0, 3.0),
+            point(2.0, 1.0),
+            point(1.0, 1.0),
+            point(1.0, 3.0),
+            point(0.0, 3.0),
+        ],
+        true,
+    );
+
+    let mut splitter = Splitter::new();
+    let new_sub_paths = splitter.segment_split(
+        &mut path,
+        &AllSubPaths,
+        &LineSegment {
+            from: point(-1.0, 1.0),
+            to: point(4.0, 1.0),
+        },
+    );
+
+    assert_eq!(new_sub_paths.len(), 2);
+    let sp2 = new_sub_paths[0];
+    let sp3 = new_sub_paths[1];
+
+    let events1: Vec<PathEvent> = path.sub_path_edges(sp).path_iter().collect();
+    let events2: Vec<PathEvent> = path.sub_path_edges(sp2).path_iter().collect();
+    let events3: Vec<PathEvent> = path.sub_path_edges(sp3).path_iter().collect();
+
+    println!("\n{:?}\n", events1);
+    println!("\n{:?}\n", events2);
+    println!("\n{:?}\n", events3);
 }

--- a/geom/src/line.rs
+++ b/geom/src/line.rs
@@ -186,6 +186,13 @@ impl<S: Scalar> LineSegment<S> {
             return None;
         }
 
+        if self.to == other.to
+            || self.from == other.from
+            || self.from == other.to
+            || self.to == other.from {
+            return None;
+        }
+
         let v1 = self.to_vector();
         let v2 = other.to_vector();
 
@@ -207,7 +214,7 @@ impl<S: Scalar> LineSegment<S> {
         let t = v3.cross(v2) * sign_v1_cross_v2;
         let u = v3.cross(v1) * sign_v1_cross_v2;
 
-        if t <= S::ZERO || t >= abs_v1_cross_v2 || u <= S::ZERO || u >= abs_v1_cross_v2 {
+        if t < S::ZERO || t > abs_v1_cross_v2 || u < S::ZERO || u > abs_v1_cross_v2 {
             return None;
         }
 


### PR DESCRIPTION
The remaining outstanding bug is properly dealing with edges that are overlapping the split line.