### PR TITLE
Fix invalid package names in the examples.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,15 +1,4 @@
 [[package]]
-name = "Path walking example"
-version = "0.1.0"
-dependencies = [
- "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_device_gl 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_window_glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.11.1",
-]
-
-[[package]]
 name = "adler32"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,7 +358,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "gfx-rs advanced example"
+name = "gfx-rs-advanced-example"
 version = "0.1.0"
 dependencies = [
  "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -380,7 +369,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "gfx-rs basic example"
+name = "gfx-rs-basic-example"
 version = "0.1.0"
 dependencies = [
  "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -471,7 +460,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "glium_basic"
+name = "glium-basic-example"
 version = "0.1.0"
 dependencies = [
  "glium 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -479,7 +468,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "glium_basic_shapes"
+name = "glium-basic-shapes-example"
 version = "0.1.0"
 dependencies = [
  "glium 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -509,7 +498,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "intersections example"
+name = "intersections-example"
 version = "0.1.0"
 dependencies = [
  "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -747,6 +736,17 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "path-walking-example"
+version = "0.1.0"
+dependencies = [
+ "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_device_gl 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_window_glutin 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon 0.11.1",
 ]
 
 [[package]]

--- a/examples/gfx_advanced/Cargo.toml
+++ b/examples/gfx_advanced/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gfx-rs advanced example"
+name = "gfx-rs-advanced-example"
 version = "0.1.0"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 workspace = "../.."

--- a/examples/gfx_basic/Cargo.toml
+++ b/examples/gfx_basic/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gfx-rs basic example"
+name = "gfx-rs-basic-example"
 version = "0.1.0"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 workspace = "../.."

--- a/examples/glium_basic/Cargo.toml
+++ b/examples/glium_basic/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "glium_basic"
+name = "glium-basic-example"
 version = "0.1.0"
 authors = ["orhanbalci <orhanbalci@gmail.com>"]
 workspace = "../.."

--- a/examples/glium_basic_shapes/Cargo.toml
+++ b/examples/glium_basic_shapes/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "glium_basic_shapes"
+name = "glium-basic-shapes-example"
 version = "0.1.0"
 workspace = "../.."
 

--- a/examples/intersections/Cargo.toml
+++ b/examples/intersections/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "intersections example"
+name = "intersections-example"
 version = "0.1.0"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 workspace = "../.."

--- a/examples/svg_render/Cargo.toml
+++ b/examples/svg_render/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "svg_render"
+name = "svg-rendering-example"
 description = "A simple svg renderer based on resvg"
 version = "0.1.0"
 authors = ["Roland Kovacs <zen3ger@gmail.com>"]

--- a/examples/walk_path/Cargo.toml
+++ b/examples/walk_path/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "Path walking example"
+name = "path-walking-example"
 version = "0.1.0"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 workspace = "../.."


### PR DESCRIPTION
Addresses breakage with rustc 1.30 since cargo checks that package names are valid.