### PR TITLE
 Add arc_to_cubic_beziers for Arcs. 

### DIFF
--- a/geom/src/arc.rs
+++ b/geom/src/arc.rs
@@ -164,7 +164,7 @@ impl<S: Scalar> Arc<S> {
     where
         F: FnMut(&QuadraticBezierSegment<S>)
     {
-        arc_to_to_quadratic_beziers(self, cb);
+        arc_to_quadratic_beziers(self, cb);
     }
 
     /// Approximate the arc with a sequence of cubic bézier curves.
@@ -513,7 +513,7 @@ impl Default for ArcFlags {
     }
 }
 
-fn arc_to_to_quadratic_beziers<S, F>(
+fn arc_to_quadratic_beziers<S, F>(
     arc: &Arc<S>,
     callback: &mut F,
 )


### PR DESCRIPTION
Note that I increased the step for cubic beziers to pi/2 from the pi/4 used in the quadratic case - I'm new to this so I'm not sure if that's appropriate or not (it's based on a comment at https://pomax.github.io/bezierinfo/#circles_cubic).

I'm attaching plots of the four test Arcs from arc.rs with their cubic approximations, plus a fifth with a larger sweep_angle
[graphs.pdf](https://github.com/nical/lyon/files/2450677/graphs.pdf)


