### PR TITLE
Update Cargo.lock for svg_render's name change.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "svg_render"
+name = "svg-rendering-example"
 version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Each time I build cargo makes this update - looks like it got missed in #417?