### PR TITLE
lyon_geom version 0.12.2.

### DIFF
--- a/geom/Cargo.toml
+++ b/geom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_geom"
-version = "0.12.1"
+version = "0.12.2"
 description = "2D quadratic and cubic bézier arcs and line segment math on top of euclid."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"


### PR DESCRIPTION
Publish the new arc to cubic bézier conversion added in #419.