### PR TITLE
Changes around cubic bezier line intersections

### DIFF
--- a/geom/src/cubic_bezier.rs
+++ b/geom/src/cubic_bezier.rs
@@ -550,7 +550,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         self.is_x_monotonic() && self.is_y_monotonic()
     }
 
-    /// Computes the intersections (if any) between this segment a line.
+    /// Computes the intersections (if any) between this segment and a line.
     ///
     /// The result is provided in the form of the `t` parameters of each
     /// point along curve. To get the intersection points, sample the curve
@@ -601,7 +601,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         return result;
     }
 
-    /// Computes the intersections (if any) between this segment a line segment.
+    /// Computes the intersections (if any) between this segment and a line segment.
     ///
     /// The result is provided in the form of the `t` parameters of each
     /// point along curve and segment. To get the intersection points, sample

--- a/geom/src/utils.rs
+++ b/geom/src/utils.rs
@@ -55,13 +55,13 @@ pub fn cubic_polynomial_roots<S: Scalar>(a: S, b: S, c: S, d: S) -> ArrayVec<[S;
 
     if S::abs(a) < S::EPSILON {
         // quadratic equation
-        let delta = b * b - S::FOUR * a * c;
+        let delta = c * c - S::FOUR * b * d;
         if delta > S::ZERO {
             let sqrt_delta = S::sqrt(delta);
-            result.push((-b - sqrt_delta) / (S::TWO * a));
-            result.push((-b + sqrt_delta) / (S::TWO * a));
+            result.push((-c - sqrt_delta) / (S::TWO * b));
+            result.push((-c + sqrt_delta) / (S::TWO * b));
         } else if S::abs(delta) < S::EPSILON {
-            result.push(-b / (S::TWO * a));
+            result.push(-c / (S::TWO * b));
         }
         return result;
     }
@@ -116,4 +116,8 @@ fn cubic_polynomial() {
     assert_approx_eq(cubic_polynomial_roots(2.0, -4.0, 2.0, 0.0), &[0.0, 1.0], 0.0000001);
     assert_approx_eq(cubic_polynomial_roots(-1.0, 1.0, -1.0, 1.0), &[1.0], 0.000001);
     assert_approx_eq(cubic_polynomial_roots(-2.0, 2.0, -1.0, 10.0), &[2.0], 0.00005);
+
+    // Quadratics.
+    assert_approx_eq(cubic_polynomial_roots(0.0, 1.0, -5.0, -14.0), &[-2.0, 7.0], 0.00005);
+    assert_approx_eq(cubic_polynomial_roots(0.0, 1.0, -6.0, 9.0), &[3.0], 0.00005);
 }

--- a/geom/src/utils.rs
+++ b/geom/src/utils.rs
@@ -85,7 +85,8 @@ pub fn cubic_polynomial_roots<S: Scalar>(a: S, b: S, c: S, d: S) -> ArrayVec<[S;
 
         result.push(-bn * frac_1_3 + (s + t));
 
-        if S::abs(s - t) < S::EPSILON {
+        // Don't add the repeated root when s + t == 0.
+        if S::abs(s - t) < S::EPSILON && S::abs(s + t) >= S::EPSILON {
             result.push(-bn * frac_1_3 - (s + t) / S::TWO);
         }
     } else {
@@ -116,8 +117,11 @@ fn cubic_polynomial() {
     assert_approx_eq(cubic_polynomial_roots(2.0, -4.0, 2.0, 0.0), &[0.0, 1.0], 0.0000001);
     assert_approx_eq(cubic_polynomial_roots(-1.0, 1.0, -1.0, 1.0), &[1.0], 0.000001);
     assert_approx_eq(cubic_polynomial_roots(-2.0, 2.0, -1.0, 10.0), &[2.0], 0.00005);
+    // (x - 1)^3, with a triple root, should only return one root.
+    assert_approx_eq(cubic_polynomial_roots(1.0, -3.0, 3.0, -1.0), &[1.0], 0.00005);
 
     // Quadratics.
     assert_approx_eq(cubic_polynomial_roots(0.0, 1.0, -5.0, -14.0), &[-2.0, 7.0], 0.00005);
+    // (x - 3)^2, with a double root, should only return one root.
     assert_approx_eq(cubic_polynomial_roots(0.0, 1.0, -6.0, 9.0), &[3.0], 0.00005);
 }


### PR DESCRIPTION
(I haven't checked the behavior when a curve and a line segment intersect at an endpoint: I _think_ the old behavior depended on the "left/top closed, right/bottom open" behavior of Rect.contains, and maybe rounding issues; now I think we have a "left closed, right closed" behavior (and still rounding issues?), so we might include an endpoint intersection in some cases where we didn't previously.  Maybe a new issue? or I can address it here if you like.)