### PR TITLE
Update Cargo.lock for the recent lyon_geom version bump.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_geom"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -641,7 +641,7 @@ dependencies = [
 name = "lyon_path"
 version = "0.12.0"
 dependencies = [
- "lyon_geom 0.12.1",
+ "lyon_geom 0.12.2",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 


### PR DESCRIPTION
Cargo makes these changes each time I build.