### PR TITLE
Don't divide by zero in cubic_bezier::split_range.

### DIFF
--- a/geom/src/cubic_bezier.rs
+++ b/geom/src/cubic_bezier.rs
@@ -100,8 +100,18 @@ impl<S: Scalar> CubicBezierSegment<S> {
 
     /// Return the sub-curve inside a given range of t.
     ///
-    /// This is equivalent splitting at the range's end points.
+    /// This is equivalent to splitting at the range's end points.
     pub fn split_range(&self, t_range: Range<S>) -> Self {
+        if t_range.start == t_range.end {
+            let pt = self.sample(t_range.start);
+            return CubicBezierSegment {
+                from: pt,
+                ctrl1: pt,
+                ctrl2: pt,
+                to: pt,
+            };
+        }
+
         let t1 = t_range.start;
         let t2 = (t_range.end - t_range.start) / (S::ONE - t_range.start);
 


### PR DESCRIPTION
We only actually divide by zero and return NANs when t_range == 1.0..1.0, but we
might as well short circuit the entire t_range.start == t_range.end case while
we're at it.

I ran into this while testing the cubic bezier intersection work: the domain of one of the curves was reduced by fat-lining to 1.0..1.0 because their was an endpoint intersection there, and then I was seeing a lot of NANs after trying to split the original curve down to that new interval.