### PR TITLE
Introduce path cursors.

### DIFF
--- a/path/src/lib.rs
+++ b/path/src/lib.rs
@@ -54,3 +54,63 @@ pub use events::*;
 pub use path_state::*;
 pub use geom::ArcFlags;
 pub use geom::math as math;
+
+use std::ops::{Add, Sub};
+use std::u32;
+
+pub type Index = u32;
+
+/// A virtual vertex offset in a geometry.
+///
+/// The `VertexId`s are only valid between `GeometryBuilder::begin_geometry` and
+/// `GeometryBuilder::end_geometry`. `GeometryBuilder` implementations typically be translate
+/// the ids internally so that first `VertexId` after `begin_geometry` is zero.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct VertexId(pub Index);
+
+impl VertexId {
+    pub const INVALID: VertexId = VertexId(u32::MAX);
+
+    pub fn offset(&self) -> Index { self.0 }
+
+    pub fn to_usize(&self) -> usize { self.0 as usize }
+
+    pub fn from_usize(v: usize) -> Self { VertexId(v as Index) }
+}
+
+impl Add<u32> for VertexId {
+    type Output = Self;
+    fn add(self, rhs: u32) -> Self {
+        VertexId(self.0 + rhs)
+    }
+}
+
+impl Sub<u32> for VertexId {
+    type Output = Self;
+    fn sub(self, rhs: u32) -> Self {
+        VertexId(self.0 - rhs)
+    }
+}
+
+impl From<u16> for VertexId {
+    fn from(v: u16) -> Self { VertexId(v as Index) }
+}
+impl From<u32> for VertexId {
+    fn from(v: u32) -> Self { VertexId(v) }
+}
+impl From<i32> for VertexId {
+    fn from(v: i32) -> Self { VertexId(v as Index) }
+}
+
+impl From<VertexId> for u16 {
+    fn from(v: VertexId) -> Self { v.0 as u16 }
+}
+impl From<VertexId> for u32 {
+    fn from(v: VertexId) -> Self { v.0 }
+}
+impl From<VertexId> for i32 {
+    fn from(v: VertexId) -> Self { v.0 as i32 }
+}
+impl From<VertexId> for usize {
+    fn from(v: VertexId) -> Self { v.0 as usize }
+}

--- a/tessellation/src/geometry_builder.rs
+++ b/tessellation/src/geometry_builder.rs
@@ -219,51 +219,11 @@
 //! }
 //! ```
 
+pub use path::{VertexId, Index};
 
 use std::marker::PhantomData;
 use std::ops::Add;
 use std::convert::From;
-
-pub type Index = u32;
-
-/// A virtual vertex offset in a geometry.
-///
-/// The `VertexId`s are only valid between `GeometryBuilder::begin_geometry` and
-/// `GeometryBuilder::end_geometry`. `GeometryBuilder` implementations typically be translate
-/// the ids internally so that first `VertexId` after `begin_geometry` is zero.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct VertexId(pub Index);
-
-impl VertexId {
-    pub fn offset(&self) -> Index { self.0 }
-}
-
-impl Add<u32> for VertexId {
-    type Output = Self;
-    fn add(self, rhs: u32) -> Self {
-        VertexId(self.0 + rhs)
-    }
-}
-
-impl From<u16> for VertexId {
-    fn from(v: u16) -> Self { VertexId(v as Index) }
-}
-impl From<u32> for VertexId {
-    fn from(v: u32) -> Self { VertexId(v) }
-}
-impl From<i32> for VertexId {
-    fn from(v: i32) -> Self { VertexId(v as Index) }
-}
-
-impl From<VertexId> for u16 {
-    fn from(v: VertexId) -> Self { v.0 as u16 }
-}
-impl From<VertexId> for u32 {
-    fn from(v: VertexId) -> Self { v.0 }
-}
-impl From<VertexId> for i32 {
-    fn from(v: VertexId) -> Self { v.0 as i32 }
-}
 
 /// An interface separating tessellators and other geometry generation algorithms from the
 /// actual vertex construction.


### PR DESCRIPTION
Path cursors allow iterating over portions of path in forward and reverse order, and refer to edges directly.
It's a step towards making the default `Path` data structure more expressive and hopefully eventually deprecating `AdvancedPath`.