### PR TITLE
Fix `serialization` feature of lyon_path

### DIFF
--- a/path/src/lib.rs
+++ b/path/src/lib.rs
@@ -66,6 +66,7 @@ pub type Index = u32;
 /// `GeometryBuilder::end_geometry`. `GeometryBuilder` implementations typically be translate
 /// the ids internally so that first `VertexId` after `begin_geometry` is zero.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct VertexId(pub Index);
 
 impl VertexId {


### PR DESCRIPTION
Without this I get build errors like below. Maybe something should be added to `.travis.yml`?

```rust
$ cargo build --all-features
error[E0277]: the trait bound `VertexId: serde::Serialize` is not satisfied
  --> path/src/default.rs:31:5
   |
31 |     vertex: VertexId,
   |     ^^^^^^ the trait `serde::Serialize` is not implemented for `VertexId`
   |
   = note: required by `serde::ser::SerializeStruct::serialize_field`
```