### PR TITLE
Intersection detection adjustments for cubic  bézier curves

### DIFF
--- a/geom/src/cubic_bezier_intersections.rs
+++ b/geom/src/cubic_bezier_intersections.rs
@@ -259,7 +259,7 @@ fn add_curve_intersections<S: Scalar>(
         return call_count;
     }
 
-    let epsilon = if inputs_are_f32::<S>() { S::value(5e-6) } else { S::value(1e-12) };
+    let epsilon = if inputs_are_f32::<S>() { S::value(5e-6) } else { S::value(1e-9) };
 
     if domain2.start == domain2.end || curve2.is_a_point(S::ZERO) {
         add_point_curve_intersection(
@@ -367,7 +367,7 @@ fn add_curve_intersections<S: Scalar>(
         if domain2.end - domain2.start >= epsilon {
             call_count = add_curve_intersections(
                 curve2, curve1, domain2, new_domain1,
-                intersections,!flip, recursion_count, call_count,
+                intersections, !flip, recursion_count, call_count,
                 orig_curve2, orig_curve1,
             );
         } else {


### PR DESCRIPTION
Comments are in the commit messages.

The numbers I'm getting from my bench runs have changed somewhat from previous runs (I don't know why), but fwiw, without these patches, I get:
f32 curves: 22,552,339
f64 curves: 25,775,672

With the epsilon change (the first commit), I get:
f32 curves: 22,628,392 (expected no change from the previous f32 bench)
f64 curves: 24,613,664 (expected faster than the previous)

And with the new f32 sampling code (the second commit), I get:
f32 curves: 22,874,551 (expected slower than the previous)
f64 curves: 24,535,376 (expected more or less no change from the previous)