### PR TITLE
Miscelaneous fixes

### DIFF
--- a/geom/src/cubic_bezier.rs
+++ b/geom/src/cubic_bezier.rs
@@ -646,6 +646,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         cubic_bezier_intersections_t(self, curve)
     }
 
+    /// Computes the intersection points (if any) between this segment and another one.
     pub fn cubic_intersections(&self, curve: &CubicBezierSegment<S>) -> ArrayVec<[Point<S>; 9]> {
         let intersections = self.cubic_intersections_t(curve);
 
@@ -696,6 +697,24 @@ impl<S: Scalar> CubicBezierSegment<S> {
         result
     }
 
+    /// Computes the intersections (if any) between this segment a quadratic bézier segment.
+    ///
+    /// The result is provided in the form of the `t` parameters of each point along the curves. To
+    /// get the intersection points, sample the curves at the corresponding values.
+    ///
+    /// Returns endpoint intersections where an endpoint intersects the interior of the other curve,
+    /// but not endpoint/endpoint intersections.
+    ///
+    /// Returns no intersections if either curve is a point.
+    pub fn quadratic_intersections_t(&self, curve: &QuadraticBezierSegment<S>) -> ArrayVec<[(S, S); 9]> {
+        self.cubic_intersections_t(&curve.to_cubic())
+    }
+
+    /// Computes the intersection points (if any) between this segment and a quadratic bézier segment.
+    pub fn quadratic_intersections(&self, curve: &QuadraticBezierSegment<S>) -> ArrayVec<[Point<S>; 9]> {
+        self.cubic_intersections(&curve.to_cubic())
+    }
+
     /// Computes the intersections (if any) between this segment and a line.
     ///
     /// The result is provided in the form of the `t` parameters of each
@@ -736,6 +755,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         return result;
     }
 
+    /// Computes the intersection points (if any) between this segment and a line.
     pub fn line_intersections(&self, line: &Line<S>) -> ArrayVec<[Point<S>; 3]> {
         let intersections = self.line_intersections_t(&line);
 

--- a/geom/src/cubic_bezier.rs
+++ b/geom/src/cubic_bezier.rs
@@ -256,7 +256,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
     /// Computes the signed distances (min <= 0 and max >= 0) from the baseline of this
     /// curve to its two "fat line" boundary lines.
     ///
-    /// A fat line is two convervative lines between which the segment
+    /// A fat line is two conservative lines between which the segment
     /// is fully contained.
     pub(crate) fn fat_line_min_max(&self) -> (S, S) {
         let baseline = self.baseline().to_line().equation();
@@ -279,7 +279,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
 
     /// Computes a "fat line" of this segment.
     ///
-    /// A fat line is two convervative lines between which the segment
+    /// A fat line is two conservative lines between which the segment
     /// is fully contained.
     pub fn fat_line(&self) -> (LineEquation<S>, LineEquation<S>) {
         let baseline = self.baseline().to_line().equation();

--- a/geom/src/cubic_bezier.rs
+++ b/geom/src/cubic_bezier.rs
@@ -70,7 +70,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
 
     /// Return the parameter values corresponding to a given x coordinate.
     /// See also solve_t_for_x for monotonic curves.
-    pub fn parameters_for_x_value(&self, x: S) -> ArrayVec<[S; 3]> {
+    pub fn solve_t_for_x(&self, x: S) -> ArrayVec<[S; 3]> {
         if self.is_a_point(S::ZERO)
             || (self.non_point_is_linear(S::ZERO) && self.from.x == self.to.x)
         {
@@ -82,7 +82,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
 
     /// Return the parameter values corresponding to a given y coordinate.
     /// See also solve_t_for_y for monotonic curves.
-    pub fn parameters_for_y_value(&self, y: S) -> ArrayVec<[S; 3]> {
+    pub fn solve_t_for_y(&self, y: S) -> ArrayVec<[S; 3]> {
         if self.is_a_point(S::ZERO)
             || (self.non_point_is_linear(S::ZERO) && self.from.y == self.to.y)
         {
@@ -1135,8 +1135,8 @@ fn test_parameters_for_value() {
         };
 
         let epsilon = 1e-4;
-        assert_approx_eq(curve.parameters_for_x_value(5.0), &[0.5], epsilon);
-        assert_approx_eq(curve.parameters_for_y_value(6.0), &[0.5], epsilon);
+        assert_approx_eq(curve.solve_t_for_x(5.0), &[0.5], epsilon);
+        assert_approx_eq(curve.solve_t_for_y(6.0), &[0.5], epsilon);
     }
     {
         let curve = CubicBezierSegment {
@@ -1146,7 +1146,7 @@ fn test_parameters_for_value() {
             to: point(10.0, 10.0)
         };
 
-        assert_approx_eq(curve.parameters_for_y_value(10.0), &[], 0.0);
+        assert_approx_eq(curve.solve_t_for_y(10.0), &[], 0.0);
     }
 }
 

--- a/geom/src/cubic_bezier_intersections.rs
+++ b/geom/src/cubic_bezier_intersections.rs
@@ -103,8 +103,8 @@ fn point_curve_intersections<S: Scalar>(
         return result;
     }
 
-    let curve_x_t_params = curve.parameters_for_x_value(pt.x);
-    let curve_y_t_params = curve.parameters_for_y_value(pt.y);
+    let curve_x_t_params = curve.solve_t_for_x(pt.x);
+    let curve_y_t_params = curve.solve_t_for_y(pt.y);
     // We want to coalesce parameters representing the same intersection from the x and y
     // directions, but the parameter calculations aren't very accurate, so give a little more
     // leeway there (TODO: this isn't perfect, as you might expect - the dupes that pass here are
@@ -170,10 +170,10 @@ fn line_curve_intersections<S: Scalar>(
     for curve_t in curve_intersections {
         let line_intersections = if line_is_mostly_vertical {
             let intersection_y = curve.y(curve_t);
-            line_as_curve.parameters_for_y_value(intersection_y)
+            line_as_curve.solve_t_for_y(intersection_y)
         } else {
             let intersection_x = curve.x(curve_t);
-            line_as_curve.parameters_for_x_value(intersection_x)
+            line_as_curve.solve_t_for_x(intersection_x)
         };
 
         for line_t in line_intersections {
@@ -205,9 +205,9 @@ fn line_line_intersections<S: Scalar>(
         let line_is_mostly_vertical =
             S::abs(curve.from.y - curve.to.y) >= S::abs(curve.from.x - curve.to.x);
         if line_is_mostly_vertical {
-            curve.parameters_for_y_value(pt.y)
+            curve.solve_t_for_y(pt.y)
         } else {
-            curve.parameters_for_x_value(pt.x)
+            curve.solve_t_for_x(pt.x)
         }
     }
 

--- a/path/src/default.rs
+++ b/path/src/default.rs
@@ -247,8 +247,8 @@ impl Builder {
 
 #[inline]
 fn nan_check(p: Point) {
-    debug_assert!(!p.x.is_nan());
-    debug_assert!(!p.y.is_nan());
+    debug_assert!(p.x.is_finite());
+    debug_assert!(p.y.is_finite());
 }
 
 impl FlatPathBuilder for Builder {

--- a/path/src/iterator.rs
+++ b/path/src/iterator.rs
@@ -516,6 +516,8 @@ where
         }
 
         if let Some(next) = self.iter.next() {
+            debug_assert!(next.x.is_finite());
+            debug_assert!(next.y.is_finite());
             return Some(
                 if self.first {
                     self.first = false;

--- a/path/src/iterator.rs
+++ b/path/src/iterator.rs
@@ -104,6 +104,7 @@ use math::*;
 use {PathEvent, SvgEvent, FlattenedEvent, QuadraticEvent, PathState};
 use geom::{QuadraticBezierSegment, CubicBezierSegment, quadratic_bezier, cubic_bezier};
 use geom::arc;
+use builder::{FlatPathBuilder, PathBuilder, SvgBuilder};
 
 /// An extension to the common Iterator interface, that adds information which is useful when
 /// chaining path-specific iterators.
@@ -278,7 +279,7 @@ where
             _ => {}
         }
         self.current_curve = TmpFlatteningIter::None;
-        let current = self.get_state().current;
+        let current = self.get_state().current_position();
 
         match self.it.next() {
             Some(PathEvent::MoveTo(to)) => Some(FlattenedEvent::MoveTo(to)),

--- a/path/src/path_state.rs
+++ b/path/src/path_state.rs
@@ -1,16 +1,25 @@
 
-use math::{Point, Vector, point, vector};
-use geom::{Arc, SvgArc};
-use events::{PathEvent, SvgEvent, FlattenedEvent};
+use math::{Point, Vector, point, vector, Angle};
+use geom::{Arc, SvgArc, ArcFlags};
+use events::{PathEvent, SvgEvent};
+use builder::{FlatPathBuilder, PathBuilder, SvgBuilder};
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum LastCtrl {
+    Cubic(Point),
+    Quad(Point),
+    None,
+}
 
 /// Represents the current state of a path while it is being built.
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct PathState {
     /// The current point.
-    pub current: Point,
+    current: Point,
     /// The first point of the current sub-path.
-    pub first: Point,
+    first: Point,
     /// The last control point.
-    pub last_ctrl: Point,
+    last_ctrl: LastCtrl,
 }
 
 impl PathState {
@@ -18,154 +27,152 @@ impl PathState {
         PathState {
             current: point(0.0, 0.0),
             first: point(0.0, 0.0),
-            last_ctrl: point(0.0, 0.0),
+            last_ctrl: LastCtrl::None,
         }
     }
 }
 
+impl FlatPathBuilder for PathState {
+    type PathType = PathState;
+
+    fn move_to(&mut self, to: Point) { self.move_to(to); }
+
+    fn line_to(&mut self, to: Point) { self.line_to(to); }
+
+    fn close(&mut self) { self.close(); }
+
+    fn build(self) -> PathState { self }
+
+    fn build_and_reset(&mut self) -> PathState {
+        let result = self.clone();
+        *self = PathState::new();
+        result
+    }
+
+    fn current_position(&self) -> Point {
+        self.current
+    }
+}
+
+impl PathBuilder for PathState {
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point) {
+        self.last_ctrl = LastCtrl::Quad(ctrl);
+        self.current = to;
+    }
+
+    fn cubic_bezier_to(&mut self, _ctrl1: Point, ctrl2: Point, to: Point) {
+        self.last_ctrl = LastCtrl::Cubic(ctrl2);
+        self.current = to;
+    }
+
+    fn arc(&mut self, center: Point, radii: Vector, sweep_angle: Angle, x_rotation: Angle) {
+        let start_angle = (self.current - center).angle_from_x_axis() - x_rotation;
+        let arc = Arc {
+            center,
+            radii,
+            start_angle,
+            sweep_angle,
+            x_rotation,
+        };
+        let to = arc.to();
+        self.last_ctrl = LastCtrl::None;
+        self.current = to;
+    }
+}
+
+impl SvgBuilder for PathState {
+    fn relative_move_to(&mut self, to: Vector) {
+        let to = self.relative_to_absolute(to);
+        self.move_to(to);
+    }
+    fn relative_line_to(&mut self, to: Vector) {
+        let to = self.relative_to_absolute(to);
+        self.line_to(to);
+    }
+    fn relative_quadratic_bezier_to(&mut self, ctrl: Vector, to: Vector) {
+        let to = self.relative_to_absolute(to);
+        let ctrl = self.relative_to_absolute(ctrl);
+        self.last_ctrl = LastCtrl::Quad(ctrl);
+        self.current = to;
+    }
+    fn relative_cubic_bezier_to(&mut self, _ctrl1: Vector, ctrl2: Vector, to: Vector) {
+        let to = self.relative_to_absolute(to);
+        let ctrl2 = self.relative_to_absolute(ctrl2);
+        self.last_ctrl = LastCtrl::Cubic(ctrl2);
+        self.current = to;
+    }
+    fn smooth_cubic_bezier_to(&mut self, ctrl2: Point, to: Point) {
+        self.last_ctrl = LastCtrl::Cubic(ctrl2);
+        self.current = to;
+    }
+    fn smooth_relative_cubic_bezier_to(&mut self, ctrl2: Vector, to: Vector) {
+        self.last_ctrl = LastCtrl::Cubic(self.relative_to_absolute(ctrl2));
+        self.current = self.relative_to_absolute(to);
+    }
+    fn smooth_quadratic_bezier_to(&mut self, to: Point) {
+        let last_ctrl = match self.last_ctrl {
+            LastCtrl::Quad(ctrl) => ctrl,
+            _ => self.current,
+        };
+        self.last_ctrl = LastCtrl::Quad(to + (to - last_ctrl));
+        self.current = to;
+    }
+    fn smooth_relative_quadratic_bezier_to(&mut self, to: Vector) {
+        let to = self.relative_to_absolute(to);
+        let last_ctrl = match self.last_ctrl {
+            LastCtrl::Quad(ctrl) => ctrl,
+            _ => self.current,
+        };
+        self.last_ctrl = LastCtrl::Quad(to + (to - last_ctrl));
+        self.current = to;
+    }
+    fn horizontal_line_to(&mut self, x: f32) {
+        let to = point(x, self.current.y);
+        self.line_to(to);
+    }
+    fn relative_horizontal_line_to(&mut self, dx: f32) {
+        let to = self.current + vector(dx, 0.0);
+        self.line_to(to);
+    }
+    fn vertical_line_to(&mut self, y: f32) {
+        let to = point(self.current.x, y);
+        self.line_to(to);
+    }
+    fn relative_vertical_line_to(&mut self, dy: f32) {
+        let to = self.current + vector(0.0, dy);
+        self.line_to(to);
+    }
+    fn arc_to(&mut self, _radii: Vector, _x_rotation: Angle, _flags: ArcFlags, to: Point) {
+        self.last_ctrl = LastCtrl::None;
+        self.current = to;
+    }
+    fn relative_arc_to(
+        &mut self,
+        _radii: Vector,
+        _x_rotation: Angle,
+        _flags: ArcFlags,
+        to: Vector,
+    ) {
+        let to = self.relative_to_absolute(to);
+        self.last_ctrl = LastCtrl::None;
+        self.current = to;
+    }
+}
+
 impl PathState {
-    pub fn svg_event(&mut self, event: SvgEvent) {
-        match event {
-            SvgEvent::MoveTo(to) => {
-                self.move_to(to);
-            }
-            SvgEvent::RelativeMoveTo(to) => {
-                let to = self.relative_to_absolute(to);
-                self.move_to(to);
-            }
-            SvgEvent::LineTo(to) => self.line_to(to),
-            SvgEvent::QuadraticTo(ctrl, to) => {
-                self.curve_to(ctrl, to);
-            }
-            SvgEvent::CubicTo(_, ctrl2, to) => {
-                self.curve_to(ctrl2, to);
-            }
-            SvgEvent::ArcTo(_, _, _, to) => {
-                self.last_ctrl = self.current;
-                self.current = to;
-            }
-            SvgEvent::RelativeLineTo(to) => {
-                let to = self.relative_to_absolute(to);
-                self.line_to(to);
-            }
-            SvgEvent::RelativeQuadraticTo(ctrl, to) => {
-                let to = self.relative_to_absolute(to);
-                let ctrl = self.relative_to_absolute(ctrl);
-                self.curve_to(ctrl, to);
-            }
-            SvgEvent::RelativeCubicTo(_, ctrl2, to) => {
-                let to = self.relative_to_absolute(to);
-                let ctrl2 = self.relative_to_absolute(ctrl2);
-                self.curve_to(ctrl2, to);
-            }
-            SvgEvent::RelativeArcTo(_, _, _, to) => {
-                self.last_ctrl = self.current;
-                self.relative_next(to);
-            }
-            SvgEvent::HorizontalLineTo(x) => {
-                let to = point(x, self.current.y);
-                self.line_to(to);
-            }
-            SvgEvent::VerticalLineTo(y) => {
-                let to = point(self.current.x, y);
-                self.line_to(to);
-            }
-            SvgEvent::RelativeHorizontalLineTo(x) => {
-                let to = self.current + vector(x, 0.0);
-                self.line_to(to);
-            }
-            SvgEvent::RelativeVerticalLineTo(y) => {
-                let to = self.current + vector(0.0, y);
-                self.line_to(to);
-            }
-            SvgEvent::SmoothQuadraticTo(to) => {
-                let ctrl = self.get_smooth_ctrl();
-                self.curve_to(ctrl, to);
-            }
-            SvgEvent::SmoothCubicTo(ctrl2, to) => {
-                self.curve_to(ctrl2, to);
-            }
-            SvgEvent::SmoothRelativeQuadraticTo(to) => {
-                let ctrl = self.get_smooth_ctrl();
-                let to = self.relative_to_absolute(to);
-                self.curve_to(ctrl, to);
-            }
-            SvgEvent::SmoothRelativeCubicTo(ctrl2, to) => {
-                let ctrl2 = self.relative_to_absolute(ctrl2);
-                let to = self.relative_to_absolute(to);
-                self.curve_to(ctrl2, to);
-            }
-            SvgEvent::Close => {
-                self.close();
-            }
-        }
-    }
-
-    pub fn path_event(&mut self, event: PathEvent) {
-        match event {
-            PathEvent::MoveTo(to) => {
-                self.move_to(to);
-            }
-            PathEvent::LineTo(to) => {
-                self.line_to(to);
-            }
-            PathEvent::QuadraticTo(ctrl, to) => {
-                self.curve_to(ctrl, to);
-            }
-            PathEvent::CubicTo(_, ctrl2, to) => {
-                self.curve_to(ctrl2, to);
-            }
-            PathEvent::Arc(center, radii, sweep_angle, x_rotation) => {
-                let start_angle = (self.current - center).angle_from_x_axis() - x_rotation;
-                let arc = Arc {
-                    center,
-                    radii,
-                    start_angle,
-                    sweep_angle,
-                    x_rotation,
-                };
-                let to = arc.to();
-                let ctrl = to - arc.sample_tangent(1.0);
-                self.curve_to(ctrl, to);
-            }
-            PathEvent::Close => {
-                self.close();
-            }
-        }
-    }
-
-    pub fn flattened_event(&mut self, event: FlattenedEvent) {
-        match event {
-            FlattenedEvent::MoveTo(to) => {
-                self.move_to(to);
-            }
-            FlattenedEvent::LineTo(to) => {
-                self.line_to(to);
-            }
-            FlattenedEvent::Close => {
-                self.close();
-            }
-        }
-    }
-
     pub fn move_to(&mut self, to: Point) {
-        self.last_ctrl = self.current;
+        self.last_ctrl = LastCtrl::None;
         self.current = to;
         self.first = to;
     }
 
     pub fn line_to(&mut self, to: Point) {
-        self.last_ctrl = self.current;
-        self.current = to;
-    }
-
-    pub fn curve_to(&mut self, ctrl: Point, to: Point) {
-        self.last_ctrl = ctrl;
+        self.last_ctrl = LastCtrl::None;
         self.current = to;
     }
 
     pub fn close(&mut self) {
-        self.last_ctrl = self.first;
+        self.last_ctrl = LastCtrl::None;
         self.current = self.first;
     }
 
@@ -173,7 +180,19 @@ impl PathState {
 
     pub fn relative_next(&mut self, to: Vector) { self.current = self.relative_to_absolute(to); }
 
-    pub fn get_smooth_ctrl(&self) -> Point { self.current + (self.current - self.last_ctrl) }
+    pub fn get_smooth_cubic_ctrl(&self) -> Point {
+        match self.last_ctrl {
+            LastCtrl::Cubic(ctrl) => self.current + (self.current - ctrl),
+            _ => self.current,
+        }
+    }
+
+    pub fn get_smooth_quadratic_ctrl(&self) -> Point {
+        match self.last_ctrl {
+            LastCtrl::Quad(ctrl) => self.current + (self.current - ctrl),
+            _ => self.current,
+        }
+    }
 
     pub fn relative_to_absolute(&self, v: Vector) -> Point { self.current + v }
 
@@ -207,17 +226,17 @@ impl PathState {
                 PathEvent::LineTo(point(self.current.x, self.current.y + y))
             }
             SvgEvent::SmoothQuadraticTo(to) => {
-                PathEvent::QuadraticTo(self.get_smooth_ctrl(), to)
+                PathEvent::QuadraticTo(self.get_smooth_quadratic_ctrl(), to)
             }
             SvgEvent::SmoothCubicTo(ctrl2, to) => {
-                PathEvent::CubicTo(self.get_smooth_ctrl(), ctrl2, to)
+                PathEvent::CubicTo(self.get_smooth_cubic_ctrl(), ctrl2, to)
             }
             SvgEvent::SmoothRelativeQuadraticTo(to) => {
-                PathEvent::QuadraticTo(self.get_smooth_ctrl(), self.relative_to_absolute(to))
+                PathEvent::QuadraticTo(self.get_smooth_quadratic_ctrl(), self.relative_to_absolute(to))
             }
             SvgEvent::SmoothRelativeCubicTo(ctrl2, to) => {
                 PathEvent::CubicTo(
-                    self.get_smooth_ctrl(),
+                    self.get_smooth_cubic_ctrl(),
                     self.relative_to_absolute(ctrl2),
                     self.relative_to_absolute(to),
                 )

--- a/path/src/path_state.rs
+++ b/path/src/path_state.rs
@@ -41,7 +41,7 @@ impl PathState {
                 self.curve_to(ctrl2, to);
             }
             SvgEvent::ArcTo(_, _, _, to) => {
-                self.last_ctrl = self.current; // TODO
+                self.last_ctrl = self.current;
                 self.current = to;
             }
             SvgEvent::RelativeLineTo(to) => {
@@ -59,7 +59,7 @@ impl PathState {
                 self.curve_to(ctrl2, to);
             }
             SvgEvent::RelativeArcTo(_, _, _, to) => {
-                self.last_ctrl = self.current; // TODO
+                self.last_ctrl = self.current;
                 self.relative_next(to);
             }
             SvgEvent::HorizontalLineTo(x) => {

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -2,7 +2,7 @@
 //
 // # Segment intersection
 //
-// segment-segment intersection is currently the most perf-sensituve function by far.
+// segment-segment intersection is currently the most perf-sensitive function by far.
 // A quick experiment replacing segment_intersection by a dummy function that always
 // return None made the tessellation of the log twice faster.
 // segment_intersection can be improved (it is currently a naive implementation).


### PR DESCRIPTION

- Fix some typos.
- Rename parameters_for_x_value into solve_t_for_x.
- Remove wrong todo comments in path_state.rs.
- Add cubic vs quadratic bézier intersection.
- Checks for NaNs when building a path iterator from a polyline.
- Fix the way smooth path events are handled (cf. https://github.com/nical/lyon/issues/434#issuecomment-457837573).