### PR TITLE
Revamp the iterator APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fn main() {
     {
         // Compute the tessellation.
         tessellator.tessellate_path(
-            path.path_iter(),
+            &path,
             &FillOptions::default(),
             &mut BuffersBuilder::new(&mut geometry, |vertex : FillVertex| {
                 MyVertex {

--- a/algorithms/src/advanced_path.rs
+++ b/algorithms/src/advanced_path.rs
@@ -439,6 +439,7 @@ impl<'l> EdgeLoop<'l> {
         SubPathIter {
             edge_loop: self.clone(),
             prev: point(0.0, 0.0),
+            first: point(0.0, 0.0),
             start: true,
             done: false,
             close: self.path.sub_paths[sp].is_closed,
@@ -548,6 +549,7 @@ impl SubPathSelection for SubPathIdRange {
 pub struct SubPathIter<'l> {
     edge_loop: EdgeLoop<'l>,
     prev: Point,
+    first: Point,
     start: bool,
     done: bool,
     close: bool,
@@ -559,7 +561,10 @@ impl<'l> Iterator for SubPathIter<'l> {
         if self.done {
             if self.close {
                 self.close = false;
-                return Some(PathEvent::Close)
+                return Some(PathEvent::Close(LineSegment {
+                    from: self.prev,
+                    to: self.first
+                }));
             }
 
             return None;
@@ -577,6 +582,7 @@ impl<'l> Iterator for SubPathIter<'l> {
         self.prev = to;
         if self.start {
             self.start = false;
+            self.first = to;
             return Some(PathEvent::MoveTo(to));
         }
 
@@ -700,7 +706,7 @@ fn polyline_to_path() {
     assert_eq!(events[1], PathEvent::Line(LineSegment { from: point(0.0, 0.0), to: point(1.0, 0.0) }));
     assert_eq!(events[2], PathEvent::Line(LineSegment { from: point(1.0, 0.0), to: point(1.0, 1.0) }));
     assert_eq!(events[3], PathEvent::Line(LineSegment { from: point(1.0, 1.0), to: point(0.0, 1.0) }));
-    assert_eq!(events[4], PathEvent::Close);
+    assert_eq!(events[4], PathEvent::Close(LineSegment { from: point(0.0, 1.0), to: point(0.0, 0.0) }));
     assert_eq!(events.len(), 5);
 }
 
@@ -732,7 +738,7 @@ fn split_edge() {
     assert_eq!(events[2], PathEvent::Line(LineSegment { from: point(0.5, 0.0), to: point(1.0, 0.0) }));
     assert_eq!(events[3], PathEvent::Line(LineSegment { from: point(1.0, 0.0), to: point(1.0, 1.0) }));
     assert_eq!(events[4], PathEvent::Line(LineSegment { from: point(1.0, 1.0), to: point(0.0, 1.0) }));
-    assert_eq!(events[5], PathEvent::Close);
+    assert_eq!(events[5], PathEvent::Close(LineSegment { from: point(0.0, 1.0), to: point(0.0, 0.0) }));
     assert_eq!(events.len(), 6);
 }
 

--- a/algorithms/src/fit.rs
+++ b/algorithms/src/fit.rs
@@ -56,7 +56,7 @@ pub fn fit_path(path: &Path, output_rect: &Rect, style: FitStyle) -> Path {
     let transform = fit_rectangle(&aabb, output_rect, style);
 
     let mut builder = Path::builder();
-    for evt in path.path_iter().transformed(&transform) {
+    for evt in path.iter().transformed(&transform) {
         builder.path_event(evt)
     }
 

--- a/algorithms/src/raycast.rs
+++ b/algorithms/src/raycast.rs
@@ -39,33 +39,25 @@ where
         normal: vector(0.0, 0.0),
     };
 
-    let mut prev = point(0.0, 0.0);
-    let mut first = point(0.0, 0.0);
-
     for evt in path {
         match evt {
-            PathEvent::MoveTo(to) => {
-                prev = to;
-                first = to;
-            }
-            PathEvent::Line(ref segment) => {
+            PathEvent::MoveTo(..) => {}
+            PathEvent::Line(ref segment) | PathEvent::Close(ref segment) => {
                 test_segment(&mut state, segment);
-                prev = segment.to;
             }
             PathEvent::Quadratic(ref segment) => {
+                let mut prev = segment.from;
                 segment.for_each_flattened(tolerance, &mut|p| {
                     test_segment(&mut state, &LineSegment { from: prev, to: p });
                     prev = p;
                 });
             }
             PathEvent::Cubic(ref segment) => {
+                let mut prev = segment.from;
                 segment.for_each_flattened(tolerance, &mut|p| {
                     test_segment(&mut state, &LineSegment { from: prev, to: p });
                     prev = p;
                 });
-            }
-            PathEvent::Close => {
-                test_segment(&mut state, &LineSegment { from: prev, to: first });
             }
         }
     }

--- a/algorithms/src/raycast.rs
+++ b/algorithms/src/raycast.rs
@@ -2,7 +2,7 @@
 
 use path::PathEvent;
 use math::{Point, point, Vector, vector};
-use geom::{LineSegment, QuadraticBezierSegment, CubicBezierSegment, Line};
+use geom::{LineSegment, Line};
 use std::f32;
 
 pub struct Ray {
@@ -48,20 +48,18 @@ where
                 prev = to;
                 first = to;
             }
-            PathEvent::LineTo(to) => {
-                test_segment(&mut state, &LineSegment { from: prev, to });
-                prev = to;
+            PathEvent::Line(ref segment) => {
+                test_segment(&mut state, segment);
+                prev = segment.to;
             }
-            PathEvent::QuadraticTo(ctrl, to) => {
-                let quad = QuadraticBezierSegment { from: prev, ctrl, to };
-                quad.for_each_flattened(tolerance, &mut|p| {
+            PathEvent::Quadratic(ref segment) => {
+                segment.for_each_flattened(tolerance, &mut|p| {
                     test_segment(&mut state, &LineSegment { from: prev, to: p });
                     prev = p;
                 });
             }
-            PathEvent::CubicTo(ctrl1, ctrl2, to) => {
-                let cubic = CubicBezierSegment { from: prev, ctrl1, ctrl2, to };
-                cubic.for_each_flattened(tolerance, &mut|p| {
+            PathEvent::Cubic(ref segment) => {
+                segment.for_each_flattened(tolerance, &mut|p| {
                     test_segment(&mut state, &LineSegment { from: prev, to: p });
                     prev = p;
                 });

--- a/algorithms/src/splitter.rs
+++ b/algorithms/src/splitter.rs
@@ -306,7 +306,7 @@ impl Splitter {
 
     fn to_advanced_path(&mut self, path: PathSlice, adv: &mut AdvancedPath) {
         self.point_buffer.clear();
-        for evt in path.path_iter().flattened(self.flattening_tolerance) {
+        for evt in path.iter().flattened(self.flattening_tolerance) {
             match evt {
                 FlattenedEvent::MoveTo(to) => {
                     if self.point_buffer.len() > 2 {

--- a/algorithms/src/walk.rs
+++ b/algorithms/src/walk.rs
@@ -30,7 +30,7 @@
 //!     let tolerance = 0.01; // The path flattening tolerance.
 //!     let start_offset = 0.0; // Start walking at the beginning of the path.
 //!     walk_along_path(
-//!         path.path_iter().flattened(tolerance),
+//!         path.iter().flattened(tolerance),
 //!         start_offset,
 //!         &mut pattern
 //!     );

--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -26,7 +26,7 @@ fn flattening_01_logo_simple_iter(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            for _ in path.path_iter().flattened(0.05) {}
+            for _ in path.iter().flattened(0.05) {}
         }
     })
 }
@@ -41,7 +41,7 @@ fn flattening_02_logo_iter(bench: &mut Bencher) {
     bench.iter(|| {
         let mut builder = Path::builder();
         for _ in 0..N {
-            for evt in path.path_iter().flattened(0.05) {
+            for evt in path.iter().flattened(0.05) {
                 builder.flat_event(evt);
             }
         }
@@ -56,7 +56,7 @@ fn flattening_03_logo_builder(bench: &mut Bencher) {
     bench.iter(|| {
         let mut builder = Path::builder().flattened(0.05);
         for _ in 0..N {
-            for evt in path.path_iter() {
+            for evt in path.iter() {
                 builder.path_event(evt);
             }
         }
@@ -70,7 +70,7 @@ fn fill_tess_01_logo(bench: &mut Bencher) {
 
     let mut tess = FillTessellator::new();
     let options = FillOptions::default();
-    let events = FillEvents::from_path(0.05, path.path_iter());
+    let events = FillEvents::from_path(0.05, path.iter());
 
     bench.iter(|| {
         for _ in 0..N {
@@ -87,7 +87,7 @@ fn fill_tess_02_logo_no_normals(bench: &mut Bencher) {
 
     let mut tess = FillTessellator::new();
     let options = FillOptions::default().with_normals(false);
-    let events = FillEvents::from_path(0.05, path.path_iter());
+    let events = FillEvents::from_path(0.05, path.iter());
 
     bench.iter(|| {
         for _ in 0..N {
@@ -104,7 +104,7 @@ fn fill_tess_03_logo_no_intersections(bench: &mut Bencher) {
 
     let mut tess = FillTessellator::new();
     let options = FillOptions::default().assume_no_intersections();
-    let events = FillEvents::from_path(0.05, path.path_iter());
+    let events = FillEvents::from_path(0.05, path.iter());
 
     bench.iter(|| {
         for _ in 0..N {
@@ -123,7 +123,7 @@ fn fill_tess_04_logo_no_normals_no_intersections(bench: &mut Bencher) {
     let options = FillOptions::default()
         .with_normals(false)
         .assume_no_intersections();
-    let events = FillEvents::from_path(0.05, path.path_iter());
+    let events = FillEvents::from_path(0.05, path.iter());
 
     bench.iter(|| {
         for _ in 0..N {
@@ -140,7 +140,7 @@ fn fill_tess_05_logo_no_curve(bench: &mut Bencher) {
 
     let mut tess = FillTessellator::new();
     let options = FillOptions::default();
-    let events = FillEvents::from_path(1000000.0, path.path_iter());
+    let events = FillEvents::from_path(1000000.0, path.iter());
 
     bench.iter(|| {
         for _ in 0..N {
@@ -165,7 +165,7 @@ fn cmp_01_libtess2_rust_logo(bench: &mut Bencher) {
     let mut contours = Vec::new();
 
     let tolerance = FillOptions::default().tolerance;
-    for evt in path.path_iter().flattened(tolerance) {
+    for evt in path.iter().flattened(tolerance) {
         match evt {
             FlattenedEvent::MoveTo(p) => {
                 contours.push(vec![p]);
@@ -228,7 +228,7 @@ fn cmp_02_lyon_rust_logo(bench: &mut Bencher) {
         for _ in 0..N {
             let mut tess = FillTessellator::new();
             let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::new();
-            tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers)).unwrap();
+            tess.tessellate_path(&path, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
 }
@@ -240,7 +240,7 @@ fn fill_events_01_logo(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let _events = FillEvents::from_path(0.05, path.path_iter());
+            let _events = FillEvents::from_path(0.05, path.iter());
         }
     })
 }
@@ -252,7 +252,7 @@ fn fill_events_02_logo_pre_flattened(bench: &mut Bencher) {
 
     bench.iter(|| {
         for _ in 0..N {
-            let _events = FillEvents::from_path(0.05, path.path_iter());
+            let _events = FillEvents::from_path(0.05, path.iter());
         }
     })
 }
@@ -268,7 +268,7 @@ fn fill_events_03_logo_with_tess(bench: &mut Bencher) {
     bench.iter(|| {
         for _ in 0..N {
             let mut buffers: VertexBuffers<FillVertex, u16> = VertexBuffers::new();
-            tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers)).unwrap();
+            tess.tessellate_path(&path, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
 }
@@ -284,7 +284,7 @@ fn stroke_01_logo_miter(bench: &mut Bencher) {
     bench.iter(|| {
         for _ in 0..N {
             let mut buffers: VertexBuffers<StrokeVertex, u16> = VertexBuffers::with_capacity(1024, 3000);
-            tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers)).unwrap();
+            tess.tessellate_path(&path, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
 }
@@ -300,7 +300,7 @@ fn stroke_02_logo_bevel(bench: &mut Bencher) {
     bench.iter(|| {
         for _ in 0..N {
             let mut buffers: VertexBuffers<StrokeVertex, u16> = VertexBuffers::with_capacity(1024, 3000);
-            tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers)).unwrap();
+            tess.tessellate_path(&path, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
 }
@@ -316,7 +316,7 @@ fn stroke_03_logo_round(bench: &mut Bencher) {
     bench.iter(|| {
         for _ in 0..N {
             let mut buffers: VertexBuffers<StrokeVertex, u16> = VertexBuffers::with_capacity(1024, 3000);
-            tess.tessellate_path(path.path_iter(), &options, &mut simple_builder(&mut buffers)).unwrap();
+            tess.tessellate_path(&path, &options, &mut simple_builder(&mut buffers)).unwrap();
         }
     })
 }

--- a/cli/src/flatten.rs
+++ b/cli/src/flatten.rs
@@ -21,7 +21,7 @@ pub fn flatten(mut cmd: PathCmd) -> Result<(), FlattenError> {
         // TODO: when flatten is false we should count vertices, curves, etc.
         let mut num_paths = 0;
         let mut num_vertices = 0;
-        for event in cmd.path.path_iter().flattened(cmd.tolerance) {
+        for event in cmd.path.iter().flattened(cmd.tolerance) {
             match event {
                 FlattenedEvent::MoveTo(_) => {
                     num_vertices += 1;
@@ -40,7 +40,7 @@ pub fn flatten(mut cmd: PathCmd) -> Result<(), FlattenError> {
         return Ok(());
     }
 
-    for event in cmd.path.path_iter().flattened(cmd.tolerance) {
+    for event in cmd.path.iter().flattened(cmd.tolerance) {
         match event {
             FlattenedEvent::MoveTo(p) => {
                 try!{ write!(&mut *cmd.output, "M {} {} ", p.x, p.y) };

--- a/cli/src/flatten.rs
+++ b/cli/src/flatten.rs
@@ -30,7 +30,7 @@ pub fn flatten(mut cmd: PathCmd) -> Result<(), FlattenError> {
                 FlattenedEvent::Line(_) => {
                     num_vertices += 1;
                 }
-                FlattenedEvent::Close => {}
+                FlattenedEvent::Close(_) => {}
             }
         }
 
@@ -48,7 +48,7 @@ pub fn flatten(mut cmd: PathCmd) -> Result<(), FlattenError> {
             FlattenedEvent::Line(segment) => {
                 try!{ write!(&mut *cmd.output, "L {} {} ", segment.to.x, segment.to.y) };
             }
-            FlattenedEvent::Close => {
+            FlattenedEvent::Close(..) => {
                 try!{ write!(&mut *cmd.output, "Z") };
             }
         }

--- a/cli/src/flatten.rs
+++ b/cli/src/flatten.rs
@@ -27,7 +27,7 @@ pub fn flatten(mut cmd: PathCmd) -> Result<(), FlattenError> {
                     num_vertices += 1;
                     num_paths += 1;
                 }
-                FlattenedEvent::LineTo(_) => {
+                FlattenedEvent::Line(_) => {
                     num_vertices += 1;
                 }
                 FlattenedEvent::Close => {}
@@ -45,8 +45,8 @@ pub fn flatten(mut cmd: PathCmd) -> Result<(), FlattenError> {
             FlattenedEvent::MoveTo(p) => {
                 try!{ write!(&mut *cmd.output, "M {} {} ", p.x, p.y) };
             }
-            FlattenedEvent::LineTo(p) => {
-                try!{ write!(&mut *cmd.output, "L {} {} ", p.x, p.y) };
+            FlattenedEvent::Line(segment) => {
+                try!{ write!(&mut *cmd.output, "L {} {} ", segment.to.x, segment.to.y) };
             }
             FlattenedEvent::Close => {
                 try!{ write!(&mut *cmd.output, "Z") };

--- a/cli/src/fuzzing.rs
+++ b/cli/src/fuzzing.rs
@@ -79,7 +79,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
                 match cmd.tessellator {
                     Tessellator::Default => {
                         let result = FillTessellator::new().tessellate_path(
-                            path.path_iter(),
+                            &path,
                             &options,
                             &mut NoOutput::new()
                         );
@@ -89,7 +89,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
                     }
                     Tessellator::Tess2 => {
                         let result = tess2::FillTessellator::new().tessellate_path(
-                            path.path_iter(),
+                            &path,
                             &options,
                             &mut NoOutput::new()
                         );
@@ -107,7 +107,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
                     path.as_slice(),
                     &|path: Path| {
                         FillTessellator::new().tessellate_path(
-                            path.path_iter(),
+                            &path,
                             &FillOptions::default(),
                             &mut NoOutput::new()
                         ).is_err()
@@ -119,7 +119,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
         }
         if cmd.stroke {
             StrokeTessellator::new().tessellate_path(
-                path.path_iter(),
+                &path,
                 &StrokeOptions::default(),
                 &mut NoOutput::new()
             ).unwrap();

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -27,7 +27,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
     if let Some(options) = cmd.stroke {
         stroke_width = options.line_width;
         StrokeTessellator::new().tessellate_path(
-            cmd.path.path_iter(),
+            cmd.path.iter(),
             &options,
             &mut BuffersBuilder::new(&mut geometry, WithId(1))
         ).unwrap();
@@ -37,7 +37,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         let mut path = Path::builder();
         let mut hatcher = Hatcher::new();
         hatcher.hatch_path(
-            cmd.path.path_iter(),
+            cmd.path.iter(),
             &hatch.options,
             &mut RegularHatchingPattern {
                 interval: hatch.spacing,
@@ -51,7 +51,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         let hatched_path = path.build();
 
         StrokeTessellator::new().tessellate_path(
-            hatched_path.path_iter(),
+            hatched_path.iter(),
             &hatch.stroke,
             &mut BuffersBuilder::new(&mut geometry, WithId(1))
         ).unwrap();
@@ -61,7 +61,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         let mut path = Path::builder();
         let mut hatcher = Hatcher::new();
         hatcher.dot_path(
-            cmd.path.path_iter(),
+            cmd.path.iter(),
             &dots.options,
             &mut RegularDotPattern {
                 row_interval: dots.spacing,
@@ -74,7 +74,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         let dotted_path = path.build();
 
         StrokeTessellator::new().tessellate_path(
-            dotted_path.path_iter(),
+            dotted_path.iter(),
             &dots.stroke,
             &mut BuffersBuilder::new(&mut geometry, WithId(1))
         ).unwrap();
@@ -91,7 +91,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
                     dbg_rx
                 });
                 tess.tessellate_path(
-                    cmd.path.path_iter(),
+                    cmd.path.iter(),
                     &options,
                     &mut BuffersBuilder::new(&mut geometry, WithId(0))
                 ).unwrap();
@@ -101,7 +101,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
             }
             Tessellator::Tess2 => {
                 tess2::FillTessellator::new().tessellate_path(
-                    cmd.path.path_iter(),
+                    cmd.path.iter(),
                     &options,
                     &mut BuffersBuilder::new(&mut geometry, WithId(0))
                 ).unwrap();
@@ -417,7 +417,7 @@ fn get_debug_geometry(
     let path = edge_path.build();
 
     StrokeTessellator::new().tessellate_path(
-        path.path_iter(),
+        path.iter(),
         &StrokeOptions::default().dont_apply_line_width(),
         &mut BuffersBuilder::new(edges, WithId(2)),
     ).unwrap();

--- a/cli/src/tessellate/mod.rs
+++ b/cli/src/tessellate/mod.rs
@@ -31,14 +31,14 @@ pub fn tessellate_path(cmd: TessellateCmd) -> Result<VertexBuffers<Point, u16>, 
         let ok = match cmd.tessellator {
             Tessellator::Default => {
                 FillTessellator::new().tessellate_path(
-                    cmd.path.path_iter(),
+                    &cmd.path,
                     &options,
                     &mut BuffersBuilder::new(&mut buffers, VertexCtor)
                 ).is_ok()
             }
             Tessellator::Tess2 => {
                 tess2::FillTessellator::new().tessellate_path(
-                    cmd.path.path_iter(),
+                    &cmd.path,
                     &options,
                     &mut BuffersBuilder::new(&mut buffers, Identity)
                 ).is_ok()
@@ -53,7 +53,7 @@ pub fn tessellate_path(cmd: TessellateCmd) -> Result<VertexBuffers<Point, u16>, 
 
     if let Some(options) = cmd.stroke {
         let ok = StrokeTessellator::new().tessellate_path(
-            cmd.path.path_iter(),
+            &cmd.path,
             &options,
             &mut BuffersBuilder::new(&mut buffers, VertexCtor)
         ).is_ok();

--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -7,9 +7,7 @@ extern crate lyon;
 
 use lyon::extra::rust_logo::build_logo_path;
 use lyon::path::builder::*;
-use lyon::path::iterator::*;
 use lyon::path::Path;
-use lyon::path::SvgEvent;
 use lyon::math::*;
 use lyon::tessellation::geometry_builder::{VertexConstructor, VertexBuffers, BuffersBuilder};
 use lyon::tessellation::basic_shapes::*;
@@ -25,13 +23,6 @@ use glutin::dpi::LogicalSize;
 
 use std::ops::Rem;
 
-
-//type ColorFormat = gfx::format::Rgba8;
-//type DepthFormat = gfx::format::DepthStencil;
-//type Pso<T> = gfx::PipelineState<gfx_device_gl::Resources, T>;
-//type Vbo<T> = gfx::handle::Buffer<gfx_device_gl::Resources, T>;
-//type BufferObject<T> = gfx::handle::Buffer<gfx_device_gl::Resources, T>;
-//type IndexSlice = gfx::Slice<gfx_device_gl::Resources>;
 
 pub fn split_gfx_slice<R: gfx::Resources>(
     slice: gfx::Slice<R>,
@@ -68,39 +59,9 @@ fn main() {
     let num_instances = 32;
     let tolerance = 0.02;
 
-    use lyon::geom::{math::Angle, ArcFlags};
     // Build a Path for the rust logo.
     let mut builder = SvgPathBuilder::new(Path::builder());
-    //builder.move_to(point(600.0,350.0));
-    //builder.relative_line_to(vector(50.0,-25.0));
-    //builder.relative_arc_to(vector(25.0, 25.0), Angle::degrees(-30.0), ArcFlags { large_arc: false, sweep: true }, vector(50.0,-25.0));
-    //builder.relative_line_to(vector(50.0,-25.0));
-    //builder.relative_arc_to(vector(25.0, 50.0), Angle::degrees(-30.0), ArcFlags { large_arc: false, sweep: true }, vector(50.0,-25.0));
-    //builder.relative_line_to(vector(50.0,-25.0));
-    //builder.relative_arc_to(vector(25.0, 75.0), Angle::degrees(-30.0), ArcFlags { large_arc: false, sweep: true }, vector(50.0,-25.0));
-    //builder.relative_line_to(vector(50.0,-25.0));
-    //builder.relative_arc_to(vector(25.0, 100.0), Angle::degrees(-30.0), ArcFlags { large_arc: false, sweep: true }, vector(50.0,-25.0));
-    //builder.relative_line_to(vector(50.0,-25.0));
-
-    let evts = [
-    SvgEvent::MoveTo(point(600.0,350.0)),
-    SvgEvent::RelativeLineTo(vector(50.0,-25.0)),
-    SvgEvent::RelativeArcTo(vector(25.0, 25.0), Angle::degrees(-30.0), ArcFlags { large_arc: false, sweep: true }, vector(50.0,-25.0)),
-    SvgEvent::RelativeLineTo(vector(50.0,-25.0)),
-    SvgEvent::RelativeArcTo(vector(25.0, 50.0), Angle::degrees(-30.0), ArcFlags { large_arc: false, sweep: true }, vector(50.0,-25.0)),
-    SvgEvent::RelativeLineTo(vector(50.0,-25.0)),
-    SvgEvent::RelativeArcTo(vector(25.0, 75.0), Angle::degrees(-30.0), ArcFlags { large_arc: false, sweep: true }, vector(50.0,-25.0)),
-    SvgEvent::RelativeLineTo(vector(50.0,-25.0)),
-    SvgEvent::RelativeArcTo(vector(25.0, 100.0), Angle::degrees(-30.0), ArcFlags { large_arc: false, sweep: true }, vector(50.0,-25.0)),
-    SvgEvent::RelativeLineTo(vector(50.0,-25.0)),
-    ];
-
-    for e in evts.iter() {
-        builder.svg_event(*e);
-    }
-
-
-    //build_logo_path(&mut builder);
+    build_logo_path(&mut builder);
     let path = builder.build();
 
     let mut geometry: VertexBuffers<GpuVertex, u16> = VertexBuffers::new();

--- a/examples/gfx_advanced/src/main.rs
+++ b/examples/gfx_advanced/src/main.rs
@@ -109,13 +109,13 @@ fn main() {
     let fill_prim_id = 1;
 
     let fill_count = FillTessellator::new().tessellate_path(
-        path.path_iter(),
+        &path,
         &FillOptions::tolerance(tolerance),
         &mut BuffersBuilder::new(&mut geometry, WithId(fill_prim_id as i32))
     ).unwrap();
 
     StrokeTessellator::new().tessellate_path(
-        path.path_iter(),
+        &path,
         &StrokeOptions::tolerance(tolerance).dont_apply_line_width(),
         &mut BuffersBuilder::new(&mut geometry, WithId(stroke_prim_id as i32))
     ).unwrap();

--- a/examples/gfx_basic/src/main.rs
+++ b/examples/gfx_basic/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
     let mut mesh: VertexBuffers<GpuFillVertex, u16> = VertexBuffers::new();
 
     tessellator.tessellate_path(
-        path.path_iter(),
+        &path,
         &FillOptions::tolerance(0.01),
         &mut BuffersBuilder::new(&mut mesh, VertexCtor),
     ).unwrap();

--- a/examples/glium_basic/src/main.rs
+++ b/examples/glium_basic/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
     let mut mesh: VertexBuffers<Vertex, u16> = VertexBuffers::new();
     tessellator
         .tessellate_path(
-            path.path_iter(),
+            &path,
             &FillOptions::tolerance(0.01),
             &mut BuffersBuilder::new(&mut mesh, VertexCtor),
         )

--- a/examples/intersections/src/main.rs
+++ b/examples/intersections/src/main.rs
@@ -89,7 +89,7 @@ fn main() {
 
     let stroke_options = StrokeOptions::tolerance(tolerance).dont_apply_line_width();
     StrokeTessellator::new().tessellate_path(
-        bezier_path.path_iter(),
+        &bezier_path,
         &stroke_options,
         &mut BuffersBuilder::new(
             &mut geometry,
@@ -97,7 +97,7 @@ fn main() {
         ),
     ).unwrap();
     StrokeTessellator::new().tessellate_path(
-        line_path.path_iter(),
+        &line_path,
         &stroke_options,
         &mut BuffersBuilder::new(
             &mut geometry,

--- a/examples/svg_render/src/main.rs
+++ b/examples/svg_render/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
                 ));
 
                 fill_tess.tessellate_path(
-                    convert_path(p).path_iter(),
+                    convert_path(p),
                     &FillOptions::tolerance(0.01),
                     &mut BuffersBuilder::new(
                         &mut mesh,
@@ -128,7 +128,7 @@ fn main() {
                     stroke.opacity.value() as f32
                 ));
                 let _ = stroke_tess.tessellate_path(
-                    convert_path(p).path_iter(),
+                    convert_path(p),
                     &stroke_opts.with_tolerance(0.01),
                     &mut BuffersBuilder::new(
                         &mut mesh,

--- a/examples/svg_render/src/path_convert.rs
+++ b/examples/svg_render/src/path_convert.rs
@@ -1,4 +1,3 @@
-use std::iter;
 use std::slice;
 
 use lyon::math::Point;
@@ -20,13 +19,18 @@ type SegmentIter<'a> = slice::Iter<'a, PathSegment>;
 pub struct PathConvIter<'a> {
     iter: slice::Iter<'a, PathSegment>,
     prev: Point,
+    first: Point,
 }
 
 // Provide a function which gives back a PathIter which is compatible with
 // tessellators, so we don't have to implement the PathIterator trait
 impl<'a> PathConv<'a> {
     pub fn path_iter(self) -> PathIter<PathConvIter<'a>> {
-        PathIter::new(PathConvIter { iter: self.0, prev: Point::new(0.0, 0.0), })
+        PathIter::new(PathConvIter {
+            iter: self.0,
+            prev: Point::new(0.0, 0.0),
+            first: Point::new(0.0, 0.0),
+        })
     }
 }
 
@@ -36,6 +40,7 @@ impl<'l> Iterator for PathConvIter<'l> {
         match self.iter.next() {
             Some(PathSegment::MoveTo { x, y }) => {
                 self.prev = point(x, y);
+                self.first = self.prev;
                 Some(PathEvent::MoveTo(self.prev))
             }
             Some(PathSegment::LineTo { x, y }) => {
@@ -53,7 +58,13 @@ impl<'l> Iterator for PathConvIter<'l> {
                     to: self.prev,
                 }))
             }
-            Some(PathSegment::ClosePath) => Some(PathEvent::Close),
+            Some(PathSegment::ClosePath) => {
+                self.prev = self.first;
+                Some(PathEvent::Close(LineSegment {
+                    from: self.prev,
+                    to: self.first,
+                }))
+            }
             None => None,
         }
     }

--- a/examples/svg_render/src/path_convert.rs
+++ b/examples/svg_render/src/path_convert.rs
@@ -2,53 +2,39 @@ use std::slice;
 
 use lyon::math::Point;
 use lyon::path::PathEvent;
-use lyon::path::iterator::PathIter;
 use lyon::geom::{LineSegment, CubicBezierSegment};
 
-use usvg::{Path, PathSegment};
+use usvg;
+
+// This module implements some glue between usvg and lyon.
+// PathConvIter translate usvg's path data structure into an
+// iterator of lyon's PathEvent.
 
 fn point(x: &f64, y: &f64) -> Point {
     Point::new((*x) as f32, (*y) as f32)
 }
 
-pub struct PathConv<'a>(SegmentIter<'a>);
-
-// Alias for the iterator returned by usvg::Path::iter()
-type SegmentIter<'a> = slice::Iter<'a, PathSegment>;
-
 pub struct PathConvIter<'a> {
-    iter: slice::Iter<'a, PathSegment>,
+    iter: slice::Iter<'a, usvg::PathSegment>,
     prev: Point,
     first: Point,
-}
-
-// Provide a function which gives back a PathIter which is compatible with
-// tessellators, so we don't have to implement the PathIterator trait
-impl<'a> PathConv<'a> {
-    pub fn path_iter(self) -> PathIter<PathConvIter<'a>> {
-        PathIter::new(PathConvIter {
-            iter: self.0,
-            prev: Point::new(0.0, 0.0),
-            first: Point::new(0.0, 0.0),
-        })
-    }
 }
 
 impl<'l> Iterator for PathConvIter<'l> {
     type Item = PathEvent;
     fn next(&mut self) -> Option<PathEvent> {
         match self.iter.next() {
-            Some(PathSegment::MoveTo { x, y }) => {
+            Some(usvg::PathSegment::MoveTo { x, y }) => {
                 self.prev = point(x, y);
                 self.first = self.prev;
                 Some(PathEvent::MoveTo(self.prev))
             }
-            Some(PathSegment::LineTo { x, y }) => {
+            Some(usvg::PathSegment::LineTo { x, y }) => {
                 let from = self.prev;
                 self.prev = point(x, y);
                 Some(PathEvent::Line(LineSegment { from, to: self.prev }))
             }
-            Some(PathSegment::CurveTo { x1, y1, x2, y2, x, y, }) => {
+            Some(usvg::PathSegment::CurveTo { x1, y1, x2, y2, x, y, }) => {
                 let from = self.prev;
                 self.prev = point(x, y);
                 Some(PathEvent::Cubic(CubicBezierSegment {
@@ -58,7 +44,7 @@ impl<'l> Iterator for PathConvIter<'l> {
                     to: self.prev,
                 }))
             }
-            Some(PathSegment::ClosePath) => {
+            Some(usvg::PathSegment::ClosePath) => {
                 self.prev = self.first;
                 Some(PathEvent::Close(LineSegment {
                     from: self.prev,
@@ -70,6 +56,10 @@ impl<'l> Iterator for PathConvIter<'l> {
     }
 }
 
-pub fn convert_path<'a>(p: &'a Path) -> PathConv<'a> {
-    PathConv(p.segments.iter())
+pub fn convert_path<'a>(p: &'a usvg::Path) -> PathConvIter<'a> {
+    PathConvIter {
+        iter: p.segments.iter(),
+        first: Point::new(0.0, 0.0),
+        prev: Point::new(0.0, 0.0),
+    }
 }

--- a/examples/walk_path/src/main.rs
+++ b/examples/walk_path/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
     let mut geometry: VertexBuffers<GpuVertex, u16> = VertexBuffers::new();
 
     FillTessellator::new().tessellate_path(
-        arrow_path.path_iter(),
+        &arrow_path,
         &FillOptions::tolerance(tolerance),
         &mut BuffersBuilder::new(&mut geometry, WithId(0))
     ).unwrap();
@@ -163,7 +163,7 @@ fn main() {
             // Walk along the logo and apply the pattern. This will invoke
             // the pattern's callback that fills the primitive buffer.
             walk::walk_along_path(
-                logo_path.path_iter().flattened(0.01),
+                logo_path.iter().flattened(0.01),
                 offset,
                 &mut walk::RepeatedPattern {
                     callback: |pos: Point, tangent: Vector, _| {

--- a/extra/src/debugging.rs
+++ b/extra/src/debugging.rs
@@ -20,7 +20,7 @@ pub fn path_to_polygons(path: PathSlice) -> Polygons {
             PathEvent::Line(segment) => {
                 poly.push(segment.to);
             }
-            PathEvent::Close => {
+            PathEvent::Close(..) => {
                 if !poly.is_empty() {
                     polygons.push(poly);
                 }

--- a/extra/src/debugging.rs
+++ b/extra/src/debugging.rs
@@ -9,7 +9,7 @@ pub type Polygons = Vec<Vec<Point>>;
 pub fn path_to_polygons(path: PathSlice) -> Polygons {
     let mut polygons = Vec::new();
     let mut poly = Vec::new();
-    for evt in path.path_iter() {
+    for evt in path {
         match evt {
             PathEvent::MoveTo(to) => {
                 if poly.len() > 0 {

--- a/extra/src/debugging.rs
+++ b/extra/src/debugging.rs
@@ -17,8 +17,8 @@ pub fn path_to_polygons(path: PathSlice) -> Polygons {
                 }
                 poly = vec![to];
             }
-            PathEvent::LineTo(to) => {
-                poly.push(to);
+            PathEvent::Line(segment) => {
+                poly.push(segment.to);
             }
             PathEvent::Close => {
                 if !poly.is_empty() {

--- a/path/src/builder.rs
+++ b/path/src/builder.rs
@@ -116,7 +116,7 @@ pub trait FlatPathBuilder {
             FlattenedEvent::Line(segment) => {
                 self.line_to(segment.to);
             }
-            FlattenedEvent::Close => {
+            FlattenedEvent::Close(..) => {
                 self.close();
             }
         }
@@ -149,7 +149,7 @@ pub trait PathBuilder: FlatPathBuilder {
             PathEvent::Cubic(segment) => {
                 self.cubic_bezier_to(segment.ctrl1, segment.ctrl2, segment.to);
             }
-            PathEvent::Close => {
+            PathEvent::Close(..) => {
                 self.close();
             }
         }

--- a/path/src/builder.rs
+++ b/path/src/builder.rs
@@ -113,8 +113,8 @@ pub trait FlatPathBuilder {
             FlattenedEvent::MoveTo(to) => {
                 self.move_to(to);
             }
-            FlattenedEvent::LineTo(to) => {
-                self.line_to(to);
+            FlattenedEvent::Line(segment) => {
+                self.line_to(segment.to);
             }
             FlattenedEvent::Close => {
                 self.close();
@@ -140,14 +140,14 @@ pub trait PathBuilder: FlatPathBuilder {
             PathEvent::MoveTo(to) => {
                 self.move_to(to);
             }
-            PathEvent::LineTo(to) => {
-                self.line_to(to);
+            PathEvent::Line(segment) => {
+                self.line_to(segment.to);
             }
-            PathEvent::QuadraticTo(ctrl, to) => {
-                self.quadratic_bezier_to(ctrl, to);
+            PathEvent::Quadratic(segment) => {
+                self.quadratic_bezier_to(segment.ctrl, segment.to);
             }
-            PathEvent::CubicTo(ctrl1, ctrl2, to) => {
-                self.cubic_bezier_to(ctrl1, ctrl2, to);
+            PathEvent::Cubic(segment) => {
+                self.cubic_bezier_to(segment.ctrl1, segment.ctrl2, segment.to);
             }
             PathEvent::Close => {
                 self.close();

--- a/path/src/builder.rs
+++ b/path/src/builder.rs
@@ -78,6 +78,7 @@ use math::*;
 use events::{PathEvent, FlattenedEvent, SvgEvent};
 use geom::{CubicBezierSegment, QuadraticBezierSegment, SvgArc, Arc, ArcFlags};
 use path_state::PathState;
+use std::marker::Sized;
 
 pub trait Build {
     /// The type of object that is created by this builder.
@@ -91,7 +92,7 @@ pub trait Build {
 }
 
 /// The most basic path building interface. Does not handle any kind of curve.
-pub trait FlatPathBuilder: ::std::marker::Sized {
+pub trait FlatPathBuilder {
     /// Sets the current position in preparation for the next sub-path.
     /// If the current sub-path contains edges, this ends the sub-path without closing it.
     fn move_to(&mut self, to: Point);
@@ -122,7 +123,7 @@ pub trait FlatPathBuilder: ::std::marker::Sized {
     }
 
     /// Returns a builder that approximates all curves with sequences of line segments.
-    fn flattened(self, tolerance: f32) -> FlatteningBuilder<Self> {
+    fn flattened(self, tolerance: f32) -> FlatteningBuilder<Self> where Self: Sized {
         FlatteningBuilder::new(self, tolerance)
     }
 }
@@ -155,7 +156,7 @@ pub trait PathBuilder: FlatPathBuilder {
     }
 
     /// Returns a builder that support svg commands.
-    fn with_svg(self) -> SvgPathBuilder<Self> { SvgPathBuilder::new(self) }
+    fn with_svg(self) -> SvgPathBuilder<Self> where Self : Sized { SvgPathBuilder::new(self) }
 }
 
 /// A path building interface that tries to stay close to SVG's path specification.

--- a/path/src/events.rs
+++ b/path/src/events.rs
@@ -43,7 +43,7 @@ pub enum PathEvent {
     Line(LineSegment<f32>),
     Quadratic(QuadraticBezierSegment<f32>),
     Cubic(CubicBezierSegment<f32>),
-    Close,
+    Close(LineSegment<f32>),
 }
 
 /// Path event enum that can only present quadratic bézier curves and line segments.
@@ -55,7 +55,7 @@ pub enum QuadraticEvent {
     MoveTo(Point),
     Line(LineSegment<f32>),
     Quadratic(QuadraticBezierSegment<f32>),
-    Close,
+    Close(LineSegment<f32>),
 }
 
 /// Path event enum that can only present line segments.
@@ -66,7 +66,7 @@ pub enum QuadraticEvent {
 pub enum FlattenedEvent {
     MoveTo(Point),
     Line(LineSegment<f32>),
-    Close,
+    Close(LineSegment<f32>),
 }
 
 impl FlattenedEvent {
@@ -74,7 +74,7 @@ impl FlattenedEvent {
         match self {
             FlattenedEvent::MoveTo(to) => SvgEvent::MoveTo(to),
             FlattenedEvent::Line(segment) => SvgEvent::LineTo(segment.to),
-            FlattenedEvent::Close => SvgEvent::Close,
+            FlattenedEvent::Close(..) => SvgEvent::Close,
         }
     }
 
@@ -82,7 +82,7 @@ impl FlattenedEvent {
         match self {
             FlattenedEvent::MoveTo(to) => PathEvent::MoveTo(to),
             FlattenedEvent::Line(segment) => PathEvent::Line(segment),
-            FlattenedEvent::Close => PathEvent::Close,
+            FlattenedEvent::Close(segment) => PathEvent::Close(segment),
         }
     }
 }
@@ -101,7 +101,7 @@ impl QuadraticEvent {
             QuadraticEvent::MoveTo(to) => SvgEvent::MoveTo(to),
             QuadraticEvent::Line(segment) => SvgEvent::LineTo(segment.to),
             QuadraticEvent::Quadratic(segment) => SvgEvent::QuadraticTo(segment.ctrl, segment.to),
-            QuadraticEvent::Close => SvgEvent::Close,
+            QuadraticEvent::Close(..) => SvgEvent::Close,
         }
     }
 
@@ -110,7 +110,7 @@ impl QuadraticEvent {
             QuadraticEvent::MoveTo(to) => PathEvent::MoveTo(to),
             QuadraticEvent::Line(segment) => PathEvent::Line(segment),
             QuadraticEvent::Quadratic(segment) => PathEvent::Quadratic(segment),
-            QuadraticEvent::Close => PathEvent::Close,
+            QuadraticEvent::Close(segment) => PathEvent::Close(segment),
         }
     }
 }
@@ -124,7 +124,9 @@ impl Transform for FlattenedEvent {
             FlattenedEvent::Line(ref segment) => {
                 FlattenedEvent::Line(segment.transform(mat))
             }
-            FlattenedEvent::Close => { FlattenedEvent::Close }
+            FlattenedEvent::Close(ref segment) => {
+                FlattenedEvent::Close(segment.transform(mat))
+            }
         }
     }
 }
@@ -138,10 +140,12 @@ impl Transform for QuadraticEvent {
             QuadraticEvent::Line(ref segment) => {
                 QuadraticEvent::Line(segment.transform(mat))
             }
-            QuadraticEvent::Quadratic(segment) => {
+            QuadraticEvent::Quadratic(ref segment) => {
                 QuadraticEvent::Quadratic(segment.transform(mat))
             }
-            QuadraticEvent::Close => { QuadraticEvent::Close }
+            QuadraticEvent::Close(ref segment) => {
+                QuadraticEvent::Close(segment.transform(mat))
+            }
         }
     }
 }
@@ -153,7 +157,7 @@ impl Transform for PathEvent {
             PathEvent::Line(ref segment) => { PathEvent::Line(segment.transform(mat)) }
             PathEvent::Quadratic(ref segment) => { PathEvent::Quadratic(segment.transform(mat)) }
             PathEvent::Cubic(ref segment) => { PathEvent::Cubic(segment.transform(mat)) }
-            PathEvent::Close => { PathEvent::Close }
+            PathEvent::Close(ref segment) => { PathEvent::Close(segment.transform(mat)) }
         }
     }
 }

--- a/path/src/path.rs
+++ b/path/src/path.rs
@@ -346,6 +346,147 @@ impl Builder {
     }
 }
 
+pub fn reverse_path(path: PathSlice, builder: &mut dyn PathBuilder) {
+    let points = &path.points[..];
+    // At each iteration, p points to the first point after the current verb.
+    let mut p = points.len();
+    let mut need_close = false;
+    let mut need_moveto = true;
+
+    let mut n = 0;
+
+    for v in path.verbs.iter().rev().cloned() {
+        n += 1;
+        match v {
+            Verb::LineTo
+            | Verb::QuadraticTo
+            | Verb::CubicTo => {
+                if need_moveto {
+                    need_moveto = false;
+                    builder.move_to(points[p - 1]);
+                }
+            }
+            _ => {}
+        }
+
+        match v {
+            Verb::Close => {
+                need_close = true;
+                builder.move_to(points[p - 1]);
+                need_moveto = false;
+            }
+            Verb::MoveTo => {
+                if need_close {
+                    need_close = false;
+                    builder.close();
+                }
+                need_moveto = true;
+            }
+            Verb::LineTo => {
+                builder.line_to(points[p - 2]);
+            }
+            Verb::QuadraticTo => {
+                builder.quadratic_bezier_to(points[p - 2], points[p - 3]);
+            }
+            Verb::CubicTo => {
+                builder.cubic_bezier_to(points[p - 2], points[p - 3], points[p - 4]);
+            }
+        }
+        p -= n_stored_points(v) as usize;
+    }
+
+    // This is a special case that the logic above misses: The path only contains
+    // a single MoveTo event.
+    if n == 1 && need_moveto {
+        builder.move_to(points[p]);
+    }
+}
+
+#[test]
+fn test_reverse_path() {
+    let mut builder = Path::builder();
+    builder.move_to(point(0.0, 0.0));
+    builder.line_to(point(1.0, 0.0));
+    builder.line_to(point(1.0, 1.0));
+    builder.line_to(point(0.0, 1.0));
+
+    builder.move_to(point(10.0, 0.0));
+    builder.line_to(point(11.0, 0.0));
+    builder.line_to(point(11.0, 1.0));
+    builder.line_to(point(10.0, 1.0));
+    builder.close();
+
+    builder.move_to(point(20.0, 0.0));
+    builder.quadratic_bezier_to(point(21.0, 0.0), point(21.0, 1.0));
+
+    let p1 = builder.build();
+    let mut builder = Path::builder();
+    reverse_path(p1.as_slice(), &mut builder);
+    let p2 = builder.build();
+
+    let mut it = p2.iter();
+
+    assert_eq!(it.next(), Some(PathEvent::MoveTo(point(21.0, 1.0))));
+    assert_eq!(it.next(), Some(PathEvent::QuadraticTo(point(21.0, 0.0), point(20.0, 0.0))));
+
+    assert_eq!(it.next(), Some(PathEvent::MoveTo(point(10.0, 1.0))));
+    assert_eq!(it.next(), Some(PathEvent::LineTo(point(11.0, 1.0))));
+    assert_eq!(it.next(), Some(PathEvent::LineTo(point(11.0, 0.0))));
+    assert_eq!(it.next(), Some(PathEvent::LineTo(point(10.0, 0.0))));
+    assert_eq!(it.next(), Some(PathEvent::Close));
+
+    assert_eq!(it.next(), Some(PathEvent::MoveTo(point(0.0, 1.0))));
+    assert_eq!(it.next(), Some(PathEvent::LineTo(point(1.0, 1.0))));
+    assert_eq!(it.next(), Some(PathEvent::LineTo(point(1.0, 0.0))));
+    assert_eq!(it.next(), Some(PathEvent::LineTo(point(0.0, 0.0))));
+
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn test_reverse_path_no_close() {
+    let mut builder = Path::builder();
+    builder.move_to(point(0.0, 0.0));
+    builder.line_to(point(1.0, 0.0));
+    builder.line_to(point(1.0, 1.0));
+
+    let p1 = builder.build();
+
+    let mut builder = Path::builder();
+    reverse_path(p1.as_slice(), &mut builder);
+    let p2 = builder.build();
+
+    let mut it = p2.iter();
+
+    assert_eq!(it.next(), Some(PathEvent::MoveTo(point(1.0, 1.0))));
+    assert_eq!(it.next(), Some(PathEvent::LineTo(point(1.0, 0.0))));
+    assert_eq!(it.next(), Some(PathEvent::LineTo(point(0.0, 0.0))));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn test_reverse_empty_path() {
+    let p1 = Path::builder().build();
+    let mut builder = Path::builder();
+    reverse_path(p1.as_slice(), &mut builder);
+    let p2 = builder.build();
+    assert_eq!(p2.iter().next(), None);
+}
+
+#[test]
+fn test_reverse_single_moveto() {
+    let mut builder = Path::builder();
+    builder.move_to(point(0.0, 0.0));
+    let p1 = builder.build();
+    let mut builder = Path::builder();
+    reverse_path(p1.as_slice(), &mut builder);
+    let p2 = builder.build();
+    let mut it = p2.iter();
+    assert_eq!(it.next(), Some(PathEvent::MoveTo(point(0.0, 0.0))));
+    assert_eq!(it.next(), None);
+}
+
+
 #[inline]
 fn nan_check(p: Point) {
     debug_assert!(p.x.is_finite());

--- a/path/src/path.rs
+++ b/path/src/path.rs
@@ -214,7 +214,6 @@ pub struct Builder {
     verbs: Vec<Verb>,
     current_position: Point,
     first_position: Point,
-    building: bool,
 }
 
 impl Builder {
@@ -226,7 +225,6 @@ impl Builder {
             verbs: Vec::with_capacity(cap),
             current_position: Point::new(0.0, 0.0),
             first_position: Point::new(0.0, 0.0),
-            building: false,
         }
     }
 
@@ -240,7 +238,6 @@ impl Builder {
         nan_check(to);
         self.first_position = to;
         self.current_position = to;
-        self.building = true;
         self.points.push(to);
         self.verbs.push(Verb::MoveTo);
     }
@@ -269,7 +266,6 @@ impl Builder {
 
         self.verbs.push(Verb::Close);
         self.current_position = self.first_position;
-        self.building = false;
     }
 
     pub fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point) {
@@ -349,7 +345,6 @@ impl Build for Builder {
     fn build_and_reset(&mut self) -> Path {
         self.current_position = Point::new(0.0, 0.0);
         self.first_position = Point::new(0.0, 0.0);
-        self.building = false;
 
         Path {
             points: mem::replace(&mut self.points, Vec::new()).into_boxed_slice(),

--- a/path/src/path.rs
+++ b/path/src/path.rs
@@ -1,7 +1,6 @@
 //! The default path data structure.
 
 use builder::*;
-use iterator::PathIter;
 
 use PathEvent;
 use VertexId;
@@ -79,8 +78,6 @@ impl Path {
 
     pub fn iter(&self) -> Iter { Iter::new(&self.points[..], &self.verbs[..]) }
 
-    pub fn path_iter(&self) -> PathIter<Iter> { PathIter::new(self.iter()) }
-
     pub fn points(&self) -> &[Point] { &self.points[..] }
 
     pub fn mut_points(&mut self) -> &mut [Point] { &mut self.points[..] }
@@ -142,7 +139,7 @@ impl<'l> IntoIterator for &'l Path {
 /// An immutable view over a Path.
 impl<'l> PathSlice<'l> {
 
-    pub fn iter(&self) -> Iter {
+    pub fn iter<'a>(&'a self) -> Iter<'l> {
         Iter::new(self.points, self.verbs)
     }
 
@@ -167,22 +164,6 @@ impl<'l> PathSlice<'l> {
         )
     }
 
-    pub fn path_iter(&self) -> PathIter<Iter> {
-        PathIter::new(self.iter())
-    }
-
-    pub fn path_iter_from(&self, cursor: Cursor) -> PathIter<Iter> {
-        PathIter::new(self.iter_from(cursor))
-    }
-
-    pub fn path_iter_until(&self, cursor: Cursor) -> PathIter<Iter> {
-        PathIter::new(self.iter_until(cursor))
-    }
-
-    pub fn path_iter_range(&self, cursor: ops::Range<Cursor>) -> PathIter<Iter> {
-        PathIter::new(self.iter_range(cursor))
-    }
-
     pub fn points(&self) -> &[Point] { self.points }
 
     /// Returns starting position of the edge that the provided cursor refers to.
@@ -203,12 +184,19 @@ impl<'l> PathSlice<'l> {
     }
 }
 
-//impl<'l> IntoIterator for PathSlice<'l> {
-//    type Item = PathEvent;
-//    type IntoIter = Iter<'l>;
-//
-//    fn into_iter(self) -> Iter<'l> { self.iter() }
-//}
+impl<'l> IntoIterator for PathSlice<'l> {
+    type Item = PathEvent;
+    type IntoIter = Iter<'l>;
+
+    fn into_iter(self) -> Iter<'l> { self.iter() }
+}
+
+impl<'l, 'a> IntoIterator for &'a PathSlice<'l> {
+    type Item = PathEvent;
+    type IntoIter = Iter<'l>;
+
+    fn into_iter(self) -> Iter<'l> { self.iter() }
+}
 
 /// Builds path object using the FlatPathBuilder interface.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@
 //!     {
 //!         // Compute the tessellation.
 //!         tessellator.tessellate_path(
-//!             path.path_iter(),
+//!             &path,
 //!             &FillOptions::default(),
 //!             &mut BuffersBuilder::new(&mut geometry, |vertex : FillVertex| {
 //!                 MyVertex {

--- a/tess2/src/lib.rs
+++ b/tess2/src/lib.rs
@@ -23,7 +23,7 @@
 //! - More robust against precision errors when paths have many self
 //!   intersections very close to each other.
 //!
-//! Disdvantages:
+//! Disadvantages:
 //!
 //! - About twice slower than lyon_tessellation's fill tessellator.
 //! - Does not support computing vertex normals.
@@ -70,7 +70,7 @@
 //!
 //!         // Compute the tessellation.
 //!         let result = tessellator.tessellate_path(
-//!             path.path_iter(),
+//!             &path,
 //!             &FillOptions::default(),
 //!             &mut simple_builder(&mut buffers)
 //!         );

--- a/tess2/src/tessellator.rs
+++ b/tess2/src/tessellator.rs
@@ -3,8 +3,8 @@ use flattened_path::FlattenedPath;
 
 use tess2_sys::*;
 use tessellation::{GeometryReceiver, FillOptions, FillRule, Count};
-use path::iterator::PathIterator;
 use path::builder::*;
+use path::PathEvent;
 
 use std::ptr;
 use std::slice;
@@ -37,7 +37,7 @@ impl FillTessellator {
         output: &mut dyn GeometryReceiver<Point>,
     ) -> Result<Count, ()>
     where
-        Iter: PathIterator,
+        Iter: IntoIterator<Item = PathEvent>,
     {
         let mut builder = FlattenedPath::builder().with_svg(options.tolerance);
 

--- a/tessellation/src/basic_shapes.rs
+++ b/tessellation/src/basic_shapes.rs
@@ -29,7 +29,7 @@ use math_utils::compute_normal;
 use geom::math::*;
 use geom::Arc;
 use path::builder::FlatPathBuilder;
-use path::iterator::FromPolyline;
+use path::iterator::{FlattenedIterator, FromPolyline};
 use {FillOptions, FillVertex, StrokeVertex, StrokeOptions, Side};
 use {FillTessellator, TessellationResult};
 
@@ -868,7 +868,7 @@ where
     let mut tess = StrokeTessellator::new();
 
     tess.tessellate_path(
-        FromPolyline::new(is_closed, it).path_iter(),
+        FromPolyline::new(is_closed, it).path_events(),
         options,
         output
     )
@@ -885,7 +885,7 @@ where
     Iter: Iterator<Item = Point>,
 {
     tessellator.tessellate_path(
-        FromPolyline::closed(polyline).path_iter(),
+        FromPolyline::closed(polyline).path_events(),
         options,
         output
     )

--- a/tessellation/src/earcut_tests.rs
+++ b/tessellation/src/earcut_tests.rs
@@ -1315,7 +1315,7 @@ fn tessellate_path(path: PathSlice, log: bool) -> Result<usize, TessellationErro
         }
         try!{
             tess.tessellate_path(
-                path.path_iter(),
+                path.iter(),
                 &FillOptions::tolerance(0.05),
                 &mut vertex_builder
             )

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -18,7 +18,7 @@ fn tessellate_path(path: PathSlice, log: bool) -> Result<usize, TessellationErro
         }
         try!{
             tess.tessellate_path(
-                path.path_iter(),
+                path.iter(),
                 &FillOptions::tolerance(0.05),
                 &mut vertex_builder
             )

--- a/tessellation/src/fuzz_tests.rs
+++ b/tessellation/src/fuzz_tests.rs
@@ -17,7 +17,7 @@ fn tessellate_path(path: PathSlice, log: bool, on_error: OnError) -> Result<usiz
         }
         try!{
             tess.tessellate_path(
-                path.path_iter(),
+                path,
                 &FillOptions::tolerance(0.05).on_error(on_error),
                 &mut vertex_builder
             )

--- a/tessellation/src/path_fill.rs
+++ b/tessellation/src/path_fill.rs
@@ -33,7 +33,6 @@ use math_utils::*;
 use geometry_builder::{GeometryBuilder, GeometryBuilderError, Count, VertexId};
 use path::PathEvent;
 use path::builder::{Build, FlatPathBuilder, PathBuilder};
-use path::iterator::PathIterator;
 
 #[cfg(feature="debugger")]
 use debugger::*;
@@ -252,7 +251,7 @@ enum PointType { In, Out, OnEdge(Side) }
 ///
 ///     // Compute the tessellation.
 ///     let result = tessellator.tessellate_path(
-///         path.path_iter(),
+///         path.iter(),
 ///         &FillOptions::default(),
 ///         &mut vertex_builder
 ///     );
@@ -329,11 +328,11 @@ impl FillTessellator {
         output: &mut dyn GeometryBuilder<Vertex>,
     ) -> TessellationResult
     where
-        Iter: PathIterator,
+        Iter: IntoIterator<Item = PathEvent>,
     {
         let mut events = replace(&mut self.events, FillEvents::new());
         events.clear();
-        events.set_path(options.tolerance, it);
+        events.set_path(options.tolerance, it.into_iter());
         let result = self.tessellate_events(&events, options, output);
         self.events = events;
 
@@ -1888,7 +1887,7 @@ fn tessellate_path(path: PathSlice, log: bool) -> Result<usize, TessellationErro
         }
         try!{
             tess.tessellate_path(
-                path.path_iter(),
+                path.iter(),
                 &FillOptions::tolerance(0.05),
                 &mut vertex_builder
             )

--- a/tessellation/src/path_stroke.rs
+++ b/tessellation/src/path_stroke.rs
@@ -6,7 +6,7 @@ use geom::euclid::Trig;
 use geometry_builder::{VertexId, GeometryBuilder, GeometryBuilderError};
 use basic_shapes::circle_flattening_step;
 use path::builder::{Build, FlatPathBuilder, PathBuilder};
-use path::iterator::PathIterator;
+use path::PathEvent;
 use StrokeVertex as Vertex;
 use {Side, LineCap, LineJoin, StrokeOptions, TessellationResult};
 
@@ -17,9 +17,9 @@ use std::f32::consts::PI;
 /// ## Overview
 ///
 /// The stroke tessellation algorithm simply generates a strip of triangles along
-/// the path. This method is fast and simple to implement, howerver it means that
+/// the path. This method is fast and simple to implement, however it means that
 /// if the path overlap with itself (for example in the case of a self-intersecting
-/// path), some triangles will overlap in the interesecting region, which may not
+/// path), some triangles will overlap in the intersecting region, which may not
 /// be the desired behavior. This needs to be kept in mind when rendering transparent
 /// SVG strokes since the spec mandates that each point along a semi-transparent path
 /// is shaded once no matter how many times the path overlaps with itself at this
@@ -71,7 +71,7 @@ use std::f32::consts::PI;
 ///
 ///     // Compute the tessellation.
 ///     tessellator.tessellate_path(
-///         path.path_iter(),
+///         &path,
 ///         &StrokeOptions::default(),
 ///         &mut vertex_builder
 ///     );
@@ -96,7 +96,7 @@ impl StrokeTessellator {
         builder: &mut dyn GeometryBuilder<Vertex>,
     ) -> TessellationResult
     where
-        Input: PathIterator,
+        Input: IntoIterator<Item = PathEvent>,
     {
         builder.begin_geometry();
         {
@@ -991,7 +991,7 @@ fn test_path(
 
     let mut tess = StrokeTessellator::new();
     let count = tess.tessellate_path(
-        path.path_iter(),
+        path,
         &options,
         &mut TestBuilder {
             builder: simple_builder(&mut buffers)

--- a/wasm_test/src/lib.rs
+++ b/wasm_test/src/lib.rs
@@ -20,7 +20,7 @@ fn test_logo() {
     let mut tess = FillTessellator::new();
 
     tess.tessellate_path(
-        path.path_iter(),
+        &path,
         &FillOptions::tolerance(0.05),
         &mut simple_builder(&mut buffers)
     ).unwrap();


### PR DESCRIPTION
Before this changeset, path events didn't contain the start of the curve. Pretty much all algorithms using the iterator API had to keep track of the end of the previous edge in order to do anything interesting with the next edge.
With recent simplifications of the `Path` data structure, we can ensure that the last point before the start of an event is always the start of the event's curve, which makes it easy and cheap to provide the curve directly in the original iterator and remove a lot of the complexity of iterating over paths from the user.