### PR TITLE
Fix Triangle.contains_point impl to not care about vertex winding order

### DIFF
--- a/geom/src/triangle.rs
+++ b/geom/src/triangle.rs
@@ -12,22 +12,21 @@ pub struct Triangle<S> {
 }
 
 impl<S: Scalar> Triangle<S> {
-    pub fn contains_point(&self, point: Point<S>) -> bool {
-        // see http://blackpawn.com/texts/pointinpoly/
-        let v0 = self.c - self.a;
-        let v1 = self.b - self.a;
+    #[inline]
+    fn get_barycentric_coords_for_point(&self, point: Point<S>) -> (S, S, S) {
+        let v0 = self.b - self.a;
+        let v1 = self.c - self.a;
         let v2 = point - self.a;
+        let inv = S::ONE / (v0.x * v1.y - v1.x * v0.y);
+        let a = (v0.x * v2.y - v2.x * v0.y) * inv;
+        let b = (v2.x * v1.y - v1.x * v2.y) * inv;
+        let c = S::ONE - a - b;
+        (a, b, c)
+    }
 
-        let dot00 = v0.dot(v0);
-        let dot01 = v0.dot(v1);
-        let dot02 = v0.dot(v2);
-        let dot11 = v1.dot(v1);
-        let dot12 = v1.dot(v2);
-        let inv = S::ONE / (dot00 * dot11 - dot01 * dot01);
-        let u = (dot11 * dot02 - dot01 * dot12) * inv;
-        let v = (dot11 * dot12 - dot01 * dot02) * inv;
-
-        return u > S::ZERO && v > S::ZERO && u + v < S::ONE;
+    pub fn contains_point(&self, point: Point<S>) -> bool {
+        let coords = self.get_barycentric_coords_for_point(point);
+        coords.0 > S::ZERO && coords.1 > S::ZERO && coords.2 > S::ZERO
     }
 
     /// Return the minimum bounding rectangle.

--- a/geom/src/triangle.rs
+++ b/geom/src/triangle.rs
@@ -17,9 +17,9 @@ impl<S: Scalar> Triangle<S> {
         let v0 = self.b - self.a;
         let v1 = self.c - self.a;
         let v2 = point - self.a;
-        let inv = S::ONE / (v0.x * v1.y - v1.x * v0.y);
-        let a = (v0.x * v2.y - v2.x * v0.y) * inv;
-        let b = (v2.x * v1.y - v1.x * v2.y) * inv;
+        let inv = S::ONE / v0.cross(v1);
+        let a = v0.cross(v2) * inv;
+        let b = v2.cross(v1) * inv;
         let c = S::ONE - a - b;
         (a, b, c)
     }

--- a/geom/src/triangle.rs
+++ b/geom/src/triangle.rs
@@ -134,6 +134,15 @@ fn test_triangle_contains() {
         }.contains_point(point(1.2, 0.2))
     );
 
+    // Triangle vertex winding should not matter
+    assert!(
+        Triangle {
+            a: point(1.0, 0.0),
+            b: point(0.0, 0.0),
+            c: point(0.0, 1.0),
+        }.contains_point(point(0.2, 0.2))
+    );
+
     // Point exactly on the edge counts as outside the triangle.
     assert!(
         !Triangle {


### PR DESCRIPTION
It seems like vertex winding order of triangles should not matter when checking to see if a point is inside a triangle - especially in 2D.  If it was intentional behaviour (for cases when you want to ignore the hit-test when the triangle is not front-facing?) then please document the intended usage.

Thanks!
Jon