### PR TITLE
Fix `math::F64Point` documentation

### DIFF
--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -234,7 +234,7 @@ pub mod math {
     /// Alias for ```euclid::Point2D<f32>```.
     pub type Point = euclid::Point2D<f32>;
 
-    /// Alias for ```euclid::Point2D<f32>```.
+    /// Alias for ```euclid::Point2D<f64>```.
     pub type F64Point = euclid::Point2D<f64>;
 
     /// Alias for ```euclid::Point2D<f32>```.


### PR DESCRIPTION
This commit fixes a typo in the `math::F64Point` documentation. This type is an alias for `euclid::Point2D<f64>` (not `euclid::Point2D<f32>`).