### PR TITLE
Path Stroke Tessellator Improvements to handle overlaps

### DIFF
--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -261,6 +261,27 @@ impl Side {
     pub fn is_right(self) -> bool { self == Side::Right }
 }
 
+/// Before or After. Used to describe position relative to a join.
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+pub enum Order {
+    Before,
+    After,
+}
+
+impl Order {
+    pub fn opposite(self) -> Self {
+        match self {
+            Order::Before => Order::After,
+            Order::After => Order::Before,
+        }
+    }
+
+    pub fn is_before(self) -> bool { self == Order::Before }
+
+    pub fn is_after(self) -> bool { self == Order::After }
+}
+
 /// Vertex produced by the stroke tessellators.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]


### PR DESCRIPTION
I've modified the path stroke tessellator to better handle specific cases such as acute angles or very short edges that would induce the stroke of two consecutive edges to overlap.

The modifications were designed to change as little as possible the original code at the expense of perfect geometry. In particular, without a second pass it seems impossible to generate a perfect tessellation as we need the information on the geometry of next joins that might overlap.

The solution proposed works with some overlapping triangles and collinear `flat` triangles. A few vertices were also added in some specific joins that needed two distincts vertices on the back of the join.

I've also added an Enum called Order, to specify whether an overlaps is occurring `before` or `after` the current join.