### PR TITLE
Remove needless multiplications in CubicBezierSegment::split_range

### DIFF
--- a/geom/src/cubic_bezier.rs
+++ b/geom/src/cubic_bezier.rs
@@ -157,14 +157,14 @@ impl<S: Scalar> CubicBezierSegment<S> {
         let to = self.sample(t1);
 
         let d = QuadraticBezierSegment {
-            from: (self.ctrl1 - self.from).to_point() * S::THREE,
-            ctrl: (self.ctrl2 - self.ctrl1).to_point() * S::THREE,
-            to: (self.to - self.ctrl2).to_point() * S::THREE,
+            from: (self.ctrl1 - self.from).to_point(),
+            ctrl: (self.ctrl2 - self.ctrl1).to_point(),
+            to: (self.to - self.ctrl2).to_point(),
         };
 
-        let scale = (t1 - t0) * (S::ONE / S::THREE);
-        let ctrl1 = from + d.sample(t0).to_vector() * scale;
-        let ctrl2 = to - d.sample(t1).to_vector() * scale;
+        let dt = t1 - t0;
+        let ctrl1 = from + d.sample(t0).to_vector() * dt;
+        let ctrl2 = to - d.sample(t1).to_vector() * dt;
 
         CubicBezierSegment { from, ctrl1, ctrl2, to }
     }

--- a/geom/src/quadratic_bezier.rs
+++ b/geom/src/quadratic_bezier.rs
@@ -164,19 +164,12 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
     ///
     /// This is equivalent splitting at the range's end points.
     pub fn split_range(&self, t_range: Range<S>) -> Self {
-        let t1 = t_range.start;
-        let t2 = t_range.end;
+        let t0 = t_range.start;
+        let t1 = t_range.end;
 
-        debug_assert!(t1 >= S::ZERO);
-        debug_assert!(t2 <= S::ONE);
-        debug_assert!(t1 <= t2);
-        debug_assert!(t1 != S::ONE);
-
-        let from = self.sample(t1);
-        let to = self.sample(t2);
-        let a = self.from.lerp(self.ctrl, t1);
-        let b = self.ctrl.lerp(self.to, t1);
-        let ctrl = a.lerp(b, (t2 - t1) / (S::ONE - t1));
+        let from = self.sample(t0);
+        let to = self.sample(t1);
+        let ctrl = from + (self.ctrl - self.from).lerp(self.to - self.ctrl, t0) * (t1 - t0);
 
         QuadraticBezierSegment { from, ctrl, to }
     }


### PR DESCRIPTION
Removes a few instructions.