### PR TITLE
Remove most of the recursiveness in the event sorting code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
  "lyon_extra 0.15.0",
  "lyon_svg 0.15.0",
  "lyon_tess2 0.15.0",
- "lyon_tessellation 0.15.0",
+ "lyon_tessellation 0.15.1",
 ]
 
 [[package]]
@@ -862,14 +862,14 @@ dependencies = [
 name = "lyon_tess2"
 version = "0.15.0"
 dependencies = [
- "lyon_tessellation 0.15.0",
+ "lyon_tessellation 0.15.1",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon_extra 0.15.0",

--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -204,7 +204,7 @@ fn cmp_02_lyon_rust_logo(bench: &mut Bencher) {
     // - The tessellator and other allocations are not recycled between runs.
     // - No normals.
 
-    let options = FillOptions::default().with_normals(false);
+    let options = FillOptions::default();
     let mut path = Path::builder().flattened(options.tolerance).with_svg();
     build_logo_path(&mut path);
     let path = path.build();

--- a/tessellation/Cargo.toml
+++ b/tessellation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_tessellation"
-version = "0.15.0"
+version = "0.15.1"
 description = "A low level path tessellation library."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -2055,3 +2055,30 @@ fn issue_500() {
     ).unwrap();
 }
 
+#[test]
+fn very_large_path() {
+    /// Try tessellating a path with a large number of endpoints.
+    const N: usize = 1_000_000;
+
+    let mut d: f32 = 0.0;
+    let mut builder = Path::builder();
+    builder.move_to(point(0.0, 0.0));
+    for _ in 0 .. (N/2) {
+        builder.line_to(point(d.cos(), d));
+        d += 0.1;
+    }
+    for _ in 0 .. (N/2) {
+        builder.line_to(point(d.cos() + 30.0, d));
+        d -= 0.1;
+    }
+
+    builder.close();
+
+    let mut tess = FillTessellator::new();
+
+    tess.tessellate(
+        &builder.build(),
+        &FillOptions::default(),
+        &mut NoOutput::new(),
+    ).unwrap();
+}


### PR DESCRIPTION
The event sorting code is a variant of merge sort, and the merging part (which is called a *lot*) was recursive, causing  stack overflows for paths with many points (particularly in debug builds).

This PR makes merging iterative. It removes the stack overflow for paths with a hundred million points (I didn't try higher) and adds a test case with a path containing a million points (more than that makes the test suite too slow in debug builds).

Fixes #508 