### PR TITLE
Fix bézier flattening in the event queue builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
  "lyon_extra 0.15.0",
  "lyon_svg 0.15.0",
  "lyon_tess2 0.15.0",
- "lyon_tessellation 0.15.1",
+ "lyon_tessellation 0.15.2",
 ]
 
 [[package]]
@@ -862,14 +862,14 @@ dependencies = [
 name = "lyon_tess2"
 version = "0.15.0"
 dependencies = [
- "lyon_tessellation 0.15.1",
+ "lyon_tessellation 0.15.2",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon_extra 0.15.0",

--- a/tessellation/Cargo.toml
+++ b/tessellation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_tessellation"
-version = "0.15.1"
+version = "0.15.2"
 description = "A low level path tessellation library."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"

--- a/tessellation/src/event_queue.rs
+++ b/tessellation/src/event_queue.rs
@@ -213,6 +213,7 @@ impl EventQueue {
     }
 
     pub(crate) fn insert_sibling(&mut self, sibling: TessEventId, position: Point, data: EdgeData) {
+        debug_assert!(is_after(data.to, position));
         let idx = self.events.len() as TessEventId;
         let next_sibling = self.events[sibling as usize].next_sibling;
 
@@ -656,6 +657,10 @@ impl EventQueueBuilder {
         mut t0: f32,
         mut t1: f32,
     ) {
+        if from == to {
+            return;
+        }
+
         let mut evt_pos = from;
         let mut evt_to = to;
         if is_after(evt_pos, to) {
@@ -748,6 +753,10 @@ impl EventQueueBuilder {
         let mut first = None;
         let is_first_edge = self.nth == 0;
         segment.for_each_flattened_with_t(self.tolerance, &mut|to, t1| {
+            if from == to {
+                return;
+            }
+
             if first == None {
                 first = Some(to)
                 // We can't call vertex(prev, from, to) in the first iteration
@@ -829,6 +838,10 @@ impl EventQueueBuilder {
         let mut first = None;
         let is_first_edge = self.nth == 0;
         segment.for_each_flattened_with_t(self.tolerance, &mut|to, t1| {
+            if from == to {
+                return;
+            }
+
             if first == None {
                 first = Some(to)
                 // We can't call vertex(prev, from, to) in the first iteration

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -2056,6 +2056,70 @@ fn issue_500() {
 }
 
 #[test]
+fn issue_518_1() {
+    let mut builder = Path::builder();
+    builder.move_to(point(-76.95, -461.8));
+    builder.quadratic_bezier_to(
+        point(-75.95, -462.6),
+        point(-74.65, -462.8),
+    );
+    builder.line_to(point(-79.1, -456.4));
+    builder.line_to(point(-83.4, -464.75));
+    builder.line_to(point(-80.75, -464.75));
+    builder.line_to(point(-79.05, -458.1));
+    builder.quadratic_bezier_to(
+        point(-78.65, -460.2),
+        point(-77.35, -461.45),
+    );
+    builder.line_to(point(-77.1, -461.65));
+    builder.line_to(point(-76.95, -461.8));
+    builder.close();
+
+    let mut tess = FillTessellator::new();
+
+    let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
+
+    tess.tessellate(
+        &builder.build(),
+        &FillOptions::default(),
+        &mut simple_builder(&mut buffers),
+    ).unwrap();
+}
+
+#[test]
+fn issue_518_2() {
+    let mut builder = Path::builder();
+    builder.move_to(point(-69.1, -465.5));
+    builder.line_to(point(-69.1, -461.65));
+    builder.quadratic_bezier_to(
+        point(-70.95, -462.8),
+        point(-72.95, -462.9),
+    );
+    builder.quadratic_bezier_to(
+        point(-75.65, -463.1),
+        point(-77.35, -461.45),
+    );
+    builder.quadratic_bezier_to(
+        point(-78.65, -460.2),
+        point(-79.05, -458.1),
+    );
+    builder.line_to(point(-80.55, -465.5));
+    builder.line_to(point(-69.1, -465.5));
+    builder.close();
+
+    let mut tess = FillTessellator::new();
+
+    let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
+
+    tess.tessellate(
+        &builder.build(),
+        &FillOptions::default(),
+        &mut simple_builder(&mut buffers),
+    ).unwrap();
+}
+
+
+#[test]
 fn very_large_path() {
     /// Try tessellating a path with a large number of endpoints.
     const N: usize = 1_000_000;


### PR DESCRIPTION
At the end of the of the flattening of a curve the last edge can be so small that it is effectively just a point, which confuses the code that detects vertex events. The resulting event queue can then miss important events, causing badness in the tessellator.

Fixes #518.