### PR TITLE
Reexport BasicGeometryBuilder in lyon_tessellation and hide vertex_builder

### DIFF
--- a/tessellation/src/geometry_builder.rs
+++ b/tessellation/src/geometry_builder.rs
@@ -384,6 +384,7 @@ impl<'l, OutputVertex: 'l, OutputIndex:'l, Ctor> BuffersBuilder<'l, OutputVertex
     }
 }
 
+#[doc(hidden)]
 /// Creates a `BuffersBuilder`.
 pub fn vertex_builder<OutputVertex, OutputIndex, Input, Ctor>(
     buffers: &mut VertexBuffers<OutputVertex, OutputIndex>,

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -218,7 +218,7 @@ pub use crate::stroke::*;
 
 #[doc(inline)]
 pub use crate::geometry_builder::{
-    GeometryBuilder, FillGeometryBuilder, StrokeGeometryBuilder, GeometryReceiver,
+    GeometryBuilder, FillGeometryBuilder, StrokeGeometryBuilder, BasicGeometryBuilder, GeometryReceiver,
     FillVertexConstructor, StrokeVertexConstructor, BasicVertexConstructor,
     VertexBuffers, BuffersBuilder, Count, GeometryBuilderError,
 };


### PR DESCRIPTION
Fixes #525