### PR TITLE
Better handle sorting horizontal edges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ name = "geom_bench"
 version = "0.0.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.3",
+ "lyon 0.15.5",
 ]
 
 [[package]]
@@ -781,13 +781,13 @@ dependencies = [
 
 [[package]]
 name = "lyon"
-version = "0.15.3"
+version = "0.15.5"
 dependencies = [
  "lyon_algorithms 0.15.0",
  "lyon_extra 0.15.0",
  "lyon_svg 0.15.0",
  "lyon_tess2 0.15.0",
- "lyon_tessellation 0.15.4",
+ "lyon_tessellation 0.15.5",
 ]
 
 [[package]]
@@ -809,7 +809,7 @@ dependencies = [
  "gfx_window_glutin 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.3",
+ "lyon 0.15.5",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -862,14 +862,14 @@ dependencies = [
 name = "lyon_tess2"
 version = "0.15.0"
 dependencies = [
- "lyon_tessellation 0.15.4",
+ "lyon_tessellation 0.15.5",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon_extra 0.15.0",
@@ -882,7 +882,7 @@ dependencies = [
 name = "lyon_wasm_test"
 version = "0.11.0"
 dependencies = [
- "lyon 0.15.3",
+ "lyon 0.15.5",
 ]
 
 [[package]]
@@ -1117,7 +1117,7 @@ dependencies = [
  "gfx_device_gl 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_window_glutin 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.3",
+ "lyon 0.15.5",
 ]
 
 [[package]]
@@ -1125,7 +1125,7 @@ name = "path_bench"
 version = "0.0.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.3",
+ "lyon 0.15.5",
 ]
 
 [[package]]
@@ -1584,7 +1584,7 @@ name = "svg-rendering-example"
 version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.3",
+ "lyon 0.15.5",
  "usvg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu-native 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1683,7 +1683,7 @@ name = "tess_bench"
 version = "0.0.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.3",
+ "lyon 0.15.5",
  "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1930,7 +1930,7 @@ dependencies = [
 name = "wgpu-example"
 version = "0.1.0"
 dependencies = [
- "lyon 0.15.3",
+ "lyon 0.15.5",
  "wgpu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu-native 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.20.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon"
-version = "0.15.3"
+version = "0.15.5"
 description = "2D Graphics rendering on the GPU using tessellation."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"
@@ -36,7 +36,7 @@ libtess2 = ["lyon_tess2"]
 
 [dependencies]
 
-lyon_tessellation = { version = "0.15.3", path = "tessellation/" }
+lyon_tessellation = { version = "0.15.5", path = "tessellation/" }
 lyon_algorithms = { version = "0.15.0", path = "algorithms/" }
 lyon_extra = { version = "0.15.0", optional = true, path = "extra/" }
 lyon_svg = { version = "0.15.0", optional = true, path = "svg/" }

--- a/tessellation/Cargo.toml
+++ b/tessellation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_tessellation"
-version = "0.15.4"
+version = "0.15.5"
 description = "A low level path tessellation library."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"

--- a/tessellation/src/fill.rs
+++ b/tessellation/src/fill.rs
@@ -1545,10 +1545,20 @@ impl FillTessellator {
             } else {
                 debug_assert!(!is_after(self.current_position, edge.to));
 
-                let x = if edge.to.y == y {
-                    edge.to.x
-                } else if edge.from.y == y {
+                let eq_to = edge.to.y == y;
+                let eq_from = edge.from.y == y;
+
+                let x = if eq_to && eq_from {
+                    let current_x = self.current_position.x;
+                    if edge.max_x >= current_x && edge.min_x <= current_x {
+                        self.current_position.x
+                    } else {
+                        edge.min_x
+                    }
+                } else if eq_from {
                     edge.from.x
+                } else if eq_to {
+                    edge.to.x
                 } else {
                     edge.solve_x_for_y(y)
                 };

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -2146,3 +2146,29 @@ fn very_large_path() {
         &mut NoOutput::new(),
     ).unwrap();
 }
+
+#[test]
+fn issue_529() {
+    let mut builder = Path::builder();
+
+    builder.move_to(point(203.01, 174.67));
+    builder.line_to(point(203.04, 174.72));
+    builder.line_to(point(203.0, 174.68));
+    builder.close();
+
+    builder.move_to(point(203.0, 174.66));
+    builder.line_to(point(203.01, 174.68));
+    builder.line_to(point(202.99, 174.68));
+    builder.close();
+
+    let mut tess = FillTessellator::new();
+
+    tess.tessellate(
+        &builder.build(),
+        &FillOptions::default(),
+        &mut NoOutput::new(),
+    ).unwrap();
+
+    // SVG path syntax:
+    // "M 203.01 174.67 L 203.04 174.72 L 203 174.68 ZM 203 174.66 L 203.01 174.68 L 202.99 174.68 Z"
+}


### PR DESCRIPTION
Sorting horizontal edges needed a bit of extra care when the edge overlaps the current vertex of the sweep line without being at the endpoints. It mostly worked before except in cases with very small edges.

Fixes #529