### PR TITLE
Move/line to the start of an arc if the current position is not on the arc

### DIFF
--- a/path/src/path.rs
+++ b/path/src/path.rs
@@ -423,6 +423,18 @@ impl Builder {
 
         let start_angle = (self.current_position - center).angle_from_x_axis() - x_rotation;
         let arc = Arc { start_angle, center, radii, sweep_angle, x_rotation };
+
+        // If the current position is not on the arc, move or line to the beginning of the
+        // arc.
+        let arc_start = arc.from();
+        if (arc_start - self.current_position).square_length() < 0.01 {
+            if self.need_moveto {
+                self.move_to(arc_start);
+            } else {
+                self.line_to(arc_start);
+            }
+        }
+
         arc.for_each_quadratic_bezier(&mut|curve| {
             self.quadratic_bezier_to(curve.ctrl, curve.to);
         });

--- a/tessellation/src/stroke.rs
+++ b/tessellation/src/stroke.rs
@@ -312,13 +312,24 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
     ) {
         let start_angle = (self.current - center).angle_from_x_axis() - x_rotation;
         let mut first = true;
-        Arc {
+        let arc = Arc {
             center,
             radii,
             start_angle,
             sweep_angle,
             x_rotation,
-        }.for_each_flattened(
+        };
+
+        let arc_start = arc.from();
+        if (arc_start - self.current).square_length() < 0.01 {
+            if self.nth == 0 && !self.previous_command_was_move {
+                self.move_to(arc_start);
+            } else {
+                self.line_to(arc_start);
+            }
+        }
+
+        arc.for_each_flattened(
             self.options.tolerance,
             &mut |point| {
                 self.edge_to(point, EndpointId::INVALID, 0.0, first);


### PR DESCRIPTION
Fixes #536.

As is, the flattening builder doesn't know whether the current sub-path has an existing point, so it's doing a line_to even when it should have used move_to. That will have to be fixed in a followup (the regular path builder does it correctly, though).