### PR TITLE
Implement Raph Levien's quadratic bézier flattening algorithm.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ name = "geom_bench"
 version = "0.0.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.5",
+ "lyon 0.15.6",
 ]
 
 [[package]]
@@ -781,20 +781,20 @@ dependencies = [
 
 [[package]]
 name = "lyon"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "lyon_algorithms 0.15.0",
  "lyon_extra 0.15.0",
  "lyon_svg 0.15.0",
  "lyon_tess2 0.15.0",
- "lyon_tessellation 0.15.5",
+ "lyon_tessellation 0.15.6",
 ]
 
 [[package]]
 name = "lyon_algorithms"
 version = "0.15.0"
 dependencies = [
- "lyon_path 0.15.1",
+ "lyon_path 0.15.2",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sid 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -809,7 +809,7 @@ dependencies = [
  "gfx_window_glutin 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.5",
+ "lyon 0.15.6",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -818,7 +818,7 @@ dependencies = [
 name = "lyon_extra"
 version = "0.15.0"
 dependencies = [
- "lyon_path 0.15.1",
+ "lyon_path 0.15.2",
  "lyon_svg 0.15.0",
 ]
 
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_path"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "lyon_geom 0.15.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -854,7 +854,7 @@ dependencies = [
 name = "lyon_svg"
 version = "0.15.0"
 dependencies = [
- "lyon_path 0.15.1",
+ "lyon_path 0.15.2",
  "svgparser 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -862,18 +862,18 @@ dependencies = [
 name = "lyon_tess2"
 version = "0.15.0"
 dependencies = [
- "lyon_tessellation 0.15.5",
+ "lyon_tessellation 0.15.6",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon_extra 0.15.0",
- "lyon_path 0.15.1",
+ "lyon_path 0.15.2",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sid 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -882,7 +882,7 @@ dependencies = [
 name = "lyon_wasm_test"
 version = "0.11.0"
 dependencies = [
- "lyon 0.15.5",
+ "lyon 0.15.6",
 ]
 
 [[package]]
@@ -1117,7 +1117,7 @@ dependencies = [
  "gfx_device_gl 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_window_glutin 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.5",
+ "lyon 0.15.6",
 ]
 
 [[package]]
@@ -1125,7 +1125,7 @@ name = "path_bench"
 version = "0.0.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.5",
+ "lyon 0.15.6",
 ]
 
 [[package]]
@@ -1584,7 +1584,7 @@ name = "svg-rendering-example"
 version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.5",
+ "lyon 0.15.6",
  "usvg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu-native 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1683,7 +1683,7 @@ name = "tess_bench"
 version = "0.0.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.5",
+ "lyon 0.15.6",
  "tess2-sys 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1930,7 +1930,7 @@ dependencies = [
 name = "wgpu-example"
 version = "0.1.0"
 dependencies = [
- "lyon 0.15.5",
+ "lyon 0.15.6",
  "wgpu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu-native 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.20.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Replaces the quadratic bézier flattening implementation with @raphlinus's, described in https://raphlinus.github.io/graphics/curves/2019/12/23/flatten-quadbez.html 

It addresses an annoying issue with the previous implementation which was that the last segment was sometimes very small as a result of the iterative approach.

The only issue so far is that it does not handle the case with aligned control and endpoints where the control point is not between the endpoints (this currently defaults to a single line between the endpoints).