### PR TITLE
Fix bad cubic flattening when the cubic curve is exactly equivalent to a quadratic curve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_geom"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.20.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -846,7 +846,7 @@ dependencies = [
 name = "lyon_path"
 version = "0.15.2"
 dependencies = [
- "lyon_geom 0.15.1",
+ "lyon_geom 0.15.2",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/geom/Cargo.toml
+++ b/geom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_geom"
-version = "0.15.1"
+version = "0.15.2"
 description = "2D quadratic and cubic bézier arcs and line segment math on top of euclid."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"

--- a/geom/src/flatten_cubic.rs
+++ b/geom/src/flatten_cubic.rs
@@ -12,14 +12,14 @@ use crate::quadratic_bezier::FlattenedT as FlattenedQuadraticSegment;
 // https://scholarsarchive.byu.edu/cgi/viewcontent.cgi?article=1000&context=facpub#section.10.6
 // and the error metric from the caffein owl blog post http://caffeineowl.com/graphics/2d/vectorial/cubic2quad01.html
 fn num_quadratics<S: Scalar>(curve: &CubicBezierSegment<S>, tolerance: S) -> S {
-    debug_assert!(tolerance >= S::EPSILON);
+    debug_assert!(tolerance > S::ZERO);
 
     let x = curve.from.x - S::THREE * curve.ctrl1.x + S::THREE * curve.ctrl2.x - curve.to.x;
     let y = curve.from.y - S::THREE * curve.ctrl1.y + S::THREE * curve.ctrl2.y - curve.to.y;
 
     let err = x * x + y * y;
 
-    (err / (S::value(432.0) * tolerance * tolerance)).powf(S::ONE / S::SIX).ceil()
+    (err / (S::value(432.0) * tolerance * tolerance)).powf(S::ONE / S::SIX).ceil().max(S::ONE)
 }
 
 pub fn flatten_cubic_bezier_with_t<S: Scalar, F>(curve: &CubicBezierSegment<S>, tolerance: S, callback: &mut F)


### PR DESCRIPTION
This one was a little silly. The flattening approximation first evaluates the number of quadratic sub-segments needed to approximate the cubic curve. This is based on an error evaluation and when that error is ends up exactly at zero, the resulting number of edges ends up at zero as well and we fail to round up to one the number of required segments. This mends up basically replacing the whole cubic curve with a single line. The fix is simply to ensure we generate at least one quadratic curve in that case.

Fixes #558 