### PR TITLE
Fix a few fill tessellator issues

### DIFF
--- a/tessellation/src/fill.rs
+++ b/tessellation/src/fill.rs
@@ -710,7 +710,13 @@ impl FillTessellator {
     /// Enable/disable some verbose logging during the tessellation, for
     /// debugging purposes.
     pub fn set_logging(&mut self, is_enabled: bool) {
-        self.log = is_enabled;
+        #[cfg(debug_assertions)]
+        let forced = env::var("LYON_FORCE_LOGGING").is_ok();
+
+        #[cfg(not(debug_assertions))]
+        let forced = false;
+
+        self.log = is_enabled || forced;
     }
 
     fn tessellator_loop(
@@ -732,7 +738,7 @@ impl FillTessellator {
             if let Err(e) = self.process_events(&mut scan, output) {
                 // Something went wrong, attempt to salvage the state of the sweep
                 // line
-                self.recover_from_error(e);
+                self.recover_from_error(e, output);
                 // ... and try again.
                 self.process_events(&mut scan, output)?
             }
@@ -819,6 +825,8 @@ impl FillTessellator {
             self.edges_below.len(),
         );
 
+        tess_log!(self, "edges below (initially): {:#?}", self.edges_below);
+
         // Step 1 - Scan the active edge list, deferring processing and detecting potential
         // ordering issues in the active edges.
         self.scan_active_edges(scan)?;
@@ -862,7 +870,7 @@ impl FillTessellator {
             } else {
                 tess_log!(
                     self,
-                    r#"  <path d="M {} {} L {} {}" class="edge", winding="{}" sort_x="{:.}" min_x="{:.}"/>"#,
+                    r#"  <path d="M {:.5?} {:.5?} L {:.5?} {:.5?}" class="edge", winding="{:>2}" sort_x="{:.}" min_x="{:.}"/>"#,
                     e.from.x,
                     e.from.y,
                     e.to.x,
@@ -879,16 +887,18 @@ impl FillTessellator {
 
     #[cfg(debug_assertions)]
     fn check_active_edges(&self) {
-        let mut winding = 0;
-        for edge in &self.active.edges {
+        let mut winding = WindingState::new();
+        for (idx, edge) in self.active.edges.iter().enumerate() {
+            winding.update(self.fill_rule, edge.winding);
             if edge.is_merge {
-                assert!(self.fill_rule.is_in(winding));
+                assert!(self.fill_rule.is_in(winding.number));
             } else {
-                assert!(!is_after(self.current_position, edge.to));
-                winding += edge.winding;
+                assert!(!is_after(self.current_position, edge.to), "error at edge {}, position {:?}", idx, edge.to);
             }
         }
-        assert_eq!(winding, 0);
+        assert_eq!(winding.number, 0);
+        let expected_span_count = (winding.span_index + 1) as usize;
+        assert_eq!(self.fill.spans.len(), expected_span_count);
     }
 
     /// Scan the active edges to find the information we will need for the tessellation, without
@@ -1268,7 +1278,8 @@ impl FillTessellator {
             });
             tess_log!(
                 self,
-                "add edge below {:?} -> {:?} ({:?})",
+                "split {:?}, add edge below {:?} -> {:?} ({:?})",
+                edge_idx,
                 self.current_position,
                 self.edges_below.last().unwrap().to,
                 active_edge.winding,
@@ -1309,13 +1320,13 @@ impl FillTessellator {
             winding.is_in
         );
         tess_log!(self, "winding state before point: {:?}", winding);
-        tess_log!(self, "edges below: {:?}", self.edges_below);
+        tess_log!(self, "edges below: {:#?}", self.edges_below);
 
         self.sort_edges_below();
 
-        if scan.split_event {
-            debug_assert!(self.edges_below.len() >= 2);
+        self.handle_coincident_edges_below();
 
+        if scan.split_event {
             // Split event.
             //
             //  ...........
@@ -1553,17 +1564,7 @@ impl FillTessellator {
 
                 let active_edge = &mut self.active.edges[active_edge_idx];
 
-                if is_near(self.current_position, intersection_position) {
-                    tess_log!(self, "fix intersection position to current_position");
-                    intersection_position = self.current_position;
-                    // We moved the intersection to the current position to avoid breaking ordering.
-                    // This means we won't be adding an intersection event and we have to treat
-                    // splitting the two edges in a special way:
-                    // - the edge below does not need to be split.
-                    // - the active edge is split so that it's upper part now ends at the current
-                    //   position which means it must be removed, however removing edges ending at
-                    //   the current position happens before the intersection checks. So instead we
-                    //   modify it in place and don't add a new event.
+                if self.current_position == intersection_position {
                     active_edge.from = intersection_position;
                     active_edge.min_x = active_edge.min_x.min(intersection_position.x);
                     let src_range = &mut self.events.edge_data[active_edge.src_edge as usize].range;
@@ -1588,7 +1589,7 @@ impl FillTessellator {
                     tess_log!(self, "intersection near below.to");
                     intersection_position = edge_below.to;
                 } else if is_near(intersection_position, active_edge.to) {
-                    tess_log!(self, "intersection near below.to");
+                    tess_log!(self, "intersection near active_edge.to");
                     intersection_position = active_edge.to;
                 }
 
@@ -1596,6 +1597,7 @@ impl FillTessellator {
                 let b_src_edge_data = self.events.edge_data[edge_below.src_edge as usize].clone();
 
                 let mut inserted_evt = None;
+                let mut flipped_active = false;
 
                 if active_edge.to != intersection_position
                     && active_edge.from != intersection_position
@@ -1620,6 +1622,7 @@ impl FillTessellator {
                         ));
                     } else {
                         tess_log!(self, "flip active edge after intersection");
+                        flipped_active = true;
                         self.events.insert_sorted(
                             active_edge.to,
                             EdgeData {
@@ -1682,11 +1685,25 @@ impl FillTessellator {
                             },
                             self.current_event_id,
                         );
-                    };
+
+                        if flipped_active {
+                            // It is extremely rare but if we end up flipping both of the
+                            // edges that are inserted in the event queue, then we created a
+                            // merge event which means we have to insert a vertex event into
+                            // the queue, otherwise the tessellator will skip over the end of
+                            // these two edges.
+                            self.events.vertex_event_sorted(
+                                intersection_position,
+                                b_src_edge_data.to_id,
+                                self.current_event_id,
+                            );
+                        }
+                    }
 
                     edge_below.to = intersection_position;
                     edge_below.range_end = remapped_tb;
                 }
+
             }
         }
 
@@ -1789,7 +1806,7 @@ impl FillTessellator {
         }
     }
 
-    fn recover_from_error(&mut self, _error: InternalError) {
+    fn recover_from_error(&mut self, _error: InternalError, output: &mut dyn FillGeometryBuilder) {
         tess_log!(self, "Attempt to recover error {:?}", _error);
 
         self.sort_active_edges();
@@ -1829,6 +1846,11 @@ impl FillTessellator {
             }
         }
 
+        while self.fill.spans.len() > (winding.span_index + 1) as usize {
+            self.fill.spans.last_mut().unwrap().tess.flush(output);
+            self.fill.spans.pop();
+        }
+
         tess_log!(self, "-->");
 
         #[cfg(debug_assertions)]
@@ -1839,6 +1861,69 @@ impl FillTessellator {
         self.edges_below
             .sort_by(|a, b| b.angle.partial_cmp(&a.angle).unwrap_or(Ordering::Equal));
     }
+
+    fn handle_coincident_edges_below(&mut self) {
+        if self.edges_below.len() < 2 {
+            return;
+        }
+
+        for idx in (0..(self.edges_below.len() - 1)).rev() {
+            let a_idx = idx;
+            let b_idx = idx + 1;
+            let a_angle = self.edges_below[a_idx].angle;
+            let b_angle = self.edges_below[b_idx].angle;
+            if (a_angle - b_angle).abs() > 0.001 {
+                continue;
+            }
+
+            let a_to = self.edges_below[a_idx].to;
+            let b_to = self.edges_below[b_idx].to;
+            let (lower_idx, upper_idx, split) = match compare_positions(a_to, b_to) {
+                Ordering::Greater => (a_idx, b_idx, true),
+                Ordering::Less => (b_idx, a_idx, true),
+                Ordering::Equal => (a_idx, b_idx, false),
+            };
+
+            tess_log!(self, "coincident edges {:?} -> {:?} / {:?}", self.current_position, a_to, b_to);
+
+            tess_log!(self, "update winding: {:?} -> {:?}", self.edges_below[upper_idx].winding, self.edges_below[upper_idx].winding + self.edges_below[lower_idx].winding);
+            self.edges_below[upper_idx].winding += self.edges_below[lower_idx].winding;
+            let split_point = self.edges_below[upper_idx].to;
+
+            tess_log!(self, "remove coincident edge {:?}, split:{:?}", idx, split);
+            let edge = self.edges_below.remove(lower_idx);
+
+            if !split {
+                continue;
+            }
+
+            let src_edge_data = self.events.edge_data[edge.src_edge as usize].clone();
+
+            let t = LineSegment {
+                from: self.current_position,
+                to: edge.to,
+            }.solve_t_for_y(split_point.y);
+
+            let src_range = src_edge_data.range.start..edge.range_end;
+            let t_remapped = remap_t_in_range(t, src_range);
+
+            let edge_data = EdgeData {
+                range: t_remapped..edge.range_end,
+                winding: edge.winding,
+                to: edge.to,
+                is_edge: true,
+                ..src_edge_data
+            };
+
+            self.events.insert_sorted(
+                split_point,
+                edge_data,
+                self.current_event_id,
+            );
+        }
+
+    }
+
 
     fn reset(&mut self) {
         self.current_position = point(f32::MIN, f32::MIN);
@@ -1878,7 +1963,7 @@ pub(crate) fn is_after(a: Point, b: Point) -> bool {
 
 #[inline]
 pub(crate) fn is_near(a: Point, b: Point) -> bool {
-    (a - b).square_length() < 0.0001
+    (a - b).square_length() < 0.000000001
 }
 
 #[inline]

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -135,7 +135,7 @@ fn test_path_with_rotations(path: Path, step: f32, expected_triangle_count: Opti
 
     let mut angle = Angle::radians(0.0);
     while angle.radians < PI * 2.0 {
-        println!("\n\n ==================== angle = {:?}", angle);
+        //println!("\n\n ==================== angle = {:?}", angle);
 
         let tranformed_path = path.transformed(&Rotation::new(angle));
 
@@ -2188,3 +2188,201 @@ fn issue_529() {
     // SVG path syntax:
     // "M 203.01 174.67 L 203.04 174.72 L 203 174.68 ZM 203 174.66 L 203.01 174.68 L 202.99 174.68 Z"
 }
+
+#[test]
+fn issue_562_1() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(757.26587, 494.72363));
+    builder.line_to(point(833.3479, 885.81494));
+    builder.line_to(point(342.08817, 855.6907));
+    builder.close();
+
+    builder.begin(point(580.21893, 759.2482));
+    builder.line_to(point(545.2758, 920.6801));
+    builder.line_to(point(739.3726, 23.550331));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+
+    // SVG path syntax:
+    // "M 757.26587 494.72363 L 833.3479 885.81494 L 342.08817 855.6907 ZM 580.21893 759.2482 L 545.2758 920.6801 L 739.3726 23.550331 Z"
+}
+
+#[test]
+fn issue_562_2() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(3071.0, 737.0));
+    builder.line_to(point(3071.0, 738.0));
+    builder.line_to(point(3071.0, 738.0));
+    builder.close();
+
+    builder.begin(point(3071.0, 3071.0));
+    builder.line_to(point(3071.0, 703.0));
+    builder.line_to(point(3071.0, 703.0));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+
+    // SVG path syntax:
+    // "M 3071 737 L 3071 738 L 3071 738 ZM 3071 3071 L 3071 703 L 3071 703 Z"
+}
+
+#[test]
+fn issue_562_3() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(4224.0, -128.0));
+    builder.line_to(point(3903.0, 3615.0));
+    builder.line_to(point(3903.0, 3590.0));
+    builder.line_to(point(3893.0, 3583.0));
+    builder.close();
+
+    builder.begin(point(3898.0, 3898.0));
+    builder.line_to(point(3898.0, 3585.0));
+    builder.line_to(point(3897.0, 3585.0));
+    builder.close();
+
+    builder.begin(point(3899.0, 3899.0));
+    builder.line_to(point(3899.0, 1252.0));
+    builder.line_to(point(3899.0, 1252.0));
+    builder.close();
+
+    builder.begin(point(3897.0, 3897.0));
+    builder.line_to(point(3897.0, 3536.0));
+    builder.line_to(point(3897.0, 3536.0));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+
+    // SVG path syntax:
+    // "M 4224 -128 L 3903 3615 L 3903 3590 L 3893 3583 ZM 3898 3898 L 3898 3585 L 3897 3585 ZM 3899 3899 L 3899 1252 L 3899 1252 ZM 3897 3897 L 3897 3536 L 3897 3536 Z"
+}
+
+#[test]
+fn issue_562_4() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(160.39546, 11.226683));
+    builder.line_to(point(160.36594, 11.247373));
+    builder.line_to(point(160.32234, 11.28461));
+    builder.line_to(point(160.36172, 11.299779));
+    builder.line_to(point(160.39265, 11.361827));
+    builder.close();
+
+    builder.begin(point(160.36313, 160.36313));
+    builder.line_to(point(160.36313, 11.14253));
+    builder.line_to(point(160.36313, 11.14253));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+
+    // SVG path syntax:
+    // "M 160.39546 11.226683 L 160.36594 11.247373 L 160.32234 11.28461 L 160.36172 11.299779 L 160.39265 11.361827 ZM 160.36313 160.36313 L 160.36313 11.14253 L 160.36313 11.14253 Z"
+}
+
+#[test]
+fn issue_562_5() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(0.88427734, 0.2277832));
+    builder.line_to(point(0.88671875, 0.22143555));
+    builder.line_to(point(0.91259766, 0.23803711));
+    builder.line_to(point(0.8869629, 0.22607422));
+    builder.line_to(point(0.88793945, 0.22827148));
+    builder.line_to(point(0.8869629, 0.22607422));
+    builder.line_to(point(0.89453125, 0.2265625));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+
+    // SVG path syntax:
+    // "M 0.88427734 0.2277832 L 0.88671875 0.22143555 L 0.91259766 0.23803711 L 0.8869629 0.22607422 L 0.88793945 0.22827148 L 0.8869629 0.22607422 L 0.89453125 0.2265625 Z"
+}
+
+#[test]
+fn issue_562_6() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(-499.51904, 864.00793));
+    builder.line_to(point(510.1705, -862.41235));
+    builder.line_to(point(1005.31006, 6.4012146));
+    builder.line_to(point(-994.65857, -4.8055725));
+    builder.line_to(point(-489.81372, -868.01575));
+    builder.line_to(point(500.4652, 869.6113));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+
+    // SVG path syntax:
+    // "M -499.51904 864.00793 L 510.1705 -862.41235 L 1005.31006 6.4012146 L -994.65857 -4.8055725 L -489.81372 -868.01575 L 500.4652 869.6113 Z"
+}
+
+#[test]
+fn issue_562_7() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(-880.59766, -480.86603));
+    builder.line_to(point(878.77014, 470.2519));
+    builder.line_to(point(709.1563, 698.824));
+    builder.line_to(point(-710.9838, -709.4381));
+    builder.line_to(point(-483.84427, -880.9657));
+    builder.line_to(point(482.01672, 870.35156));
+    builder.line_to(point(215.75311, 970.9385));
+    builder.line_to(point(-217.58063, -981.5527));
+    builder.line_to(point(66.236084, -1003.05));
+    builder.line_to(point(-68.063614, 992.4358));
+    builder.line_to(point(-346.44025, 933.1019));
+    builder.line_to(point(344.61273, -943.71606));
+    builder.line_to(point(594.9969, -808.35785));
+    builder.line_to(point(-596.8244, 797.7438));
+    builder.line_to(point(934.5602, -358.7028));
+    builder.line_to(point(-936.3877, 348.08868));
+    builder.line_to(point(-998.05756, 70.22009));
+    builder.line_to(point(996.23004, -80.83423));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+
+    // SVG path syntax:
+    // "M -880.59766 -480.86603 L 878.77014 470.2519 L 709.1563 698.824 L -710.9838 -709.4381 L -483.84427 -880.9657 L 482.01672 870.35156 L 215.75311 970.9385 L -217.58063 -981.5527 L 66.236084 -1003.05 L -68.063614 992.4358 L -346.44025 933.1019 L 344.61273 -943.71606 L 594.9969 -808.35785 L -596.8244 797.7438 L 934.5602 -358.7028 L -936.3877 348.08868 L -998.05756 70.22009 L 996.23004 -80.83423 Z"
+}
+
+#[test]
+fn issue_562_8() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(997.84753, -18.145767));
+    builder.line_to(point(-1001.9789, 8.1993265));
+    builder.line_to(point(690.0551, 716.8084));
+    builder.line_to(point(-694.1865, -726.7548));
+    builder.line_to(point(-589.4575, -814.2759));
+    builder.line_to(point(585.3262, 804.3294));
+    builder.line_to(point(469.6551, 876.7747));
+    builder.line_to(point(-473.78647, -886.7211));
+    builder.line_to(point(-349.32822, -942.74115));
+    builder.line_to(point(345.1968, 932.7947));
+    builder.line_to(point(-218.4011, -981.2923));
+    builder.line_to(point(-83.44396, -1001.6565));
+    builder.line_to(point(-57.160374, 993.50793));
+    builder.line_to(point(53.02899, -1003.4543));
+    builder.line_to(point(188.47563, -986.65234));
+    builder.line_to(point(-192.60701, 976.7059));
+    builder.line_to(point(-324.50436, 941.61707));
+    builder.line_to(point(320.37296, -951.56354));
+    builder.line_to(point(446.26376, -898.84155));
+    builder.line_to(point(-450.39514, 888.89514));
+    builder.line_to(point(-567.9344, 819.52203));
+    builder.line_to(point(563.80304, -829.4685));
+    builder.line_to(point(670.8013, -744.73676));
+    builder.line_to(point(-769.3966, 636.2781));
+    builder.line_to(point(909.81805, -415.4218));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+
+    // SVG path syntax:
+    // "M 997.84753 -18.145767 L -1001.9789 8.1993265 L 690.0551 716.8084 L -694.1865 -726.7548 L -589.4575 -814.2759 L 585.3262 804.3294 L 469.6551 876.7747 L -473.78647 -886.7211 L -349.32822 -942.74115 L 345.1968 932.7947 L -218.4011 -981.2923 L -83.44396 -1001.6565 L -57.160374 993.50793 L 53.02899 -1003.4543 L 188.47563 -986.65234 L -192.60701 976.7059 L -324.50436 941.61707 L 320.37296 -951.56354 L 446.26376 -898.84155 L -450.39514 888.89514 L -567.9344 819.52203 L 563.80304 -829.4685 L 670.8013 -744.73676 L -769.3966 636.2781 L 909.81805 -415.4218 Z"
+}
+


### PR DESCRIPTION
The main issue is that coincident edges don't play well with self-intersection soups. Collapsing them avoids active edge reordering which breaks the NonZero mode.

On top of that the NonZero fill rule is generally more sensible to some situations that don't break with EvenOdd so a number of adjustments to the intersection handling code allowed us to run into them quite a bit less.

The third change is that while very rare, it is possible for an intersection to end-up below all endpoints of the intersecting edges. When this happens it creates a merge event that the main loop of the tessellator skips unless the event is explicitly inserted. This change adds the missing event.

Fixes #562 (and a few other cases discovered along the way).