### PR TITLE
Another wave of path API and documentation changes

### DIFF
--- a/bench/path/src/main.rs
+++ b/bench/path/src/main.rs
@@ -180,7 +180,7 @@ fn commands_id_iter(bench: &mut Bencher) {
 
     let mut i = 0;
     bench.iter(|| {
-        for evt in path.id_events() {
+        for evt in &path {
             i += match evt {
                 IdEvent::Begin { at: p }
                 | IdEvent::Line { to: p, .. }

--- a/path/src/lib.rs
+++ b/path/src/lib.rs
@@ -55,8 +55,14 @@ mod events;
 
 pub use crate::events::*;
 pub use crate::geom::ArcFlags;
+#[doc(inline)]
 pub use crate::path::{Path, PathSlice};
+#[doc(inline)]
 pub use crate::path_buffer::{PathBuffer, PathBufferSlice};
+#[doc(inline)]
+pub use crate::polygon::{Polygon, IdPolygon};
+#[doc(inline)]
+pub use crate::commands::{PathCommands, PathCommandsSlice};
 
 use math::Point;
 use std::fmt;

--- a/path/src/path.rs
+++ b/path/src/path.rs
@@ -91,7 +91,7 @@ impl Path {
 
     /// Creates an [WithSvg](../builder/struct.WithSvg.html) to build a path
     /// with a rich set of commands.
-    pub fn extended_builder() -> WithSvg<Builder> {
+    pub fn svg_builder() -> WithSvg<Builder> {
         WithSvg::new(Self::builder())
     }
 
@@ -137,14 +137,13 @@ impl Path {
 
     /// Applies a transform to all endpoints and control points of this path and
     /// Returns the result.
-    pub fn transformed<T: Transformation<f32>>(&self, transform: &T) -> Self {
-        let mut result = self.clone();
-        result.apply_transform(transform);
+    pub fn transformed<T: Transformation<f32>>(mut self, transform: &T) -> Self {
+        self.apply_transform(transform);
 
-        result
+        self
     }
 
-    /// Reversed version of this path with edge loops are specified in the opposite
+    /// Returns a reversed version of this path with edge loops specified in the opposite
     /// order.
     pub fn reversed(&self) -> Self {
         reverse_path(self.as_slice())
@@ -181,26 +180,6 @@ impl Path {
                 }
                 IdEvent::End { .. } => {}
             }
-        }
-    }
-
-    /// Concatenate two paths.
-    ///
-    /// They must have the same number of custom attributes.
-    pub fn merge(&self, other: &Self) -> Self {
-        assert_eq!(self.num_attributes, other.num_attributes);
-
-        let mut verbs = Vec::with_capacity(self.verbs.len() + other.verbs.len());
-        let mut points = Vec::with_capacity(self.points.len() + other.points.len());
-        verbs.extend_from_slice(&self.verbs);
-        verbs.extend_from_slice(&other.verbs);
-        points.extend_from_slice(&self.points);
-        points.extend_from_slice(&other.points);
-
-        Path {
-            verbs: verbs.into_boxed_slice(),
-            points: points.into_boxed_slice(),
-            num_attributes: self.num_attributes,
         }
     }
 }
@@ -510,6 +489,11 @@ impl Builder {
         self.points.reserve(endpoints + ctrl_points);
         self.verbs.reserve(endpoints);
     }
+
+    #[inline]
+    pub fn concatenate(&mut self, paths: &[PathSlice]) {
+        concatenate_paths(&mut self.points, &mut self.verbs, paths, 0);
+    }
 }
 
 impl PathBuilder for Builder {
@@ -621,6 +605,16 @@ impl BuilderWithAttributes {
             verbs: self.builder.verbs.into_boxed_slice(),
             num_attributes: self.num_attributes,
         }
+    }
+
+    #[inline]
+    pub fn concatenate(&mut self, paths: &[PathSlice]) {
+        concatenate_paths(
+            &mut self.builder.points,
+            &mut self.builder.verbs,
+            paths,
+            self.num_attributes,
+        );
     }
 
     fn push_attributes(&mut self, attributes: &[f32]) {
@@ -1006,6 +1000,30 @@ fn interpolated_attributes(
     unsafe {
         let ptr = &points[idx].x as *const f32;
         std::slice::from_raw_parts(ptr, num_attributes)
+    }
+}
+
+fn concatenate_paths(
+    points: &mut Vec<Point>,
+    verbs: &mut Vec<Verb>,
+    paths: &[PathSlice],
+    num_attributes: usize,
+) {
+    let mut np = 0;
+    let mut nv = 0;
+
+    for path in paths {
+        assert_eq!(path.num_attributes(), num_attributes);
+        np += path.points.len();
+        nv += path.verbs.len();
+    }
+
+    verbs.reserve(nv);
+    points.reserve(np);
+
+    for path in paths {
+        verbs.extend_from_slice(&path.verbs);
+        points.extend_from_slice(&path.points);
     }
 }
 
@@ -1618,7 +1636,7 @@ fn test_path_builder_empty_begin() {
 
 
 #[test]
-fn test_merge_paths() {
+fn test_concatenate() {
     let mut builder = Path::builder();
     builder.begin(point(0.0, 0.0));
     builder.line_to(point(5.0, 0.0));
@@ -1635,7 +1653,12 @@ fn test_merge_paths() {
 
     let path2 = builder.build();
 
-    let path = path1.merge(&path2);
+    let mut builder = Path::builder();
+    builder.concatenate(&[
+        path1.as_slice(),
+        path2.as_slice(),
+    ]);
+    let path = builder.build();
 
     let mut it = path.iter();
     assert_eq!(

--- a/tessellation/src/fill.rs
+++ b/tessellation/src/fill.rs
@@ -2237,6 +2237,13 @@ impl<'l> FillBuilder<'l> {
             p
         }
     }
+
+    pub fn build(self) -> TessellationResult {
+        let mut event_queue = self.events.build();
+        std::mem::swap(&mut self.tessellator.events, &mut event_queue);
+
+        self.tessellator.tessellate_impl(self.options, None, self.output)
+    }
 }
 
 impl<'l> PathBuilder for FillBuilder<'l> {
@@ -2376,10 +2383,7 @@ impl<'l> Build for FillBuilder<'l> {
 
     #[inline]
     fn build(self) -> TessellationResult {
-        let mut event_queue = self.events.build();
-        std::mem::swap(&mut self.tessellator.events, &mut event_queue);
-
-        self.tessellator.tessellate_impl(self.options, None, self.output)
+        self.build()
     }
 }
 
@@ -2478,7 +2482,7 @@ fn fill_vertex_source_01() {
 
     let mut tess = FillTessellator::new();
     tess.tessellate_with_ids(
-        cmds.id_events(),
+        cmds.iter(),
         &(endpoints, endpoints),
         Some(&AttributeSlice::new(attributes, 3)),
         &FillOptions::default(),
@@ -2738,7 +2742,7 @@ fn fill_vertex_source_03() {
 
     let mut tess = FillTessellator::new();
     tess.tessellate_with_ids(
-        cmds.id_events(),
+        cmds.iter(),
         &(endpoints, endpoints),
         Some(&AttributeSlice::new(attributes, 1)),
         &FillOptions::default(),

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -137,7 +137,7 @@ fn test_path_with_rotations(path: Path, step: f32, expected_triangle_count: Opti
     while angle.radians < PI * 2.0 {
         //println!("\n\n ==================== angle = {:?}", angle);
 
-        let tranformed_path = path.transformed(&Rotation::new(angle));
+        let tranformed_path = path.clone().transformed(&Rotation::new(angle));
 
         test_path_internal(tranformed_path.as_slice(), FillRule::EvenOdd, expected_triangle_count);
         test_path_internal(tranformed_path.as_slice(), FillRule::NonZero, None);
@@ -424,7 +424,7 @@ fn test_rust_logo_with_intersection() {
 
 #[cfg(test)]
 fn scale_path(path: &mut Path, scale: f32) {
-    *path = path.transformed(&Scale::new(scale))
+    *path = path.clone().transformed(&Scale::new(scale))
 }
 
 #[test]

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 #![deny(bare_trait_objects)]
+#![deny(unconditional_recursion)]
 // TODO: Tessellation pipeline diagram needs to be updated.
 
 //! Tessellation of 2D fill and stroke operations.


### PR DESCRIPTION
 - `Path::merged` is removed in favor of `path::Builder::concatenate`.
 - `PathBuilder::extend` convenience to consume an iterator of `PathEvent`.
 - `ComansSlice` renamed into `PathCommandsSlice` for consistency.
 - More types are exposed in the root module of `lyon_path`.
 - `Path::transformed` consumes self to avoid reallocation in some cases (Fixes #501).
 - `PathCommands::id_events` renamed into `PathCommands::iter`. 