### PR TITLE
Stroke tessellator improvements

### DIFF
--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -29,6 +29,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
     let mut stroke = StrokeTessellator::new();
 
     if let Some(options) = cmd.stroke {
+        let options = options.dont_apply_line_width();
         stroke_width = options.line_width;
         stroke.tessellate(
             cmd.path.iter(),
@@ -448,7 +449,7 @@ pub static VERTEX_SHADER: &'static str = &"
         int id = a_prim_id + gl_InstanceID;
         Primitive prim = primitives[id];
 
-        vec2 local_pos = a_position + a_normal * prim.width + prim.translation;
+        vec2 local_pos = a_position + a_normal * prim.width * 0.5 + prim.translation;
         vec2 world_pos = local_pos - u_scroll_offset;
         vec2 transformed_pos = world_pos * u_zoom / (vec2(0.5, -0.5) * u_resolution);
 

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -750,3 +750,32 @@ fn test_with_miter_limit() {
 fn test_with_invalid_miter_limit() {
     let _ = StrokeOptions::default().with_miter_limit(0.0);
 }
+
+#[test]
+fn test_line_width() {
+    use crate::math::{Point, point};
+    let mut builder = crate::path::Path::builder();
+    builder.begin(point(0.0, 1.0));
+    builder.line_to(point(2.0, 1.0));
+    builder.end(false);
+    let path = builder.build();
+
+    let options = StrokeOptions::DEFAULT.with_line_width(2.0);
+    let mut geometry: VertexBuffers<Point, u16> = VertexBuffers::new();
+    StrokeTessellator::new().tessellate(
+        path.iter(),
+        &options,
+        &mut crate::geometry_builder::simple_builder(&mut geometry),
+    ).unwrap();
+
+
+    for p in &geometry.vertices {
+        assert!(
+            *p == point(0.0, 0.0)
+            || *p == point(0.0, 2.0)
+            || *p == point(2.0, 0.0)
+            || *p == point(2.0, 2.0)
+        );
+    }
+}
+

--- a/tessellation/src/stroke.rs
+++ b/tessellation/src/stroke.rs
@@ -609,37 +609,16 @@ impl<'l> StrokeBuilder<'l> {
                 return;
             }
 
-            self.attributes.normal = self.previous_normal;
-            self.attributes.side = Side::Left;
-            self.attributes.src = VertexSource::Endpoint {
-                id: self.previous_endpoint,
-            };
-            self.attributes.advancement = self.sub_path_start_length;
-            self.attributes.buffer_is_valid = false;
-
-            let first_left_id = match add_vertex!(self, position: self.previous) {
-                Ok(id) => id,
-                Err(e) => {
-                    self.error(e);
-                    return;
-                }
-            };
-
-            self.attributes.normal = -self.previous_normal;
-            self.attributes.side = Side::Right;
-
-            let first_right_id = match add_vertex!(self, position: self.previous) {
-                Ok(id) => id,
-                Err(e) => {
-                    self.error(e);
-                    return;
-                }
-            };
-
-            self.output
-                .add_triangle(first_right_id, first_left_id, self.second_right_id);
-            self.output
-                .add_triangle(first_left_id, self.second_left_id, self.second_right_id);
+            self.output.add_triangle(
+                self.previous_right_id,
+                self.previous_left_id,
+                self.second_right_id,
+            );
+            self.output.add_triangle(
+                self.previous_left_id,
+                self.second_left_id,
+                self.second_right_id,
+            );
         }
 
         self.sub_path_start_length = self.length;
@@ -780,7 +759,7 @@ impl<'l> StrokeBuilder<'l> {
     }
 
     fn edge_to(&mut self, to: Point, endpoint: EndpointId, t: f32, with_join: bool) {
-        if to == self.current {
+        if (to - self.current).square_length() < self.options.tolerance * self.options.tolerance {
             return;
         }
 


### PR DESCRIPTION
 - Fix incorrect stroke tessellation when closing a path with certain joins like MiterClip.
 - Improve the tessellation of round joins (less thin triangles).
 - Simplify the code handling folding joins.
 - Fix wrong line width in the cli viewer.