### PR TITLE
Improve the geometry building API

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -436,7 +436,6 @@ fn get_stroke(matches: &ArgMatches) -> Option<StrokeOptions> {
         options.line_width = get_line_width(matches);
         options.line_join = get_line_join(matches);
         options.tolerance = get_tolerance(matches);
-        options.apply_line_width = false;
         if let Some(limit) = get_miter_limit(matches) {
             options.miter_limit = limit;
         }
@@ -486,7 +485,6 @@ fn get_hatching(matches: &ArgMatches) -> Option<HatchingParams> {
         stroke.line_width = get_line_width(matches);
         stroke.line_join = get_line_join(matches);
         stroke.tolerance = get_tolerance(matches);
-        stroke.apply_line_width = false;
 
         let options = HatchingOptions::DEFAULT
             .with_tolerance(stroke.tolerance)
@@ -519,7 +517,6 @@ fn get_dots(matches: &ArgMatches) -> Option<DotParams> {
         stroke.end_cap = cap;
         stroke.line_width = get_line_width(matches);
         stroke.tolerance = get_tolerance(matches);
-        stroke.apply_line_width = false;
 
         let options = DotOptions::DEFAULT
             .with_tolerance(stroke.tolerance)

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -472,11 +472,11 @@ pub static FRAGMENT_SHADER: &'static str = &"
 pub struct WithId(pub i32);
 
 impl FillVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(&mut self, position: Point, _: tessellation::FillAttributes) -> GpuVertex {
-        debug_assert!(!position.x.is_nan());
-        debug_assert!(!position.y.is_nan());
+    fn new_vertex(&mut self, vertex: tessellation::FillAttributes) -> GpuVertex {
+        debug_assert!(!vertex.position().x.is_nan());
+        debug_assert!(!vertex.position().y.is_nan());
         GpuVertex {
-            position: position.to_array(),
+            position: vertex.position().to_array(),
             normal: [0.0, 0.0],
             prim_id: self.0,
         }
@@ -513,11 +513,11 @@ impl StrokeVertexConstructor<GpuVertex> for WithId {
 struct BgVertexCtor;
 
 impl FillVertexConstructor<BgVertex> for BgVertexCtor {
-    fn new_vertex(&mut self, position: Point, _: tessellation::FillAttributes) -> BgVertex {
-        debug_assert!(!position.x.is_nan());
-        debug_assert!(!position.y.is_nan());
+    fn new_vertex(&mut self, vertex: tessellation::FillAttributes) -> BgVertex {
+        debug_assert!(!vertex.position().x.is_nan());
+        debug_assert!(!vertex.position().y.is_nan());
         BgVertex {
-            position: position.to_array(),
+            position: vertex.position().to_array(),
         }
     }
 }

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -472,7 +472,7 @@ pub static FRAGMENT_SHADER: &'static str = &"
 pub struct WithId(pub i32);
 
 impl FillVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(&mut self, vertex: tessellation::FillAttributes) -> GpuVertex {
+    fn new_vertex(&mut self, vertex: tessellation::FillVertex) -> GpuVertex {
         debug_assert!(!vertex.position().x.is_nan());
         debug_assert!(!vertex.position().y.is_nan());
         GpuVertex {
@@ -496,7 +496,7 @@ impl tess2::geometry_builder::BasicVertexConstructor<GpuVertex> for WithId {
 }
 
 impl StrokeVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(&mut self, vertex: tessellation::StrokeAttributes) -> GpuVertex {
+    fn new_vertex(&mut self, vertex: tessellation::StrokeVertex) -> GpuVertex {
         debug_assert!(!vertex.position().x.is_nan());
         debug_assert!(!vertex.position().y.is_nan());
         debug_assert!(!vertex.normal().x.is_nan());
@@ -513,7 +513,7 @@ impl StrokeVertexConstructor<GpuVertex> for WithId {
 struct BgVertexCtor;
 
 impl FillVertexConstructor<BgVertex> for BgVertexCtor {
-    fn new_vertex(&mut self, vertex: tessellation::FillAttributes) -> BgVertex {
+    fn new_vertex(&mut self, vertex: tessellation::FillVertex) -> BgVertex {
         debug_assert!(!vertex.position().x.is_nan());
         debug_assert!(!vertex.position().y.is_nan());
         BgVertex {

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -29,7 +29,6 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
     let mut stroke = StrokeTessellator::new();
 
     if let Some(options) = cmd.stroke {
-        let options = options.dont_apply_line_width();
         stroke_width = options.line_width;
         stroke.tessellate(
             cmd.path.iter(),
@@ -508,7 +507,7 @@ impl StrokeVertexConstructor<GpuVertex> for WithId {
         debug_assert!(!attributes.normal().y.is_nan());
         debug_assert!(!attributes.advancement().is_nan());
         GpuVertex {
-            position: position.to_array(),
+            position: attributes.position_on_path().to_array(),
             normal: attributes.normal().to_array(),
             prim_id: self.0,
         }

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -496,19 +496,15 @@ impl tess2::geometry_builder::BasicVertexConstructor<GpuVertex> for WithId {
 }
 
 impl StrokeVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(
-        &mut self,
-        position: Point,
-        attributes: tessellation::StrokeAttributes,
-    ) -> GpuVertex {
-        debug_assert!(!position.x.is_nan());
-        debug_assert!(!position.y.is_nan());
-        debug_assert!(!attributes.normal().x.is_nan());
-        debug_assert!(!attributes.normal().y.is_nan());
-        debug_assert!(!attributes.advancement().is_nan());
+    fn new_vertex(&mut self, vertex: tessellation::StrokeAttributes) -> GpuVertex {
+        debug_assert!(!vertex.position().x.is_nan());
+        debug_assert!(!vertex.position().y.is_nan());
+        debug_assert!(!vertex.normal().x.is_nan());
+        debug_assert!(!vertex.normal().y.is_nan());
+        debug_assert!(!vertex.advancement().is_nan());
         GpuVertex {
-            position: attributes.position_on_path().to_array(),
-            normal: attributes.normal().to_array(),
+            position: vertex.position_on_path().to_array(),
+            normal: vertex.normal().to_array(),
             prim_id: self.0,
         }
     }

--- a/examples/walk_path/src/main.rs
+++ b/examples/walk_path/src/main.rs
@@ -395,11 +395,9 @@ pub static FRAGMENT_SHADER: &'static str = &"
 pub struct WithId(pub i32);
 
 impl FillVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(&mut self, position: Point, _: FillAttributes) -> GpuVertex {
-        debug_assert!(!position.x.is_nan());
-        debug_assert!(!position.y.is_nan());
+    fn new_vertex(&mut self, vertex: FillAttributes) -> GpuVertex {
         GpuVertex {
-            position: position.to_array(),
+            position: vertex.position().to_array(),
             prim_id: self.0,
         }
     }
@@ -408,11 +406,9 @@ impl FillVertexConstructor<GpuVertex> for WithId {
 pub struct BgVertexCtor;
 
 impl FillVertexConstructor<BgVertex> for BgVertexCtor {
-    fn new_vertex(&mut self, position: Point, _: FillAttributes) -> BgVertex {
-        debug_assert!(!position.x.is_nan());
-        debug_assert!(!position.y.is_nan());
+    fn new_vertex(&mut self, vertex: FillAttributes) -> BgVertex {
         BgVertex {
-            position: position.to_array(),
+            position: vertex.position().to_array(),
         }
     }
 }

--- a/examples/walk_path/src/main.rs
+++ b/examples/walk_path/src/main.rs
@@ -12,7 +12,7 @@ use lyon::path::builder::*;
 use lyon::path::iterator::*;
 use lyon::path::Path;
 use lyon::tessellation::geometry_builder::*;
-use lyon::tessellation::{FillAttributes, FillOptions, FillTessellator};
+use lyon::tessellation::{FillVertex, FillOptions, FillTessellator};
 
 use gfx::traits::{Device, FactoryExt};
 
@@ -395,7 +395,7 @@ pub static FRAGMENT_SHADER: &'static str = &"
 pub struct WithId(pub i32);
 
 impl FillVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(&mut self, vertex: FillAttributes) -> GpuVertex {
+    fn new_vertex(&mut self, vertex: FillVertex) -> GpuVertex {
         GpuVertex {
             position: vertex.position().to_array(),
             prim_id: self.0,
@@ -406,7 +406,7 @@ impl FillVertexConstructor<GpuVertex> for WithId {
 pub struct BgVertexCtor;
 
 impl FillVertexConstructor<BgVertex> for BgVertexCtor {
-    fn new_vertex(&mut self, vertex: FillAttributes) -> BgVertex {
+    fn new_vertex(&mut self, vertex: FillVertex) -> BgVertex {
         BgVertex {
             position: vertex.position().to_array(),
         }

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -556,7 +556,7 @@ fn main() {
 pub struct WithId(pub i32);
 
 impl FillVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(&mut self, vertex: tessellation::FillAttributes) -> GpuVertex {
+    fn new_vertex(&mut self, vertex: tessellation::FillVertex) -> GpuVertex {
         GpuVertex {
             position: vertex.position().to_array(),
             normal: [0.0, 0.0],
@@ -566,7 +566,7 @@ impl FillVertexConstructor<GpuVertex> for WithId {
 }
 
 impl StrokeVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(&mut self, vertex: tessellation::StrokeAttributes) -> GpuVertex {
+    fn new_vertex(&mut self, vertex: tessellation::StrokeVertex) -> GpuVertex {
         GpuVertex {
             position: vertex.position_on_path().to_array(),
             normal: vertex.normal().to_array(),

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
 
     stroke_tess.tessellate_path(
         &path,
-        &StrokeOptions::tolerance(tolerance).dont_apply_line_width(),
+        &StrokeOptions::tolerance(tolerance),
         &mut BuffersBuilder::new(&mut geometry, WithId(stroke_prim_id as i32)),
     ).unwrap();
 
@@ -583,7 +583,7 @@ impl StrokeVertexConstructor<GpuVertex> for WithId {
         debug_assert!(!attributes.normal().y.is_nan());
         debug_assert!(!attributes.advancement().is_nan());
         GpuVertex {
-            position: position.to_array(),
+            position: attributes.position_on_path().to_array(),
             normal: attributes.normal().to_array(),
             prim_id: self.0,
         }

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -572,19 +572,10 @@ impl FillVertexConstructor<GpuVertex> for WithId {
 }
 
 impl StrokeVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(
-        &mut self,
-        position: Point,
-        attributes: tessellation::StrokeAttributes,
-    ) -> GpuVertex {
-        debug_assert!(!position.x.is_nan());
-        debug_assert!(!position.y.is_nan());
-        debug_assert!(!attributes.normal().x.is_nan());
-        debug_assert!(!attributes.normal().y.is_nan());
-        debug_assert!(!attributes.advancement().is_nan());
+    fn new_vertex(&mut self, vertex: tessellation::StrokeAttributes) -> GpuVertex {
         GpuVertex {
-            position: attributes.position_on_path().to_array(),
-            normal: attributes.normal().to_array(),
+            position: vertex.position_on_path().to_array(),
+            normal: vertex.normal().to_array(),
             prim_id: self.0,
         }
     }

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -556,15 +556,9 @@ fn main() {
 pub struct WithId(pub i32);
 
 impl FillVertexConstructor<GpuVertex> for WithId {
-    fn new_vertex(
-        &mut self,
-        position: Point,
-        _attributes: tessellation::FillAttributes,
-    ) -> GpuVertex {
-        debug_assert!(!position.x.is_nan());
-        debug_assert!(!position.y.is_nan());
+    fn new_vertex(&mut self, vertex: tessellation::FillAttributes) -> GpuVertex {
         GpuVertex {
-            position: position.to_array(),
+            position: vertex.position().to_array(),
             normal: [0.0, 0.0],
             prim_id: self.0,
         }

--- a/examples/wgpu_svg/src/main.rs
+++ b/examples/wgpu_svg/src/main.rs
@@ -527,12 +527,9 @@ pub struct VertexCtor {
 }
 
 impl FillVertexConstructor<GpuVertex> for VertexCtor {
-    fn new_vertex(&mut self, position: Point, _: tessellation::FillAttributes) -> GpuVertex {
-        assert!(!position.x.is_nan());
-        assert!(!position.y.is_nan());
-
+    fn new_vertex(&mut self, vertex: tessellation::FillAttributes) -> GpuVertex {
         GpuVertex {
-            position: position.to_array(),
+            position: vertex.position().to_array(),
             prim_id: self.prim_id,
         }
     }
@@ -540,12 +537,8 @@ impl FillVertexConstructor<GpuVertex> for VertexCtor {
 
 impl StrokeVertexConstructor<GpuVertex> for VertexCtor {
     fn new_vertex(&mut self, vertex: tessellation::StrokeAttributes) -> GpuVertex {
-        let position = vertex.position();
-        assert!(!position.x.is_nan());
-        assert!(!position.y.is_nan());
-
         GpuVertex {
-            position: position.to_array(),
+            position: vertex.position().to_array(),
             prim_id: self.prim_id,
         }
     }

--- a/examples/wgpu_svg/src/main.rs
+++ b/examples/wgpu_svg/src/main.rs
@@ -539,7 +539,8 @@ impl FillVertexConstructor<GpuVertex> for VertexCtor {
 }
 
 impl StrokeVertexConstructor<GpuVertex> for VertexCtor {
-    fn new_vertex(&mut self, position: Point, _: tessellation::StrokeAttributes) -> GpuVertex {
+    fn new_vertex(&mut self, vertex: tessellation::StrokeAttributes) -> GpuVertex {
+        let position = vertex.position();
         assert!(!position.x.is_nan());
         assert!(!position.y.is_nan());
 

--- a/examples/wgpu_svg/src/main.rs
+++ b/examples/wgpu_svg/src/main.rs
@@ -527,7 +527,7 @@ pub struct VertexCtor {
 }
 
 impl FillVertexConstructor<GpuVertex> for VertexCtor {
-    fn new_vertex(&mut self, vertex: tessellation::FillAttributes) -> GpuVertex {
+    fn new_vertex(&mut self, vertex: tessellation::FillVertex) -> GpuVertex {
         GpuVertex {
             position: vertex.position().to_array(),
             prim_id: self.prim_id,
@@ -536,7 +536,7 @@ impl FillVertexConstructor<GpuVertex> for VertexCtor {
 }
 
 impl StrokeVertexConstructor<GpuVertex> for VertexCtor {
-    fn new_vertex(&mut self, vertex: tessellation::StrokeAttributes) -> GpuVertex {
+    fn new_vertex(&mut self, vertex: tessellation::StrokeVertex) -> GpuVertex {
         GpuVertex {
             position: vertex.position().to_array(),
             prim_id: self.prim_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@
 //!         tessellator.tessellate_path(
 //!             &path,
 //!             &FillOptions::default(),
-//!             &mut BuffersBuilder::new(&mut geometry, |vertex: FillAttributes| {
+//!             &mut BuffersBuilder::new(&mut geometry, |vertex: FillVertex| {
 //!                 MyVertex {
 //!                     position: vertex.position().to_array(),
 //!                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,9 +148,9 @@
 //!         tessellator.tessellate_path(
 //!             &path,
 //!             &FillOptions::default(),
-//!             &mut BuffersBuilder::new(&mut geometry, |pos: Point, _: FillAttributes| {
+//!             &mut BuffersBuilder::new(&mut geometry, |vertex: FillAttributes| {
 //!                 MyVertex {
-//!                     position: pos.to_array(),
+//!                     position: vertex.position().to_array(),
 //!                 }
 //!             }),
 //!         ).unwrap();

--- a/tessellation/src/fill.rs
+++ b/tessellation/src/fill.rs
@@ -307,7 +307,7 @@ struct PendingEdge {
 ///
 /// This is the complicated, but most powerful mechanism. The tessellator keeps track of where
 /// each vertex comes from in the original path, and provides access to this information via
-/// an iterator of [`VertexSource`](enum.VertexSource.html) in `FillAttributes::sources`.
+/// an iterator of [`VertexSource`](enum.VertexSource.html) in `FillVertex::sources`.
 ///
 /// It is most common for the vertex source iterator to yield a single `VertexSource::Endpoint`
 /// source, which happens when the vertex directly corresponds to an endpoint of the original path.
@@ -330,7 +330,7 @@ struct PendingEdge {
 /// of the edges they originate from.
 ///
 /// Custom endpoint attributes are represented as `&[f32]` slices accessible via
-/// `FillAttributes::interpolated_attributes`. All vertices, whether they originate from a single
+/// `FillVertex::interpolated_attributes`. All vertices, whether they originate from a single
 /// endpoint or some more complex source, have exactly the same number of attributes.
 /// Without having to know about the meaning of attributes, the tessellator can either
 /// forward the slice of attributes from a provided `AttributeStore` when possible or
@@ -339,7 +339,7 @@ struct PendingEdge {
 /// To use this feature, make sure to use `FillTessellator::tessellate_path` or
 /// `FillTessellator::tessellate_with_ids` instead of `FillTessellator::tessellate`.
 ///
-/// Attributes are lazily computed when calling `FillAttributes::interpolated_attributes`.
+/// Attributes are lazily computed when calling `FillVertex::interpolated_attributes`.
 /// In other words they don't add overhead when not used, however it is best to avoid calling
 /// interpolated_attributes several times per vertex.
 ///
@@ -412,7 +412,7 @@ struct PendingEdge {
 /// // A custom vertex constructor, see the geometry_builder module.
 /// struct Ctor;
 /// impl FillVertexConstructor<MyVertex> for Ctor {
-///     fn new_vertex(&mut self, mut vertex: FillAttributes) -> MyVertex {
+///     fn new_vertex(&mut self, mut vertex: FillVertex) -> MyVertex {
 ///         let position = vertex.position();
 ///         let attrs = vertex.interpolated_attributes();
 ///         MyVertex {
@@ -790,7 +790,7 @@ impl FillTessellator {
         };
 
         self.current_vertex = output.add_fill_vertex(
-            FillAttributes {
+            FillVertex {
                 position,
                 events: &self.events,
                 current_event,
@@ -2005,7 +2005,7 @@ fn reorient(p: Point) -> Point {
 }
 
 /// Extra vertex information from the `FillTessellator`, accessible when building vertices.
-pub struct FillAttributes<'l> {
+pub struct FillVertex<'l> {
     position: Point,
     events: &'l EventQueue,
     current_event: TessEventId,
@@ -2013,7 +2013,7 @@ pub struct FillAttributes<'l> {
     attrib_store: Option<&'l dyn AttributeStore>,
 }
 
-impl<'l> FillAttributes<'l> {
+impl<'l> FillVertex<'l> {
     pub fn position(&self) -> Point {
         self.position
     }
@@ -2035,7 +2035,7 @@ impl<'l> FillAttributes<'l> {
     /// a flattened curve. If two endpoints are at the same position only one of
     /// them is returned.
     ///
-    /// See also: `FillAttributes::sources`.
+    /// See also: `FillVertex::sources`.
     pub fn as_endpoint_id(&self) -> Option<EndpointId> {
         let mut current = self.current_event;
         while self.events.valid_id(current) {
@@ -2507,7 +2507,7 @@ fn fill_vertex_source_01() {
     impl FillGeometryBuilder for CheckVertexSources {
         fn add_fill_vertex(
             &mut self,
-            mut vertex: FillAttributes,
+            mut vertex: FillVertex,
         ) -> Result<VertexId, GeometryBuilderError> {
             let pos = vertex.position();
             for src in vertex.sources() {
@@ -2609,7 +2609,7 @@ fn fill_vertex_source_02() {
     impl FillGeometryBuilder for CheckVertexSources {
         fn add_fill_vertex(
             &mut self,
-            mut vertex: FillAttributes,
+            mut vertex: FillVertex,
         ) -> Result<VertexId, GeometryBuilderError> {
             let pos = vertex.position();
             for src in vertex.sources() {
@@ -2766,7 +2766,7 @@ fn fill_vertex_source_03() {
     }
 
     impl FillGeometryBuilder for CheckVertexSources {
-        fn add_fill_vertex(&mut self, mut vertex: FillAttributes) -> Result<VertexId, GeometryBuilderError> {
+        fn add_fill_vertex(&mut self, mut vertex: FillVertex) -> Result<VertexId, GeometryBuilderError> {
             if eq(vertex.position(), point(1.0, 1.0)) {
                 assert_eq!(vertex.interpolated_attributes(), &[1.5]);
                 assert_eq!(vertex.sources().count(), 2);
@@ -2815,7 +2815,7 @@ fn fill_builder_vertex_source() {
     }
 
     impl FillGeometryBuilder for CheckVertexSources {
-        fn add_fill_vertex(&mut self, vertex: FillAttributes) -> Result<VertexId, GeometryBuilderError> {
+        fn add_fill_vertex(&mut self, vertex: FillVertex) -> Result<VertexId, GeometryBuilderError> {
             let pos = vertex.position();
             for src in vertex.sources() {
                 if eq(pos, point(0.0, 0.0)) {

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -51,8 +51,7 @@ fn test_too_many_vertices() {
     impl FillGeometryBuilder for Builder {
         fn add_fill_vertex(
             &mut self,
-            _pos: Point,
-            _attrib: FillAttributes,
+            _: FillAttributes,
         ) -> Result<VertexId, GeometryBuilderError> {
             if self.max_vertices == 0 {
                 return Err(GeometryBuilderError::TooManyVertices);

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -3,7 +3,7 @@ use crate::math::*;
 use crate::geometry_builder::*;
 use crate::path::builder::{Build, PathBuilder};
 use crate::path::{Path, PathSlice};
-use crate::{FillAttributes, FillOptions, FillRule, FillTessellator, TessellationError, VertexId};
+use crate::{FillVertex, FillOptions, FillRule, FillTessellator, TessellationError, VertexId};
 
 use std::env;
 
@@ -51,7 +51,7 @@ fn test_too_many_vertices() {
     impl FillGeometryBuilder for Builder {
         fn add_fill_vertex(
             &mut self,
-            _: FillAttributes,
+            _: FillVertex,
         ) -> Result<VertexId, GeometryBuilderError> {
             if self.max_vertices == 0 {
                 return Err(GeometryBuilderError::TooManyVertices);

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -447,15 +447,6 @@ pub struct StrokeOptions {
     /// Default value: `StrokeOptions::DEFAULT_TOLERANCE`.
     pub tolerance: f32,
 
-    /// Apply line width
-    ///
-    /// When set to false, the generated vertices will all be positioned in the centre
-    /// of the line. The width can be applied later on (eg in a vertex shader) by adding
-    /// the vertex normal multiplied by the line with to each vertex position.
-    ///
-    /// Default value: `true`.
-    pub apply_line_width: bool,
-
     // To be able to add fields without making it a breaking change, add an empty private field
     // which makes it impossible to create a StrokeOptions without calling the constructor.
     _private: (),
@@ -482,7 +473,6 @@ impl StrokeOptions {
         line_width: Self::DEFAULT_LINE_WIDTH,
         miter_limit: Self::DEFAULT_MITER_LIMIT,
         tolerance: Self::DEFAULT_TOLERANCE,
-        apply_line_width: true,
         _private: (),
     };
 
@@ -532,12 +522,6 @@ impl StrokeOptions {
     pub fn with_miter_limit(mut self, limit: f32) -> Self {
         assert!(limit >= Self::MINIMUM_MITER_LIMIT);
         self.miter_limit = limit;
-        self
-    }
-
-    #[inline]
-    pub fn dont_apply_line_width(mut self) -> Self {
-        self.apply_line_width = false;
         self
     }
 }

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -319,8 +319,8 @@ impl Order {
     }
 }
 
-pub use fill::FillAttributes;
-pub use stroke::StrokeAttributes;
+pub use fill::FillVertex;
+pub use stroke::StrokeVertex;
 
 /// Where a vertex produced by a tessellator comes from in the original path.
 ///

--- a/tessellation/src/stroke.rs
+++ b/tessellation/src/stroke.rs
@@ -285,7 +285,7 @@ pub struct StrokeBuilder<'l> {
     options: StrokeOptions,
     error: Option<TessellationError>,
     output: &'l mut dyn StrokeGeometryBuilder,
-    attributes: StrokeAttributesData<'l>,
+    attributes: StrokeVertexData<'l>,
     validator: DebugValidator,
     next_endpoint_id: EndpointId,
 }
@@ -440,7 +440,7 @@ impl<'l> StrokeBuilder<'l> {
             options: *options,
             error: None,
             output,
-            attributes: StrokeAttributesData {
+            attributes: StrokeVertexData {
                 position_on_path: zero,
                 normal: vector(0.0, 0.0),
                 half_width: options.line_width * 0.5,
@@ -622,22 +622,22 @@ impl<'l> StrokeBuilder<'l> {
         self.attributes.normal = vector(1.0, 1.0);
         self.attributes.side = Side::Right;
 
-        let a = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let a = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.attributes.normal = vector(1.0, -1.0);
         self.attributes.side = Side::Left;
 
-        let b = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let b = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.attributes.normal = vector(-1.0, -1.0);
         self.attributes.side = Side::Left;
 
-        let c = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let c = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.attributes.normal = vector(-1.0, 1.0);
         self.attributes.side = Side::Right;
 
-        let d = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let d = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.output.add_triangle(a, b, c);
         self.output.add_triangle(a, c, d);
@@ -652,12 +652,12 @@ impl<'l> StrokeBuilder<'l> {
         self.attributes.normal = vector(-1.0, 0.0);
         self.attributes.side = Side::Left;
 
-        let left_id = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let left_id = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.attributes.normal = vector(1.0, 0.0);
         self.attributes.side = Side::Right;
 
-        let right_id = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let right_id = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.tessellate_round_cap(center, vector(0.0, -1.0), left_id, right_id, true)?;
         self.tessellate_round_cap(center, vector(0.0, 1.0), left_id, right_id, false)
@@ -734,12 +734,12 @@ impl<'l> StrokeBuilder<'l> {
             self.attributes.normal = n1;
             self.attributes.side = Side::Left;
 
-            let first_left_id = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+            let first_left_id = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
             self.attributes.normal = n2;
             self.attributes.side = Side::Right;
 
-            let first_right_id = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+            let first_right_id = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
             if self.options.start_cap == LineCap::Round {
                 self.tessellate_round_cap(first, d, first_left_id, first_right_id, true)?;
@@ -877,7 +877,7 @@ impl<'l> StrokeBuilder<'l> {
         self.attributes.normal = dir;
         self.attributes.side = Side::Left;
 
-        let mid_vertex = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let mid_vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         let (v1, v2, v3) = if is_start {
             (left, right, mid_vertex)
@@ -946,7 +946,7 @@ impl<'l> StrokeBuilder<'l> {
         self.attributes.normal = -front_normal;
         self.attributes.side = front_side.opposite();
 
-        let back_vertex = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let back_vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
         
         Ok(Some(back_vertex))
     }
@@ -1036,7 +1036,7 @@ impl<'l> StrokeBuilder<'l> {
             LineJoin::Miter => {
                 self.attributes.normal = front_normal;
                 self.attributes.side = front_side;
-                let front_vertex = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+                let front_vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
                 self.previous_normal = normal;
 
                 debug_assert!(back_vertex.is_some());
@@ -1077,12 +1077,12 @@ impl<'l> StrokeBuilder<'l> {
         self.attributes.normal = previous_normal * neg_if_right;
         self.attributes.side = front_side;
 
-        let front_start_vertex = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let front_start_vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.attributes.normal = next_normal * neg_if_right;
         self.attributes.side = front_side;
 
-        let front_end_vertex = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let front_end_vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.previous_normal = next_normal;
 
@@ -1127,10 +1127,10 @@ impl<'l> StrokeBuilder<'l> {
         self.attributes.side = front_side;
 
         self.attributes.normal = start_normal;
-        let front_start_vertex = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let front_start_vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.attributes.normal = end_normal;
-        let front_end_vertex = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let front_end_vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         // Add the triangle joining the back vertex and the start/end front vertices.
         if let Some(back_vertex) = back_vertex {
@@ -1176,12 +1176,12 @@ impl<'l> StrokeBuilder<'l> {
         self.attributes.normal = v1 * neg_if_right;
         self.attributes.side = front_side;
 
-        let front_start_vertex = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let front_start_vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.attributes.normal = v2 * neg_if_right;
         self.attributes.side = front_side;
 
-        let front_end_vertex = self.output.add_stroke_vertex(StrokeAttributes(&mut self.attributes))?;
+        let front_end_vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.attributes))?;
 
         self.previous_normal = normal;
 
@@ -1244,7 +1244,7 @@ fn tess_round_cap(
     num_recursions: u32,
     side: Side,
     invert_winding: bool,
-    attributes: &mut StrokeAttributesData,
+    attributes: &mut StrokeVertexData,
     output: &mut dyn StrokeGeometryBuilder,
 ) -> Result<(), TessellationError> {
     if num_recursions == 0 {
@@ -1259,7 +1259,7 @@ fn tess_round_cap(
     attributes.side = side;
 
     let vertex =
-        output.add_stroke_vertex(StrokeAttributes(attributes))?;
+        output.add_stroke_vertex(StrokeVertex(attributes))?;
 
     let (v1, v2, v3) = if invert_winding {
         (vertex, vb, va)
@@ -1335,7 +1335,7 @@ fn approximate_thin_rectangle(builder: &mut StrokeBuilder, rect: &Rect) {
 }
 
 /// Extra vertex information from the `StrokeTessellator`.
-pub(crate) struct StrokeAttributesData<'l> {
+pub(crate) struct StrokeVertexData<'l> {
     pub(crate) position_on_path: Point,
     pub(crate) half_width: f32,
     pub(crate) normal: Vector,
@@ -1348,9 +1348,9 @@ pub(crate) struct StrokeAttributesData<'l> {
 }
 
 /// Extra vertex information from the `StrokeTessellator` accessible when building vertices.
-pub struct StrokeAttributes<'a, 'b>(pub(crate) &'b mut StrokeAttributesData<'a>);
+pub struct StrokeVertex<'a, 'b>(pub(crate) &'b mut StrokeVertexData<'a>);
 
-impl<'a, 'b> StrokeAttributes<'a, 'b> {
+impl<'a, 'b> StrokeVertex<'a, 'b> {
     /// The vertex position.
     #[inline]
     pub fn position(&self) -> Point {
@@ -1463,7 +1463,7 @@ fn test_path(path: PathSlice, options: &StrokeOptions, expected_triangle_count: 
     impl<'l> StrokeGeometryBuilder for TestBuilder<'l> {
         fn add_stroke_vertex(
             &mut self,
-            attributes: StrokeAttributes,
+            attributes: StrokeVertex,
         ) -> Result<VertexId, GeometryBuilderError> {
             assert!(!attributes.position().x.is_nan());
             assert!(!attributes.position().y.is_nan());
@@ -1628,7 +1628,7 @@ fn test_too_many_vertices() {
     impl StrokeGeometryBuilder for Builder {
         fn add_stroke_vertex(
             &mut self,
-            _: StrokeAttributes,
+            _: StrokeVertex,
         ) -> Result<VertexId, GeometryBuilderError> {
             if self.max_vertices == 0 {
                 return Err(GeometryBuilderError::TooManyVertices);
@@ -1711,7 +1711,7 @@ fn stroke_vertex_source_01() {
     impl StrokeGeometryBuilder for CheckVertexSources {
         fn add_stroke_vertex(
             &mut self,
-            mut attr: StrokeAttributes,
+            mut attr: StrokeVertex,
         ) -> Result<VertexId, GeometryBuilderError> {
             let pos = attr.position_on_path();
             let src = attr.source();


### PR DESCRIPTION
 - `StrokeAttributes` is renamed into `StrokeVertex`.
 - `FillAttributes` is renamed into `FillVertex`.
 - Fill and stroke geometry builders and vertex constructors don't pass the the position separately from the rest of the attributes anymore. Instead, `FillVertex` and `StrokeVertex` have a `position()` method.
 - `StrokeOptions::apply_line_width` is removed. The line width is always applied to `StrokeVertex::position`, while `StrokeVertex::position_on_path` provides something equivalent to what one would have previously obtained with `apply_line_width = false`.