### PR TITLE
Add a way to generate reduced test cases from the command line

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,7 @@ mod flatten;
 mod fuzzing;
 mod show;
 mod tessellate;
+mod reduce;
 
 use clap::*;
 use commands::*;
@@ -156,6 +157,10 @@ fn main() {
                         .takes_value(true),
                 ),
         )
+        .subcommand(
+            declare_tess_params(SubCommand::with_name("reduce"), true)
+                .about("Find a reduced testcase")
+        )
         .get_matches();
 
     if let Some(command) = matches.subcommand_matches("tessellate") {
@@ -224,6 +229,11 @@ fn main() {
         let cmd = get_tess_command(command, true);
         let render_params = get_render_params(command);
         show::show_path(cmd, render_params);
+    }
+
+    if let Some(command) = matches.subcommand_matches("reduce") {
+        let cmd = get_tess_command(command, true);
+        reduce::reduce_testcase(cmd);
     }
 }
 

--- a/cli/src/reduce.rs
+++ b/cli/src/reduce.rs
@@ -1,0 +1,41 @@
+use commands::{TessellateCmd, Tessellator};
+use lyon::path::Path;
+use lyon::tessellation::geometry_builder::*;
+use lyon::tessellation::{FillTessellator, StrokeTessellator};
+
+pub fn reduce_testcase(cmd: TessellateCmd) {
+    if let Some(options) = cmd.stroke {
+        lyon::extra::debugging::find_reduced_test_case(cmd.path.as_slice(), &|path: Path| {
+            StrokeTessellator::new().tessellate_path(
+                &path,
+                &options,
+                &mut NoOutput::new(),
+            ).is_err()
+        });
+    }
+
+    if let Some(_) = cmd.hatch {
+        unimplemented!();
+    }
+
+    if let Some(_) = cmd.dots {
+        unimplemented!();
+    }
+
+    if let Some(options) = cmd.fill {
+        match cmd.tessellator {
+            Tessellator::Default => {
+                lyon::extra::debugging::find_reduced_test_case(cmd.path.as_slice(), &|path: Path| {
+                    FillTessellator::new().tessellate_path(
+                        &path,
+                        &options,
+                        &mut NoOutput::new(),
+                    ).is_err()
+                });
+            }
+            Tessellator::Tess2 => {
+                unimplemented!();
+            }
+        }
+    }
+}

--- a/cli/src/reduce.rs
+++ b/cli/src/reduce.rs
@@ -1,11 +1,16 @@
 use commands::{TessellateCmd, Tessellator};
 use lyon::path::Path;
+use lyon::path::traits::*;
 use lyon::tessellation::geometry_builder::*;
 use lyon::tessellation::{FillTessellator, StrokeTessellator};
 
 pub fn reduce_testcase(cmd: TessellateCmd) {
     if let Some(options) = cmd.stroke {
-        lyon::extra::debugging::find_reduced_test_case(cmd.path.as_slice(), &|path: Path| {
+        let mut flattener = Path::builder().flattened(options.tolerance);
+        flattener.extend(cmd.path.iter());
+        let path = flattener.build();
+
+        lyon::extra::debugging::find_reduced_test_case(path.as_slice(), &|path: Path| {
             StrokeTessellator::new().tessellate_path(
                 &path,
                 &options,
@@ -23,9 +28,13 @@ pub fn reduce_testcase(cmd: TessellateCmd) {
     }
 
     if let Some(options) = cmd.fill {
+        let mut flattener = Path::builder().flattened(options.tolerance);
+        flattener.extend(cmd.path.iter());
+        let path = flattener.build();
+
         match cmd.tessellator {
             Tessellator::Default => {
-                lyon::extra::debugging::find_reduced_test_case(cmd.path.as_slice(), &|path: Path| {
+                lyon::extra::debugging::find_reduced_test_case(path.as_slice(), &|path: Path| {
                     FillTessellator::new().tessellate_path(
                         &path,
                         &options,


### PR DESCRIPTION
New `reduce` command in the cli app. Accepts mostly the same parameters as `show` and `tessellate`.