### PR TITLE
Handle horizontal edges explicitly in the first part of the active ege scan

### DIFF
--- a/tessellation/src/fill.rs
+++ b/tessellation/src/fill.rs
@@ -973,6 +973,9 @@ impl FillTessellator {
                         current_x
                     );
                     false
+                } else if active_edge.from.y == active_edge.to.y {
+                    connecting_edges = true;
+                    false
                 } else {
                     let ex = active_edge.solve_x_for_y(self.current_position.y);
 


### PR DESCRIPTION
Fixes #591. 

The fix for the branch [0.15](https://github.com/nical/lyon/tree/0.15) is already published on crates.io, this is the fix for the master branch which hasn't been published on crates.io yet.