### PR TITLE
Fix incorrect vertex source for the first point of stroke subpaths.

### DIFF
--- a/tessellation/src/stroke.rs
+++ b/tessellation/src/stroke.rs
@@ -728,6 +728,9 @@ impl<'l> StrokeBuilder<'l> {
             let n2 = normalized_tangent(d);
             let n1 = -n2;
 
+            self.attributes.src = VertexSource::Endpoint {
+                id: self.first_endpoint,
+            };
             self.attributes.advancement = self.sub_path_start_length;
             self.attributes.position_on_path = first;
 


### PR DESCRIPTION
Fixes #592.

This fixes the the problem with the custom attributes of the first endpoint of each subpath. The other issue was present on branch 0.15 but not on master because it went away with a refactoring of the stroke tessellator.

the fix for branch 0.15 is already published on [crates.io](https://crates.io/crates/lyon_tessellation/0.15.9).