### PR TITLE
Update the examples to use wgpu 0.6.0

### DIFF
--- a/examples/wgpu/Cargo.toml
+++ b/examples/wgpu/Cargo.toml
@@ -14,7 +14,7 @@ lyon = { path = "../../", features = ["extra"] }
 env_logger = "0.7"
 log = "0.4"
 
-wgpu = "0.5.0"
+wgpu = "0.6.0"
 wgpu-native = "0.5.0"
 winit = "0.20.0-alpha4"
 futures = "0.3.5"

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -509,41 +509,20 @@ fn main() {
             ];
         }
 
-        let globals_transfer_buffer =
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: None,
-                contents: bytemuck::cast_slice(&[Globals {
-                    resolution: [
-                        scene.window_size.width as f32,
-                        scene.window_size.height as f32,
-                    ],
-                    zoom: scene.zoom,
-                    scroll_offset: scene.scroll.to_array(),
-                }]),
-                usage: wgpu::BufferUsage::COPY_SRC,
-            });
-
-        let prim_transfer_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: None,
-            contents: bytemuck::cast_slice(&cpu_primitives),
-            usage: wgpu::BufferUsage::COPY_SRC,
-        });
-
-        encoder.copy_buffer_to_buffer(
-            &globals_transfer_buffer,
-            0,
+        queue.write_buffer(
             &globals_ubo,
             0,
-            globals_buffer_byte_size,
+            bytemuck::cast_slice(&[Globals {
+                resolution: [
+                    scene.window_size.width as f32,
+                    scene.window_size.height as f32,
+                ],
+                zoom: scene.zoom,
+                scroll_offset: scene.scroll.to_array(),
+            }]),
         );
 
-        encoder.copy_buffer_to_buffer(
-            &prim_transfer_buffer,
-            0,
-            &prims_ubo,
-            0,
-            prim_buffer_byte_size,
-        );
+        queue.write_buffer(&prims_ubo, 0, bytemuck::cast_slice(&cpu_primitives));
 
         {
             // A resolve target is only supported if the attachment actually uses anti-aliasing

--- a/examples/wgpu_svg/Cargo.toml
+++ b/examples/wgpu_svg/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 lyon = { path = "../../", features = ["extra"] }
 
 clap = "2.32.0"
-wgpu = "0.5.0"
+wgpu = "0.6.0"
 wgpu-native = "0.5.0"
 winit = "0.20.0-alpha4"
 usvg = "0.4"

--- a/examples/wgpu_svg/src/main.rs
+++ b/examples/wgpu_svg/src/main.rs
@@ -464,23 +464,14 @@ fn main() {
             label: Some("Encoder"),
         });
 
-        let globals_transfer_buffer =
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: None,
-                contents: bytemuck::cast_slice(&[GpuGlobals {
-                    aspect_ratio: scene.window_size.width as f32 / scene.window_size.height as f32,
-                    zoom: [scene.zoom, scene.zoom],
-                    pan: scene.pan,
-                }]),
-                usage: wgpu::BufferUsage::COPY_SRC,
-            });
-
-        encoder.copy_buffer_to_buffer(
-            &globals_transfer_buffer,
-            0,
+        queue.write_buffer(
             &globals_ubo,
             0,
-            globals_buffer_byte_size,
+            bytemuck::cast_slice(&[GpuGlobals {
+                aspect_ratio: scene.window_size.width as f32 / scene.window_size.height as f32,
+                zoom: [scene.zoom, scene.zoom],
+                pan: scene.pan,
+            }]),
         );
 
         {

--- a/examples/wgpu_svg/src/main.rs
+++ b/examples/wgpu_svg/src/main.rs
@@ -388,40 +388,9 @@ fn main() {
     render_pipeline_descriptor.primitive_topology = wgpu::PrimitiveTopology::LineList;
     let wireframe_render_pipeline = device.create_render_pipeline(&render_pipeline_descriptor);
 
-    let prim_transfer_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: None,
-        contents: bytemuck::cast_slice(&primitives),
-        usage: wgpu::BufferUsage::COPY_SRC,
-    });
+    queue.write_buffer(&transforms_ubo, 0, bytemuck::cast_slice(&transforms));
 
-    let transform_transfer_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: None,
-        contents: bytemuck::cast_slice(&transforms),
-        usage: wgpu::BufferUsage::COPY_SRC,
-    });
-
-    // Initializaition encode to same primitive and transform data that will not change over frames
-    let mut init_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-        label: Some("Init encoder"),
-    });
-
-    init_encoder.copy_buffer_to_buffer(
-        &transform_transfer_buffer,
-        0,
-        &transforms_ubo,
-        0,
-        transform_buffer_byte_size,
-    );
-
-    init_encoder.copy_buffer_to_buffer(
-        &prim_transfer_buffer,
-        0,
-        &prims_ubo,
-        0,
-        prim_buffer_byte_size,
-    );
-
-    queue.submit(Some(init_encoder.finish()));
+    queue.write_buffer(&prims_ubo, 0, bytemuck::cast_slice(&primitives));
 
     // The main loop.
 


### PR DESCRIPTION
wgpu 0.6.0 is now released :tada: https://gfx-rs.github.io/2020/08/18/release-0.6.html

Most of the changes are straightforward. One thing to note is replacement of transfer buffers with the new feature `queue.write_buffer()`, which the nice people on wgpu's matrix chat kindly told me.