### PR TITLE
Store Span's tesselator behind a pointer

### DIFF
--- a/tessellation/src/monotone.rs
+++ b/tessellation/src/monotone.rs
@@ -32,7 +32,7 @@ impl BasicMonotoneTessellator {
         }
     }
 
-    pub fn begin(mut self, pos: Point, id: VertexId) -> Self {
+    pub fn begin(&mut self, pos: Point, id: VertexId) {
         debug_assert!(id != VertexId::INVALID);
         let first = MonotoneVertex {
             pos,
@@ -47,8 +47,6 @@ impl BasicMonotoneTessellator {
         self.stack.clear();
         self.stack.reserve(16);
         self.stack.push(first);
-
-        self
     }
 
     #[inline]
@@ -146,14 +144,16 @@ impl BasicMonotoneTessellator {
 fn test_monotone_tess() {
     println!(" ------------ ");
     {
-        let mut tess = BasicMonotoneTessellator::new().begin(point(0.0, 0.0), VertexId(0));
+        let mut tess = BasicMonotoneTessellator::new();
+        tess.begin(point(0.0, 0.0), VertexId(0));
         tess.vertex(point(-1.0, 1.0), VertexId(1), Side::Left);
         tess.end(point(1.0, 2.0), VertexId(2));
         assert_eq!(tess.triangles.len(), 1);
     }
     println!(" ------------ ");
     {
-        let mut tess = BasicMonotoneTessellator::new().begin(point(0.0, 0.0), VertexId(0));
+        let mut tess = BasicMonotoneTessellator::new();
+        tess.begin(point(0.0, 0.0), VertexId(0));
         tess.vertex(point(1.0, 1.0), VertexId(1), Side::Right);
         tess.vertex(point(-1.5, 2.0), VertexId(2), Side::Left);
         tess.vertex(point(-1.0, 3.0), VertexId(3), Side::Left);
@@ -163,7 +163,8 @@ fn test_monotone_tess() {
     }
     println!(" ------------ ");
     {
-        let mut tess = BasicMonotoneTessellator::new().begin(point(0.0, 0.0), VertexId(0));
+        let mut tess = BasicMonotoneTessellator::new();
+        tess.begin(point(0.0, 0.0), VertexId(0));
         tess.vertex(point(1.0, 1.0), VertexId(1), Side::Right);
         tess.vertex(point(3.0, 2.0), VertexId(2), Side::Right);
         tess.vertex(point(1.0, 3.0), VertexId(3), Side::Right);
@@ -174,7 +175,8 @@ fn test_monotone_tess() {
     }
     println!(" ------------ ");
     {
-        let mut tess = BasicMonotoneTessellator::new().begin(point(0.0, 0.0), VertexId(0));
+        let mut tess = BasicMonotoneTessellator::new();
+        tess.begin(point(0.0, 0.0), VertexId(0));
         tess.vertex(point(-1.0, 1.0), VertexId(1), Side::Left);
         tess.vertex(point(-3.0, 2.0), VertexId(2), Side::Left);
         tess.vertex(point(-1.0, 3.0), VertexId(3), Side::Left);
@@ -236,8 +238,8 @@ impl AdvancedMonotoneTessellator {
         }
     }
 
-    pub fn begin(mut self, pos: Point, id: VertexId) -> Self {
-        self.tess = self.tess.begin(pos, id);
+    pub fn begin(&mut self, pos: Point, id: VertexId) {
+        self.tess.begin(pos, id);
         self.left.reference_point = pos;
         self.right.reference_point = pos;
         self.left.prev = pos;
@@ -248,8 +250,6 @@ impl AdvancedMonotoneTessellator {
         self.right.events.clear();
         self.left.push(MonotoneVertex { pos, id, side: Side::Left });
         self.right.push(MonotoneVertex { pos, id, side: Side::Right });
-
-        self
     }
 
     pub fn vertex(&mut self, pos: Point, id: VertexId, side: Side) {


### PR DESCRIPTION
`MonotoneTessellator` is a huge struct, so copying it around when pushing/popping and especially in `spans.retain()` is relatively expensive. Boxing it adds a layer of indirection and extra `Option` checks in other parts of the algorithm, but significantly speeds up `cleanup_spans`, `begin_span` and `end_span`.

Tessellation benchmarks see a 15-30% improvement. I can also see a similar 10-20% improvement in real world uses in https://github.com/ruffle-rs/ruffle in wasm builds.

Benchmarks before vs after:
```
fill_events_01_logo                 72,443 ns/iter (+/- 8,185)  ->  72,465 ns/iter (+/- 4,044)
fill_events_02_logo_pre_flattened   40,760 ns/iter (+/- 8,680)  ->  39,751 ns/iter (+/- 2,796)
fill_events_03_logo_with_tess      251,327 ns/iter (+/- 6,709)  -> 209,559 ns/iter (+/- 51,154)
fill_tess_01_logo                  213,336 ns/iter (+/- 9,482)  -> 168,523 ns/iter (+/- 5,023)
fill_tess_03_logo_no_intersections 230,245 ns/iter (+/- 7,912)  -> 185,115 ns/iter (+/- 11,044)
fill_tess_05_logo_no_curve         132,274 ns/iter (+/- 6,337)  ->  92,060 ns/iter (+/- 13,499)
fill_tess_06_logo_with_ids         210,871 ns/iter (+/- 27,150) -> 168,993 ns/iter (+/- 11,192)
flattening_01_logo_simple_iter      41,266 ns/iter (+/- 923)    ->  40,935 ns/iter (+/- 2,431)
flattening_02_logo_iter             51,051 ns/iter (+/- 2,705)  ->  52,444 ns/iter (+/- 2,448)
flattening_03_logo_builder          39,201 ns/iter (+/- 2,078)  ->  39,273 ns/iter (+/- 1,429)
stroke_01_logo_miter                67,696 ns/iter (+/- 3,201)  ->  67,516 ns/iter (+/- 4,866)
stroke_02_logo_bevel                72,127 ns/iter (+/- 3,793)  ->  73,016 ns/iter (+/- 4,191)
stroke_03_logo_round                81,014 ns/iter (+/- 11,486) ->  81,680 ns/iter (+/- 6,663)
```

I tried running tests, but `cargo test` only saw 4 doctests, and ignored 2 of them - is this right?

Only thing I'm not sure about is `fn tess()` and its error handling; feel free to suggest alternatives.