### PR TITLE
Fix incorrect tessellation (issue 623)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "arrayvec 0.5.1",
  "lyon_extra",

--- a/tessellation/Cargo.toml
+++ b/tessellation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_tessellation"
-version = "0.17.2"
+version = "0.17.3"
 description = "A low level path tessellation library."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"

--- a/tessellation/src/event_queue.rs
+++ b/tessellation/src/event_queue.rs
@@ -990,7 +990,7 @@ fn test_event_queue_push_sorted() {
 
 #[test]
 fn test_logo() {
-    use crate::path::{builder::Build, Path};
+    use crate::path::Path;
 
     let mut path = Path::builder().with_svg();
 

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -1,7 +1,7 @@
 use crate::extra::rust_logo::build_logo_path;
 use crate::math::*;
 use crate::geometry_builder::*;
-use crate::path::builder::{Build, PathBuilder};
+use crate::path::builder::PathBuilder;
 use crate::path::{Path, PathSlice};
 use crate::{FillVertex, FillOptions, FillRule, FillTessellator, TessellationError, VertexId};
 


### PR DESCRIPTION
Fixes #623.

The error was happening in the monotone tessellator because the reference x coordinate of each side was reset whenever a convex chain of vertex was flushed, without taking into account that the other side might extend from further above to further below the chain that is flushed. It is not enough to track a reference x coordinate for the duration of a convex chain, we also need to track a reference x coordinate valid since the beginning of the convex of the opposite side as well. This patch adds a conservative_reference_x which does that. It is only relaxed to the current chain's reference x coordinate when the opposite side is flushed, ensuring that no edge from the other opposite side can intersect the the current side's unresolved convex chain.