### PR TITLE
Soundness fixes

### DIFF
--- a/path/src/commands.rs
+++ b/path/src/commands.rs
@@ -89,7 +89,7 @@ struct CmdIter<'l> {
 }
 
 impl<'l> CmdIter<'l> {
-    fn new(slice: &[u32]) -> Self {
+    fn new(slice: &'l [u32]) -> Self {
         let ptr = slice.as_ptr();
         let end = unsafe { ptr.add(slice.len()) };
         CmdIter {
@@ -629,7 +629,7 @@ pub struct Iter<'l> {
 }
 
 impl<'l> Iter<'l> {
-    fn new(cmds: &[u32]) -> Self {
+    fn new(cmds: &'l [u32]) -> Self {
         Iter {
             cmds: CmdIter::new(cmds),
             idx: 0,

--- a/path/src/path.rs
+++ b/path/src/path.rs
@@ -759,6 +759,11 @@ impl<'l> PointIter<'l> {
     }
 
     #[inline]
+    fn remaining_len(&self) -> usize {
+        (self.end as usize - self.ptr as usize) / std::mem::size_of::<Point>()
+    }
+
+    #[inline]
     fn next(&mut self) -> Point {
         // Don't bother panicking here. calls to next
         // are always followed by advance_n which will
@@ -777,9 +782,10 @@ impl<'l> PointIter<'l> {
 
     #[inline]
     fn advance_n(&mut self, n: usize) {
-        let ptr = self.ptr.wrapping_add(n);
-        assert!(ptr <= self.end);
-        self.ptr = ptr;
+        unsafe {
+            assert!(self.remaining_len() >= n);
+            self.ptr = self.ptr.add(n);
+        }
     }
 }
 


### PR DESCRIPTION
* Correct lifetimes in iterator constructors.
* Use `wrapping_add` instead of `add` when the pointer can wrap (otherwise it is UB even if the result is never dereferenced).
* Avoid creating invalid slices (it is UB even if they are never dereferenced).