### PR TITLE
Fix the hatching algorithm.

### DIFF
--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lyon_algorithms"
-version = "0.17.1"
+version = "0.17.2"
 description = "2D Path manipulation/transformation algorithms."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"


### PR DESCRIPTION
Since the path building revamp, users of the low-level builder are expected to match begin/end exactly and not close opportunistically. The hatch builder was doing an extra close when building.

Fixes #634.