### PR TITLE
Fix incorrect case in #[doc(hidden)]

### DIFF
--- a/algorithms/src/aabb.rs
+++ b/algorithms/src/aabb.rs
@@ -31,7 +31,7 @@ where
     }
 }
 
-#[doc(Hidden)]
+#[doc(hidden)]
 pub trait FastBoundingRect {
     fn min_max(&self, min: &mut Point, max: &mut Point);
 }
@@ -86,7 +86,7 @@ where
     }
 }
 
-#[doc(Hidden)]
+#[doc(hidden)]
 pub trait TightBoundingRect {
     fn min_max(&self, min: &mut Point, max: &mut Point);
 }


### PR DESCRIPTION
The latest Rust nightly throws an error on incorrect casing in the `doc` attribute:
```
rustc 1.52.0-nightly (35dbef235 2021-03-02)

error: unknown `doc` attribute `Hidden`
  --> algorithms\src\aabb.rs:34:7
   |
34 | #[doc(Hidden)]
   |       ^^^^^^
```
