### PR TITLE
rustfmt

### DIFF
--- a/algorithms/src/advanced_path.rs
+++ b/algorithms/src/advanced_path.rs
@@ -4,8 +4,8 @@
 //  - simplify/remove it.
 
 use crate::math::*;
-use crate::path::{Path, PathEvent};
 use crate::path::polygon::Polygon;
+use crate::path::{Path, PathEvent};
 use sid::{Id, IdRange, IdSlice, IdVec};
 use std::ops;
 use std::u16;

--- a/algorithms/src/hatching.rs
+++ b/algorithms/src/hatching.rs
@@ -26,11 +26,11 @@
 //! let hatched_path = hatches.build();
 //! ```
 
-use crate::math::{point, vector, Angle, Point, Rotation, Vector};
 use crate::geom::LineSegment;
+use crate::math::{point, vector, Angle, Point, Rotation, Vector};
 use crate::path::builder::{Build, PathBuilder};
 use crate::path::private::DebugValidator;
-use crate::path::{self, PathEvent, EndpointId};
+use crate::path::{self, EndpointId, PathEvent};
 use std::marker::PhantomData;
 
 use std::cmp::Ordering;
@@ -705,7 +705,7 @@ fn simple_hatching() {
         &HatchingOptions::DEFAULT,
         &mut RegularHatchingPattern {
             interval: 1.0,
-            callback: &mut|segment: &HatchSegment| {
+            callback: &mut |segment: &HatchSegment| {
                 hatches.add_line_segment(&LineSegment {
                     from: segment.a.position,
                     to: segment.b.position,

--- a/algorithms/src/hit_test.rs
+++ b/algorithms/src/hit_test.rs
@@ -35,7 +35,12 @@ where
                 prev_winding = None;
             }
             PathEvent::Line { from, to } => {
-                test_segment(*point, &LineSegment { from, to }, &mut winding, &mut prev_winding);
+                test_segment(
+                    *point,
+                    &LineSegment { from, to },
+                    &mut winding,
+                    &mut prev_winding,
+                );
             }
             PathEvent::End { last, first, .. } => {
                 test_segment(
@@ -56,7 +61,12 @@ where
                 }
                 let mut prev = segment.from;
                 segment.for_each_flattened(tolerance, &mut |p| {
-                    test_segment(*point, &LineSegment { from: prev, to: p }, &mut winding, &mut prev_winding);
+                    test_segment(
+                        *point,
+                        &LineSegment { from: prev, to: p },
+                        &mut winding,
+                        &mut prev_winding,
+                    );
                     prev = p;
                 });
             }
@@ -78,7 +88,12 @@ where
                 }
                 let mut prev = segment.from;
                 segment.for_each_flattened(tolerance, &mut |p| {
-                    test_segment(*point, &LineSegment { from: prev, to: p }, &mut winding, &mut prev_winding);
+                    test_segment(
+                        *point,
+                        &LineSegment { from: prev, to: p },
+                        &mut winding,
+                        &mut prev_winding,
+                    );
                     prev = p;
                 });
             }
@@ -88,14 +103,19 @@ where
     winding
 }
 
-fn test_segment(point: Point, segment: &LineSegment<f32>, winding: &mut i32, prev_winding: &mut Option<i32>) {
-    let y0  = segment.from.y;
-    let y1  = segment.to.y;
+fn test_segment(
+    point: Point,
+    segment: &LineSegment<f32>,
+    winding: &mut i32,
+    prev_winding: &mut Option<i32>,
+) {
+    let y0 = segment.from.y;
+    let y1 = segment.to.y;
     if f32::min(y0, y1) > point.y
         || f32::max(y0, y1) < point.y
         || f32::min(segment.from.x, segment.to.x) > point.x
-        || y0 == y1 {
-
+        || y0 == y1
+    {
         return;
     }
 
@@ -142,7 +162,7 @@ fn test_segment(point: Point, segment: &LineSegment<f32>, winding: &mut i32, pre
         //
         // The main idea is that within a sub-path we can't have consecutive affecting edges
         // of the same winding sign, so if we find some it means we are double-counting.
-        if *prev_winding != Some(w)  {
+        if *prev_winding != Some(w) {
             *winding += w;
         }
 
@@ -180,7 +200,10 @@ fn test_hit_test() {
         FillRule::EvenOdd,
         0.1
     ));
-    println!("winding {:?}", path_winding_number_at_position(&point(2.0, 0.0), path.iter(), 0.1));
+    println!(
+        "winding {:?}",
+        path_winding_number_at_position(&point(2.0, 0.0), path.iter(), 0.1)
+    );
     assert!(!hit_test_path(
         &point(2.0, 0.0),
         path.iter(),
@@ -242,6 +265,16 @@ fn hit_test_point_aligned() {
         closed: true,
     };
 
-    assert!(hit_test_path(&point(0.0, 5.0), poly.path_events(), FillRule::NonZero, 0.1));
-    assert!(!hit_test_path(&point(15.0, 5.0), poly.path_events(), FillRule::NonZero, 0.1));
+    assert!(hit_test_path(
+        &point(0.0, 5.0),
+        poly.path_events(),
+        FillRule::NonZero,
+        0.1
+    ));
+    assert!(!hit_test_path(
+        &point(15.0, 5.0),
+        poly.path_events(),
+        FillRule::NonZero,
+        0.1
+    ));
 }

--- a/algorithms/src/splitter.rs
+++ b/algorithms/src/splitter.rs
@@ -2,9 +2,9 @@ use crate::advanced_path::*;
 use crate::geom::{Line, LineSegment};
 /// Split paths with a line or line segment.
 use crate::math::*;
-use crate::path::*;
-use crate::path::polygon::Polygon;
 use crate::path::iterator::PathIterator;
+use crate::path::polygon::Polygon;
+use crate::path::*;
 use std::cmp::PartialOrd;
 use std::mem;
 
@@ -749,7 +749,6 @@ fn split_with_segment_3() {
 
 #[test]
 fn split_with_segment_4() {
-
     //  ________
     // |        |
     //-+--+-----+-

--- a/algorithms/src/walk.rs
+++ b/algorithms/src/walk.rs
@@ -42,7 +42,7 @@
 use crate::geom::{CubicBezierSegment, QuadraticBezierSegment};
 use crate::math::*;
 use crate::path::builder::*;
-use crate::path::{PathEvent, EndpointId};
+use crate::path::{EndpointId, PathEvent};
 
 use std::f32;
 
@@ -171,7 +171,7 @@ impl<'l> PathBuilder for PathWalker<'l> {
         if close {
             let first = self.first;
             self.line_to(first);
-            self.need_moveto = true;        
+            self.need_moveto = true;
         }
     }
 

--- a/bench/path/src/main.rs
+++ b/bench/path/src/main.rs
@@ -5,8 +5,8 @@ extern crate bencher;
 use lyon::extra::rust_logo::build_logo_path;
 use lyon::math::point;
 use lyon::path::commands;
-use lyon::path::PathBuffer;
 use lyon::path::traits::*;
+use lyon::path::PathBuffer;
 use lyon::path::{ControlPointId, EndpointId, Event, IdEvent, Path, PathEvent};
 
 use bencher::Bencher;
@@ -23,7 +23,6 @@ fn path_buffer_logo(bench: &mut Bencher) {
         }
     });
 }
-
 
 fn simple_path_build_empty(bench: &mut Bencher) {
     bench.iter(|| {

--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -118,12 +118,8 @@ fn fill_tess_03_logo_no_intersections(bench: &mut Bencher) {
     bench.iter(|| {
         for _ in 0..N {
             let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
-            tess.tessellate_path(
-                &path,
-                &options,
-                &mut simple_builder(&mut buffers),
-            )
-            .unwrap();
+            tess.tessellate_path(&path, &options, &mut simple_builder(&mut buffers))
+                .unwrap();
         }
     })
 }
@@ -139,12 +135,8 @@ fn fill_tess_05_logo_no_curve(bench: &mut Bencher) {
     bench.iter(|| {
         for _ in 0..N {
             let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
-            tess.tessellate_path(
-                &path,
-                &options,
-                &mut simple_builder(&mut buffers),
-            )
-            .unwrap();
+            tess.tessellate_path(&path, &options, &mut simple_builder(&mut buffers))
+                .unwrap();
         }
     })
 }

--- a/cli/src/fuzzing.rs
+++ b/cli/src/fuzzing.rs
@@ -1,13 +1,13 @@
 use crate::commands::{FuzzCmd, Tessellator};
+use lyon::algorithms::hatching::*;
 use lyon::extra::debugging::find_reduced_test_case;
+use lyon::geom::LineSegment;
 use lyon::math::*;
-use lyon::path::Path;
 use lyon::path::traits::PathBuilder;
+use lyon::path::Path;
 use lyon::tess2;
 use lyon::tessellation::geometry_builder::NoOutput;
 use lyon::tessellation::{FillTessellator, StrokeTessellator};
-use lyon::algorithms::hatching::*;
-use lyon::geom::LineSegment;
 use rand;
 use std::cmp::{max, min};
 
@@ -67,27 +67,22 @@ pub fn run(cmd: FuzzCmd) -> bool {
     loop {
         let path = generate_path(&cmd, i);
         if let Some(options) = cmd.tess.fill {
-            let status = ::std::panic::catch_unwind(|| {
-                match cmd.tess.tessellator {
-                    Tessellator::Default => {
-                        let result = FillTessellator::new().tessellate(
-                            &path,
-                            &options,
-                            &mut NoOutput::new(),
-                        );
-                        if !cmd.ignore_errors {
-                            result.unwrap();
-                        }
+            let status = ::std::panic::catch_unwind(|| match cmd.tess.tessellator {
+                Tessellator::Default => {
+                    let result =
+                        FillTessellator::new().tessellate(&path, &options, &mut NoOutput::new());
+                    if !cmd.ignore_errors {
+                        result.unwrap();
                     }
-                    Tessellator::Tess2 => {
-                        let result = tess2::FillTessellator::new().tessellate(
-                            &path,
-                            &options,
-                            &mut NoOutput::new(),
-                        );
-                        if !cmd.ignore_errors {
-                            result.unwrap();
-                        }
+                }
+                Tessellator::Tess2 => {
+                    let result = tess2::FillTessellator::new().tessellate(
+                        &path,
+                        &options,
+                        &mut NoOutput::new(),
+                    );
+                    if !cmd.ignore_errors {
+                        result.unwrap();
                     }
                 }
             });

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,15 +1,15 @@
 extern crate clap;
+extern crate itertools;
 extern crate lyon;
 extern crate rand;
-extern crate itertools;
 extern crate regex;
 
 mod commands;
 mod flatten;
 mod fuzzing;
+mod reduce;
 mod show;
 mod tessellate;
-mod reduce;
 
 use clap::*;
 use commands::*;
@@ -154,7 +154,7 @@ fn main() {
         )
         .subcommand(
             declare_tess_params(SubCommand::with_name("reduce"), true)
-                .about("Find a reduced testcase")
+                .about("Find a reduced testcase"),
         )
         .get_matches();
 
@@ -257,80 +257,95 @@ fn declare_tess_params<'a, 'b>(app: App<'a, 'b>, need_path: bool) -> App<'a, 'b>
     } else {
         app
     }
-    .arg(Arg::with_name("FILL")
-        .short("f")
-        .long("fill")
-        .help("Fills the path")
+    .arg(
+        Arg::with_name("FILL")
+            .short("f")
+            .long("fill")
+            .help("Fills the path"),
     )
-    .arg(Arg::with_name("STROKE")
-        .short("s")
-        .long("stroke")
-        .help("Strokes the path")
+    .arg(
+        Arg::with_name("STROKE")
+            .short("s")
+            .long("stroke")
+            .help("Strokes the path"),
     )
-    .arg(Arg::with_name("HATCH")
-        .long("hatch")
-        .help("Fill the path with a regular hatching pattern using the provided value as spacing")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("HATCH")
+            .long("hatch")
+            .help(
+                "Fill the path with a regular hatching pattern using the provided value as spacing",
+            )
+            .takes_value(true),
     )
-    .arg(Arg::with_name("DOT")
-        .long("dot")
-        .help("Fill the path with a regular dot pattern using the provided value as spacing")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("DOT")
+            .long("dot")
+            .help("Fill the path with a regular dot pattern using the provided value as spacing")
+            .takes_value(true),
     )
-    .arg(Arg::with_name("TOLERANCE")
-        .short("t")
-        .long("tolerance")
-        .help("Sets the tolerance threshold for flattening (0.5 by default)")
-        .value_name("TOLERANCE")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("TOLERANCE")
+            .short("t")
+            .long("tolerance")
+            .help("Sets the tolerance threshold for flattening (0.5 by default)")
+            .value_name("TOLERANCE")
+            .takes_value(true),
     )
-    .arg(Arg::with_name("LINE_WIDTH")
-        .short("w")
-        .long("line-width")
-        .help("The line width for strokes")
-        .value_name("LINE_WIDTH")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("LINE_WIDTH")
+            .short("w")
+            .long("line-width")
+            .help("The line width for strokes")
+            .value_name("LINE_WIDTH")
+            .takes_value(true),
     )
-    .arg(Arg::with_name("LINE_JOIN")
-        .long("line-join")
-        .help("The line-join type for strokes")
-        .value_name("LINE_JOIN")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("LINE_JOIN")
+            .long("line-join")
+            .help("The line-join type for strokes")
+            .value_name("LINE_JOIN")
+            .takes_value(true),
     )
-    .arg(Arg::with_name("LINE_CAP")
-        .long("line-cap")
-        .help("The line-cap type for strokes")
-        .value_name("LINE_CAP")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("LINE_CAP")
+            .long("line-cap")
+            .help("The line-cap type for strokes")
+            .value_name("LINE_CAP")
+            .takes_value(true),
     )
-    .arg(Arg::with_name("MITER_LIMIT")
-        .long("miter-limit")
-        .help("The miter limit for strokes")
-        .value_name("MITER_LIMIT")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("MITER_LIMIT")
+            .long("miter-limit")
+            .help("The miter limit for strokes")
+            .value_name("MITER_LIMIT")
+            .takes_value(true),
     )
-    .arg(Arg::with_name("FILL_RULE")
-        .long("fill-rule")
-        .help("Fill rule")
-        .value_name("FILL_RULE")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("FILL_RULE")
+            .long("fill-rule")
+            .help("Fill rule")
+            .value_name("FILL_RULE")
+            .takes_value(true),
     )
-    .arg(Arg::with_name("SWEEP_ORIENTATION")
-        .long("sweep-orientation")
-        .help("Traverse the geometry vertically or horizontally.")
-        .value_name("SWEEP_ORIENTATION")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("SWEEP_ORIENTATION")
+            .long("sweep-orientation")
+            .help("Traverse the geometry vertically or horizontally.")
+            .value_name("SWEEP_ORIENTATION")
+            .takes_value(true),
     )
-    .arg(Arg::with_name("TESSELLATOR")
-        .long("tessellator")
-        .help("Select the tessellator to use")
-        .value_name("TESSELLATOR")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("TESSELLATOR")
+            .long("tessellator")
+            .help("Select the tessellator to use")
+            .value_name("TESSELLATOR")
+            .takes_value(true),
     )
-    .arg(Arg::with_name("HATCHING_ANGLE")
-        .long("angle")
-        .help("Angle between the hatching and the x axis")
-        .takes_value(true)
+    .arg(
+        Arg::with_name("HATCHING_ANGLE")
+            .long("angle")
+            .help("Angle between the hatching and the x axis")
+            .takes_value(true),
     )
 }
 

--- a/cli/src/reduce.rs
+++ b/cli/src/reduce.rs
@@ -1,6 +1,6 @@
 use crate::commands::{TessellateCmd, Tessellator};
-use lyon::path::Path;
 use lyon::path::traits::*;
+use lyon::path::Path;
 use lyon::tessellation::geometry_builder::*;
 use lyon::tessellation::{FillTessellator, StrokeTessellator};
 
@@ -11,11 +11,9 @@ pub fn reduce_testcase(cmd: TessellateCmd) {
         let path = flattener.build();
 
         lyon::extra::debugging::find_reduced_test_case(path.as_slice(), &|path: Path| {
-            StrokeTessellator::new().tessellate_path(
-                &path,
-                &options,
-                &mut NoOutput::new(),
-            ).is_err()
+            StrokeTessellator::new()
+                .tessellate_path(&path, &options, &mut NoOutput::new())
+                .is_err()
         });
     }
 
@@ -35,11 +33,9 @@ pub fn reduce_testcase(cmd: TessellateCmd) {
         match cmd.tessellator {
             Tessellator::Default => {
                 lyon::extra::debugging::find_reduced_test_case(path.as_slice(), &|path: Path| {
-                    FillTessellator::new().tessellate_path(
-                        &path,
-                        &options,
-                        &mut NoOutput::new(),
-                    ).is_err()
+                    FillTessellator::new()
+                        .tessellate_path(&path, &options, &mut NoOutput::new())
+                        .is_err()
                 });
             }
             Tessellator::Tess2 => {

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -14,8 +14,8 @@ use lyon::algorithms::aabb::bounding_rect;
 use lyon::algorithms::hatching::*;
 use lyon::geom::LineSegment;
 use lyon::math::*;
-use lyon::path::Path;
 use lyon::path::builder::PathBuilder;
+use lyon::path::Path;
 use lyon::tess2;
 use lyon::tessellation;
 use lyon::tessellation::geometry_builder::*;
@@ -105,7 +105,6 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
     if let Some(options) = cmd.fill {
         match cmd.tessellator {
             Tessellator::Default => {
-
                 fill.tessellate(
                     &cmd.path,
                     &options,
@@ -126,24 +125,25 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
                 //}
             }
             Tessellator::Tess2 => {
-                tess2::FillTessellator::new().tessellate(
-                    cmd.path.iter(),
-                    &options,
-                    &mut tess2::geometry_builder::BuffersBuilder::new(
-                        &mut geometry,
-                        WithId(0),
-                    ),
-                ).unwrap();
+                tess2::FillTessellator::new()
+                    .tessellate(
+                        cmd.path.iter(),
+                        &options,
+                        &mut tess2::geometry_builder::BuffersBuilder::new(&mut geometry, WithId(0)),
+                    )
+                    .unwrap();
             }
         }
     }
 
     if let Some(options) = cmd.stroke {
-        stroke.tessellate(
-            cmd.path.iter(),
-            &options,
-            &mut BuffersBuilder::new(&mut geometry, WithId(1)),
-        ).unwrap();
+        stroke
+            .tessellate(
+                cmd.path.iter(),
+                &options,
+                &mut BuffersBuilder::new(&mut geometry, WithId(1)),
+            )
+            .unwrap();
     }
 
     if let Some(hatch) = cmd.hatch {
@@ -164,11 +164,13 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         );
         let hatched_path = path.build();
 
-        stroke.tessellate(
-            hatched_path.iter(),
-            &hatch.stroke,
-            &mut BuffersBuilder::new(&mut geometry, WithId(stroke_prim_id)),
-        ).unwrap();
+        stroke
+            .tessellate(
+                hatched_path.iter(),
+                &hatch.stroke,
+                &mut BuffersBuilder::new(&mut geometry, WithId(stroke_prim_id)),
+            )
+            .unwrap();
     }
 
     if let Some(dots) = cmd.dots {
@@ -187,11 +189,13 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         );
         let dotted_path = path.build();
 
-        stroke.tessellate(
-            dotted_path.iter(),
-            &dots.stroke,
-            &mut BuffersBuilder::new(&mut geometry, WithId(stroke_prim_id)),
-        ).unwrap();
+        stroke
+            .tessellate(
+                dotted_path.iter(),
+                &dots.stroke,
+                &mut BuffersBuilder::new(&mut geometry, WithId(stroke_prim_id)),
+            )
+            .unwrap();
     }
 
     let (bg_color, vignette_color) = match render_options.background {
@@ -211,8 +215,8 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
         &FillOptions::DEFAULT,
         &mut BuffersBuilder::new(&mut bg_geometry, BgVertexCtor),
-    ).unwrap();
-
+    )
+    .unwrap();
 
     let sample_count = match render_options.aa {
         AntiAliasing::Msaa(samples) => samples as u32,
@@ -683,17 +687,12 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
 
         frame_count += 1.0;
     });
-
 }
 
 fn build_wireframe_indices(indices: &[u32]) -> Vec<u32> {
     let mut set = std::collections::HashSet::new();
     let check = &mut |a: u32, b: u32| {
-        let (i1, i2) = if a < b {
-            (a, b)
-        } else {
-            (b, a)
-        };
+        let (i1, i2) = if a < b { (a, b) } else { (b, a) };
 
         set.insert((i1, i2))
     };

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -1,7 +1,7 @@
 use lyon::extra::rust_logo::build_logo_path;
 use lyon::math::*;
-use lyon::path::Path;
 use lyon::path::iterator::PathIterator;
+use lyon::path::Path;
 use lyon::tessellation;
 use lyon::tessellation::geometry_builder::*;
 use lyon::tessellation::{FillOptions, FillTessellator};
@@ -152,38 +152,45 @@ fn main() {
     builder.close();
     let arrow_path = builder.build();
 
-    fill_tess.tessellate_path(
-        &path,
-        &FillOptions::tolerance(tolerance).with_fill_rule(tessellation::FillRule::NonZero),
-        &mut BuffersBuilder::new(&mut geometry, WithId(fill_prim_id as i32)),
-    ).unwrap();
+    fill_tess
+        .tessellate_path(
+            &path,
+            &FillOptions::tolerance(tolerance).with_fill_rule(tessellation::FillRule::NonZero),
+            &mut BuffersBuilder::new(&mut geometry, WithId(fill_prim_id as i32)),
+        )
+        .unwrap();
 
     let fill_range = 0..(geometry.indices.len() as u32);
 
-    stroke_tess.tessellate_path(
-        &path,
-        &StrokeOptions::tolerance(tolerance),
-        &mut BuffersBuilder::new(&mut geometry, WithId(stroke_prim_id as i32)),
-    ).unwrap();
+    stroke_tess
+        .tessellate_path(
+            &path,
+            &StrokeOptions::tolerance(tolerance),
+            &mut BuffersBuilder::new(&mut geometry, WithId(stroke_prim_id as i32)),
+        )
+        .unwrap();
 
     let stroke_range = fill_range.end..(geometry.indices.len() as u32);
 
-    fill_tess.tessellate_path(
-        &arrow_path,
-        &FillOptions::tolerance(tolerance),
-        &mut BuffersBuilder::new(&mut geometry, WithId(arrows_prim_id as i32)),
-    ).unwrap();
-
+    fill_tess
+        .tessellate_path(
+            &arrow_path,
+            &FillOptions::tolerance(tolerance),
+            &mut BuffersBuilder::new(&mut geometry, WithId(arrows_prim_id as i32)),
+        )
+        .unwrap();
 
     let arrow_range = stroke_range.end..(geometry.indices.len() as u32);
 
     let mut bg_geometry: VertexBuffers<BgPoint, u16> = VertexBuffers::new();
 
-    fill_tess.tessellate_rectangle(
-        &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
-        &FillOptions::DEFAULT,
-        &mut BuffersBuilder::new(&mut bg_geometry, Custom),
-    ).unwrap();
+    fill_tess
+        .tessellate_rectangle(
+            &Rect::new(point(-1.0, -1.0), size(2.0, 2.0)),
+            &FillOptions::DEFAULT,
+            &mut BuffersBuilder::new(&mut bg_geometry, Custom),
+        )
+        .unwrap();
 
     let mut cpu_primitives = Vec::with_capacity(PRIM_BUFFER_LEN);
     for _ in 0..PRIM_BUFFER_LEN {
@@ -193,7 +200,7 @@ fn main() {
             width: 0.0,
             translate: [0.0, 0.0],
             angle: 0.0,
-            .. Primitive::DEFAULT
+            ..Primitive::DEFAULT
         });
     }
 
@@ -202,13 +209,13 @@ fn main() {
         color: [0.0, 0.0, 0.0, 1.0],
         z_index: num_instances as i32 + 2,
         width: 1.0,
-        .. Primitive::DEFAULT
+        ..Primitive::DEFAULT
     };
     // Main fill primitive
     cpu_primitives[fill_prim_id] = Primitive {
         color: [1.0, 1.0, 1.0, 1.0],
         z_index: num_instances as i32 + 1,
-        .. Primitive::DEFAULT
+        ..Primitive::DEFAULT
     };
     // Instance primitives
     for idx in (fill_prim_id + 1)..(fill_prim_id + num_instances as usize) {
@@ -570,7 +577,7 @@ fn main() {
                         angle: tangent.angle_from_x_axis().get(),
                         scale: 2.0,
                         z_index: arrows_prim_id as i32,
-                        .. Primitive::DEFAULT
+                        ..Primitive::DEFAULT
                     };
                     arrow_count += 1;
                     true

--- a/extra/src/triangle_rasterizer.rs
+++ b/extra/src/triangle_rasterizer.rs
@@ -2,9 +2,9 @@ use std::cmp::{max, min};
 use std::ops::Add;
 
 use euclid;
+use euclid::vec2;
 use image::MutableImageSlice;
 use math::*;
-use euclid::vec2;
 
 type IntVector = euclid::default::Vector2D<i32>;
 

--- a/geom/src/cubic_bezier.rs
+++ b/geom/src/cubic_bezier.rs
@@ -2,12 +2,12 @@ use crate::cubic_bezier_intersections::cubic_bezier_intersections_t;
 use crate::cubic_to_quadratic::*;
 pub use crate::flatten_cubic::Flattened;
 use crate::flatten_cubic::{find_cubic_bezier_inflection_points, flatten_cubic_bezier_with_t};
-use crate::{rect, Point, Rect, Vector};
 use crate::monotonic::Monotonic;
 use crate::scalar::Scalar;
 use crate::segment::{BoundingRect, Segment};
 use crate::traits::Transformation;
 use crate::utils::{cubic_polynomial_roots, min_max};
+use crate::{rect, Point, Rect, Vector};
 use crate::{Line, LineEquation, LineSegment, QuadraticBezierSegment};
 use arrayvec::ArrayVec;
 
@@ -420,11 +420,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
     }
 
     /// Iterates through the curve invoking a callback at each point.
-    pub fn for_each_flattened_with_t<F: FnMut(Point<S>, S)>(
-        &self,
-        tolerance: S,
-        callback: &mut F,
-    ) {
+    pub fn for_each_flattened_with_t<F: FnMut(Point<S>, S)>(&self, tolerance: S, callback: &mut F) {
         flatten_cubic_bezier_with_t(self, tolerance, callback);
     }
 

--- a/geom/src/cubic_bezier_intersections.rs
+++ b/geom/src/cubic_bezier_intersections.rs
@@ -1,3 +1,5 @@
+use crate::scalar::Scalar;
+use crate::CubicBezierSegment;
 ///! Computes intersection parameters for two cubic bézier curves using bézier clipping, also known
 ///! as fat line clipping.
 ///!
@@ -7,8 +9,6 @@
 ///! https://scholarsarchive.byu.edu/facpub/1/
 ///! for motivation and details of how the process works.
 use crate::{point, Point, Rect};
-use crate::scalar::Scalar;
-use crate::CubicBezierSegment;
 use arrayvec::ArrayVec;
 use std::ops::Range;
 
@@ -717,7 +717,8 @@ fn walk_convex_hull_edges_to_fat_line<S: Scalar>(
     for i in 0..hull_vertices.len() - 1 {
         let p = hull_vertices[i];
         let q = hull_vertices[i + 1];
-        if (vertices_are_for_top && q.y >= threshold) || (!vertices_are_for_top && q.y <= threshold) {
+        if (vertices_are_for_top && q.y >= threshold) || (!vertices_are_for_top && q.y <= threshold)
+        {
             return if q.y == threshold {
                 Some(q.x)
             } else {

--- a/geom/src/cubic_to_quadratic.rs
+++ b/geom/src/cubic_to_quadratic.rs
@@ -1,5 +1,5 @@
-use crate::point;
 use crate::monotonic::Monotonic;
+use crate::point;
 use crate::scalar::Scalar;
 use crate::{CubicBezierSegment, QuadraticBezierSegment};
 
@@ -28,8 +28,11 @@ where
 }
 
 /// Approximates a cubic bézier segment with a sequence of quadratic béziers.
-pub fn cubic_to_quadratics_with_t<S: Scalar, F>(curve: &CubicBezierSegment<S>, tolerance: S, cb: &mut F)
-where
+pub fn cubic_to_quadratics_with_t<S: Scalar, F>(
+    curve: &CubicBezierSegment<S>,
+    tolerance: S,
+    cb: &mut F,
+) where
     F: FnMut(&QuadraticBezierSegment<S>, std::ops::Range<S>),
 {
     debug_assert!(tolerance >= S::EPSILON);

--- a/geom/src/line.rs
+++ b/geom/src/line.rs
@@ -1,9 +1,9 @@
-use crate::{point, vector, Point, Rect, Size, Vector};
 use crate::monotonic::MonotonicSegment;
 use crate::scalar::Scalar;
 use crate::segment::{BoundingRect, Segment};
 use crate::traits::Transformation;
 use crate::utils::min_max;
+use crate::{point, vector, Point, Rect, Size, Vector};
 use std::mem::swap;
 
 use std::ops::Range;
@@ -202,7 +202,6 @@ impl<S: Scalar> LineSegment<S> {
     /// segment. To get the intersection point, sample one of the segments
     /// at the corresponding value.
     pub fn intersection_t(&self, other: &Self) -> Option<(S, S)> {
-
         if self.to == other.to
             || self.from == other.from
             || self.from == other.to

--- a/geom/src/monotonic.rs
+++ b/geom/src/monotonic.rs
@@ -1,7 +1,7 @@
-use crate::{Point, Rect, Vector};
 use crate::scalar::{NumCast, Scalar};
 use crate::segment::{BoundingRect, Segment};
 use crate::{CubicBezierSegment, QuadraticBezierSegment};
+use crate::{Point, Rect, Vector};
 use arrayvec::ArrayVec;
 use std::ops::Range;
 
@@ -399,7 +399,9 @@ where
     let mut result = ArrayVec::new();
     result.push((t1, t2));
 
-    if let Some(intersection) = first_monotonic_segment_intersecion(a, t1..a_t_range.end, b, t2..b_t_range.end, tolerance) {
+    if let Some(intersection) =
+        first_monotonic_segment_intersecion(a, t1..a_t_range.end, b, t2..b_t_range.end, tolerance)
+    {
         result.push(intersection);
     }
 

--- a/geom/src/quadratic_bezier.rs
+++ b/geom/src/quadratic_bezier.rs
@@ -1,8 +1,8 @@
-use crate::{rect, Point, Rect, Vector};
 use crate::monotonic::Monotonic;
 use crate::scalar::Scalar;
 use crate::segment::{BoundingRect, Segment};
 use crate::traits::Transformation;
+use crate::{rect, Point, Rect, Vector};
 use crate::{CubicBezierSegment, Line, LineEquation, LineSegment, Triangle};
 use arrayvec::ArrayVec;
 
@@ -29,9 +29,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
         let one_t = S::ONE - t;
         let one_t2 = one_t * one_t;
 
-        self.from * one_t2
-            + self.ctrl.to_vector() * S::TWO * one_t * t
-            + self.to.to_vector() * t2
+        self.from * one_t2 + self.ctrl.to_vector() * S::TWO * one_t * t + self.to.to_vector() * t2
     }
 
     /// Sample the x coordinate of the curve at t (expecting t between 0 and 1).
@@ -95,7 +93,11 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
             }
         }
 
-        if self.from.y > self.to.y { S::ZERO } else { S::ONE }
+        if self.from.y > self.to.y {
+            S::ZERO
+        } else {
+            S::ONE
+        }
     }
 
     /// Find the advancement of the y-least position in the curve.
@@ -109,7 +111,11 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
             }
         }
 
-        if self.from.y < self.to.y { S::ZERO } else { S::ONE }
+        if self.from.y < self.to.y {
+            S::ZERO
+        } else {
+            S::ONE
+        }
     }
 
     /// Return the y inflection point or None if this curve is y-monotonic.
@@ -137,7 +143,11 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
             }
         }
 
-        if self.from.x > self.to.x { S::ZERO } else { S::ONE }
+        if self.from.x > self.to.x {
+            S::ZERO
+        } else {
+            S::ONE
+        }
     }
 
     /// Find the advancement of the x-least position in the curve.
@@ -151,7 +161,11 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
             }
         }
 
-        if self.from.x < self.to.x { S::ZERO } else { S::ONE }
+        if self.from.x < self.to.x {
+            S::ZERO
+        } else {
+            S::ONE
+        }
     }
 
     /// Return the x inflection point or None if this curve is x-monotonic.
@@ -306,9 +320,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
     where
         F: FnMut(Point<S>),
     {
-        self.for_each_flattened_t(tolerance, &mut|t| {
-            callback(self.sample(t))
-        });
+        self.for_each_flattened_t(tolerance, &mut |t| callback(self.sample(t)));
     }
 
     /// Compute a flattened approximation of the curve, invoking a callback at
@@ -349,9 +361,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
     where
         F: FnMut(Point<S>, S),
     {
-        self.for_each_flattened_t(tolerance, &mut|t| {
-            callback(self.sample(t), t)
-        });
+        self.for_each_flattened_t(tolerance, &mut |t| callback(self.sample(t), t));
     }
 
     /// Returns the flattened representation of the curve as an iterator, starting *after* the
@@ -598,8 +608,10 @@ impl<S: Scalar> FlatteningParameters<S> {
         let ddx = S::TWO * curve.ctrl.x - curve.from.x - curve.to.x;
         let ddy = S::TWO * curve.ctrl.y - curve.from.y - curve.to.y;
         let cross = (curve.to.x - curve.from.x) * ddy - (curve.to.y - curve.from.y) * ddx;
-        let parabola_from = ((curve.ctrl.x - curve.from.x) * ddx + (curve.ctrl.y - curve.from.y) * ddy) / cross;
-        let parabola_to = ((curve.to.x - curve.ctrl.x) * ddx + (curve.to.y - curve.ctrl.y) * ddy) / cross;
+        let parabola_from =
+            ((curve.ctrl.x - curve.from.x) * ddx + (curve.ctrl.y - curve.from.y) * ddy) / cross;
+        let parabola_to =
+            ((curve.to.x - curve.ctrl.x) * ddx + (curve.to.y - curve.ctrl.y) * ddy) / cross;
         // Note, scale can be NaN, for example with straight lines. When it happens the NaN will
         // propagate to other parameters. We catch it all by setting the iteration count to zero
         // and leave the rest as garbage.
@@ -656,7 +668,6 @@ fn approx_parabola_inv_integral<S: Scalar>(x: S) -> S {
     let quarter = S::HALF * S::HALF;
     x * (S::ONE - b + (b * b + quarter * x * x).sqrt())
 }
-
 
 /// A flattening iterator for quadratic bézier segments.
 ///
@@ -1095,7 +1106,7 @@ fn test_flattening_empty_curve() {
     assert!(iter.next().is_none());
 
     let mut count: u32 = 0;
-    curve.for_each_flattened(0.1, &mut |_| { count += 1 });
+    curve.for_each_flattened(0.1, &mut |_| count += 1);
     assert_eq!(count, 0);
 }
 
@@ -1115,6 +1126,6 @@ fn test_flattening_straight_line() {
     assert!(iter.next().is_none());
 
     let mut count: u32 = 0;
-    curve.for_each_flattened(0.1, &mut |_| { count += 1 });
+    curve.for_each_flattened(0.1, &mut |_| count += 1);
     assert_eq!(count, 1);
 }

--- a/geom/src/segment.rs
+++ b/geom/src/segment.rs
@@ -1,6 +1,6 @@
-use crate::{Point, Rect, Vector};
 use crate::scalar::Scalar;
 use crate::{CubicBezierSegment, LineSegment, QuadraticBezierSegment};
+use crate::{Point, Rect, Vector};
 
 use std::ops::Range;
 
@@ -88,25 +88,51 @@ pub trait BoundingRect {
 }
 
 macro_rules! impl_segment {
-    ($S:ty) => (
+    ($S:ty) => {
         type Scalar = $S;
-        fn from(&self) -> Point<$S> { self.from() }
-        fn to(&self) -> Point<$S> { self.to() }
-        fn sample(&self, t: $S) -> Point<$S> { self.sample(t) }
-        fn x(&self, t: $S) -> $S { self.x(t) }
-        fn y(&self, t: $S) -> $S { self.y(t) }
-        fn derivative(&self, t: $S) -> Vector<$S> { self.derivative(t) }
-        fn dx(&self, t: $S) -> $S { self.dx(t) }
-        fn dy(&self, t: $S) -> $S { self.dy(t) }
-        fn split(&self, t: $S) -> (Self, Self) { self.split(t) }
-        fn before_split(&self, t: $S) -> Self { self.before_split(t) }
-        fn after_split(&self, t: $S) -> Self { self.after_split(t) }
-        fn split_range(&self, t_range: Range<$S>) -> Self { self.split_range(t_range) }
-        fn flip(&self) -> Self { self.flip() }
+        fn from(&self) -> Point<$S> {
+            self.from()
+        }
+        fn to(&self) -> Point<$S> {
+            self.to()
+        }
+        fn sample(&self, t: $S) -> Point<$S> {
+            self.sample(t)
+        }
+        fn x(&self, t: $S) -> $S {
+            self.x(t)
+        }
+        fn y(&self, t: $S) -> $S {
+            self.y(t)
+        }
+        fn derivative(&self, t: $S) -> Vector<$S> {
+            self.derivative(t)
+        }
+        fn dx(&self, t: $S) -> $S {
+            self.dx(t)
+        }
+        fn dy(&self, t: $S) -> $S {
+            self.dy(t)
+        }
+        fn split(&self, t: $S) -> (Self, Self) {
+            self.split(t)
+        }
+        fn before_split(&self, t: $S) -> Self {
+            self.before_split(t)
+        }
+        fn after_split(&self, t: $S) -> Self {
+            self.after_split(t)
+        }
+        fn split_range(&self, t_range: Range<$S>) -> Self {
+            self.split_range(t_range)
+        }
+        fn flip(&self) -> Self {
+            self.flip()
+        }
         fn approximate_length(&self, tolerance: $S) -> $S {
             self.approximate_length(tolerance)
         }
-    )
+    };
 }
 
 /// Either a cubic, quadratic or linear bézier segment.

--- a/geom/src/triangle.rs
+++ b/geom/src/triangle.rs
@@ -1,7 +1,7 @@
-use crate::{Point, Rect, Size};
 use crate::scalar::Scalar;
 use crate::traits::Transformation;
 use crate::LineSegment;
+use crate::{Point, Rect, Size};
 
 /// A 2D triangle defined by three points `a`, `b` and `c`.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/geom/src/utils.rs
+++ b/geom/src/utils.rs
@@ -1,5 +1,5 @@
-use crate::{vector, Point, Vector};
 use crate::scalar::{Float, Scalar};
+use crate::{vector, Point, Vector};
 use arrayvec::ArrayVec;
 
 #[inline]

--- a/path/src/commands.rs
+++ b/path/src/commands.rs
@@ -459,17 +459,12 @@ impl PathCommandsBuilder {
         self.in_subpath = false;
 
         let id = EventId(self.cmds.len() as u32);
-        let cmd = if close {
-            verb::CLOSE
-        } else {
-            verb::END
-        };
+        let cmd = if close { verb::CLOSE } else { verb::END };
         self.cmds.push(cmd);
         self.cmds.push(self.first_event_index);
 
         Some(id)
     }
-
 
     pub fn line_to(&mut self, to: EndpointId) -> EventId {
         debug_assert!(self.in_subpath);
@@ -665,11 +660,7 @@ impl<'l> Iterator for Iter<'l> {
                 let from = self.prev_endpoint;
                 self.prev_endpoint = to;
                 self.idx += 3;
-                Some(IdEvent::Quadratic {
-                    from,
-                    ctrl,
-                    to,
-                })
+                Some(IdEvent::Quadratic { from, ctrl, to })
             }
             Some(verb::CUBIC) => {
                 let ctrl1 = ControlPointId(self.cmds.next().unwrap());

--- a/path/src/lib.rs
+++ b/path/src/lib.rs
@@ -47,15 +47,17 @@ pub extern crate serde;
 
 pub mod builder;
 pub mod commands;
-pub mod iterator;
-pub mod polygon;
-pub mod path_buffer;
-pub mod path;
 mod events;
+pub mod iterator;
+pub mod path;
+pub mod path_buffer;
+pub mod polygon;
 
 #[doc(hidden)]
 pub mod private;
 
+#[doc(inline)]
+pub use crate::commands::{PathCommands, PathCommandsSlice};
 pub use crate::events::*;
 pub use crate::geom::ArcFlags;
 #[doc(inline)]
@@ -63,9 +65,7 @@ pub use crate::path::{Path, PathSlice};
 #[doc(inline)]
 pub use crate::path_buffer::{PathBuffer, PathBufferSlice};
 #[doc(inline)]
-pub use crate::polygon::{Polygon, IdPolygon};
-#[doc(inline)]
-pub use crate::commands::{PathCommands, PathCommandsSlice};
+pub use crate::polygon::{IdPolygon, Polygon};
 
 use math::Point;
 use std::fmt;
@@ -74,9 +74,9 @@ use std::u32;
 pub mod traits {
     //! `lyon_path` traits reexported here for convenience.
 
+    pub use crate::builder::Build;
     pub use crate::builder::PathBuilder;
     pub use crate::builder::SvgPathBuilder;
-    pub use crate::builder::Build;
     pub use crate::iterator::PathIterator;
 }
 
@@ -116,7 +116,10 @@ pub mod math {
     /// Shorthand for `Rect::new(Point::new(x, y), Size::new(w, h))`.
     #[inline]
     pub fn rect(x: f32, y: f32, w: f32, h: f32) -> Rect {
-        Rect { origin: point(x, y), size: size(w, h) }
+        Rect {
+            origin: point(x, y),
+            size: size(w, h),
+        }
     }
 
     /// Shorthand for `Vector::new(x, y)`.
@@ -137,7 +140,6 @@ pub mod math {
         Size::new(w, h)
     }
 }
-
 
 /// The fill rule defines how to determine what is inside and what is outside of the shape.
 ///

--- a/path/src/path.rs
+++ b/path/src/path.rs
@@ -4,12 +4,12 @@
 use crate::builder::*;
 use crate::geom::traits::Transformation;
 use crate::math::*;
-use crate::{AttributeStore, ControlPointId, EndpointId, Event, IdEvent, PathEvent, PositionStore};
 use crate::private::DebugValidator;
+use crate::{AttributeStore, ControlPointId, EndpointId, Event, IdEvent, PathEvent, PositionStore};
 
+use std::fmt;
 use std::iter::IntoIterator;
 use std::u32;
-use std::fmt;
 
 /// Enumeration corresponding to the [Event](https://docs.rs/lyon_core/*/lyon_core/events/enum.Event.html) enum
 /// without the parameters.
@@ -293,7 +293,9 @@ impl<'l> fmt::Debug for PathSlice<'l> {
                     write_point(formatter, ctrl)?;
                     write_point(formatter, to)?;
                 }
-                PathEvent::Cubic { ctrl1, ctrl2, to, .. } => {
+                PathEvent::Cubic {
+                    ctrl1, ctrl2, to, ..
+                } => {
                     write!(formatter, " C")?;
                     write_point(formatter, ctrl1)?;
                     write_point(formatter, ctrl2)?;
@@ -474,7 +476,9 @@ impl Builder {
             PathEvent::Quadratic { ctrl, to, .. } => {
                 self.quadratic_bezier_to(ctrl, to);
             }
-            PathEvent::Cubic { ctrl1, ctrl2, to, .. } => {
+            PathEvent::Cubic {
+                ctrl1, ctrl2, to, ..
+            } => {
                 self.cubic_bezier_to(ctrl1, ctrl2, to);
             }
             PathEvent::End { close: true, .. } => {
@@ -541,7 +545,6 @@ pub struct BuilderWithAttributes {
 }
 
 impl BuilderWithAttributes {
-
     pub fn new(num_attributes: usize) -> Self {
         BuilderWithAttributes {
             builder: Builder::new(),
@@ -583,7 +586,12 @@ impl BuilderWithAttributes {
     }
 
     #[inline]
-    pub fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, attributes: &[f32]) -> EndpointId {
+    pub fn quadratic_bezier_to(
+        &mut self,
+        ctrl: Point,
+        to: Point,
+        attributes: &[f32],
+    ) -> EndpointId {
         let id = self.builder.quadratic_bezier_to(ctrl, to);
         self.push_attributes(attributes);
 
@@ -591,7 +599,13 @@ impl BuilderWithAttributes {
     }
 
     #[inline]
-    pub fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, attributes: &[f32]) -> EndpointId {
+    pub fn cubic_bezier_to(
+        &mut self,
+        ctrl1: Point,
+        ctrl2: Point,
+        to: Point,
+        attributes: &[f32],
+    ) -> EndpointId {
         let id = self.builder.cubic_bezier_to(ctrl1, ctrl2, to);
         self.push_attributes(attributes);
 
@@ -827,7 +841,7 @@ impl<'l> IterWithAttributes<'l> {
     fn pop_endpoint(&mut self) -> (Point, &'l [f32]) {
         let position = self.points.next();
         let attributes_ptr = self.points.ptr as *const f32;
-        self.points.advance_n(self.attrib_stride);        
+        self.points.advance_n(self.attrib_stride);
         let attributes = unsafe {
             // SAFETY: advance_n would have panicked if the slice is out of bounds
             std::slice::from_raw_parts(attributes_ptr, self.num_attributes)
@@ -1640,7 +1654,6 @@ fn test_path_builder_empty_begin() {
     assert_eq!(it.next(), None);
 }
 
-
 #[test]
 fn test_concatenate() {
     let mut builder = Path::builder();
@@ -1660,10 +1673,7 @@ fn test_concatenate() {
     let path2 = builder.build();
 
     let mut builder = Path::builder();
-    builder.concatenate(&[
-        path1.as_slice(),
-        path2.as_slice(),
-    ]);
+    builder.concatenate(&[path1.as_slice(), path2.as_slice()]);
     let path = builder.build();
 
     let mut it = path.iter();

--- a/path/src/path_buffer.rs
+++ b/path/src/path_buffer.rs
@@ -1,7 +1,7 @@
 //! A container to store multiple paths contiguously.
 
-use crate::math::*;
 use crate::builder::*;
+use crate::math::*;
 use crate::path;
 use crate::{EndpointId, PathSlice};
 
@@ -128,7 +128,9 @@ impl<'l> PathBufferSlice<'l> {
 
 impl<'l> fmt::Debug for PathBufferSlice<'l> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "PathBuffer {{ paths: {:?}, points: {:?}, verbs: {:?}, ",
+        write!(
+            formatter,
+            "PathBuffer {{ paths: {:?}, points: {:?}, verbs: {:?}, ",
             self.paths.len(),
             self.points.len(),
             self.verbs.len(),
@@ -281,7 +283,6 @@ impl<'l> Build for Builder<'l> {
     }
 }
 
-
 /// A Builder that appends a path to an existing PathBuffer, with custom attributes.
 pub struct BuilderWithAttributes<'l> {
     buffer: &'l mut PathBuffer,
@@ -351,13 +352,24 @@ impl<'l> BuilderWithAttributes<'l> {
     }
 
     #[inline]
-    pub fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, attributes: &[f32]) -> EndpointId {
+    pub fn quadratic_bezier_to(
+        &mut self,
+        ctrl: Point,
+        to: Point,
+        attributes: &[f32],
+    ) -> EndpointId {
         let id = self.builder.quadratic_bezier_to(ctrl, to, attributes);
         self.adjust_id(id)
     }
 
     #[inline]
-    pub fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, attributes: &[f32]) -> EndpointId {
+    pub fn cubic_bezier_to(
+        &mut self,
+        ctrl1: Point,
+        ctrl2: Point,
+        to: Point,
+        attributes: &[f32],
+    ) -> EndpointId {
         let id = self.builder.cubic_bezier_to(ctrl1, ctrl2, to, attributes);
         self.adjust_id(id)
     }
@@ -370,44 +382,104 @@ impl<'l> BuilderWithAttributes<'l> {
 
 #[test]
 fn simple() {
-  use crate::PathEvent;
+    use crate::PathEvent;
 
-  let mut buffer = PathBuffer::new();
+    let mut buffer = PathBuffer::new();
 
-  let mut builder = buffer.builder();
-  builder.begin(point(0.0, 0.0));
-  builder.line_to(point(10.0, 0.0));
-  builder.line_to(point(10.0, 10.0));
-  let a = builder.line_to(point(0.0, 10.0));
-  builder.end(true);
+    let mut builder = buffer.builder();
+    builder.begin(point(0.0, 0.0));
+    builder.line_to(point(10.0, 0.0));
+    builder.line_to(point(10.0, 10.0));
+    let a = builder.line_to(point(0.0, 10.0));
+    builder.end(true);
 
-  let p1 = builder.build();
+    let p1 = builder.build();
 
-  let mut builder = buffer.builder();
-  builder.begin(point(0.0, 0.0));
-  builder.line_to(point(20.0, 0.0));
-  builder.line_to(point(20.0, 20.0));
-  let b = builder.line_to(point(0.0, 20.0));
-  builder.end(false);
+    let mut builder = buffer.builder();
+    builder.begin(point(0.0, 0.0));
+    builder.line_to(point(20.0, 0.0));
+    builder.line_to(point(20.0, 20.0));
+    let b = builder.line_to(point(0.0, 20.0));
+    builder.end(false);
 
-  let p2 = builder.build();
+    let p2 = builder.build();
 
-  let mut iter = buffer.get(p1).iter();
-  assert_eq!(iter.next(), Some(PathEvent::Begin { at: point(0.0, 0.0) }));
-  assert_eq!(iter.next(), Some(PathEvent::Line { from: point(0.0, 0.0), to: point(10.0, 0.0) }));
-  assert_eq!(iter.next(), Some(PathEvent::Line { from: point(10.0, 0.0), to: point(10.0, 10.0) }));
-  assert_eq!(iter.next(), Some(PathEvent::Line { from: point(10.0, 10.0), to: point(0.0, 10.0) }));
-  assert_eq!(iter.next(), Some(PathEvent::End { last: point(0.0, 10.0), first: point(0.0, 0.0), close: true }));
-  assert_eq!(iter.next(), None);
+    let mut iter = buffer.get(p1).iter();
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::Begin {
+            at: point(0.0, 0.0)
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::Line {
+            from: point(0.0, 0.0),
+            to: point(10.0, 0.0)
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::Line {
+            from: point(10.0, 0.0),
+            to: point(10.0, 10.0)
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::Line {
+            from: point(10.0, 10.0),
+            to: point(0.0, 10.0)
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::End {
+            last: point(0.0, 10.0),
+            first: point(0.0, 0.0),
+            close: true
+        })
+    );
+    assert_eq!(iter.next(), None);
 
-  let mut iter = buffer.get(p2).iter();
-  assert_eq!(iter.next(), Some(PathEvent::Begin { at: point(0.0, 0.0) }));
-  assert_eq!(iter.next(), Some(PathEvent::Line { from: point(0.0, 0.0), to: point(20.0, 0.0) }));
-  assert_eq!(iter.next(), Some(PathEvent::Line { from: point(20.0, 0.0), to: point(20.0, 20.0) }));
-  assert_eq!(iter.next(), Some(PathEvent::Line { from: point(20.0, 20.0), to: point(0.0, 20.0) }));
-  assert_eq!(iter.next(), Some(PathEvent::End { last: point(0.0, 20.0), first: point(0.0, 0.0), close: false }));
-  assert_eq!(iter.next(), None);
+    let mut iter = buffer.get(p2).iter();
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::Begin {
+            at: point(0.0, 0.0)
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::Line {
+            from: point(0.0, 0.0),
+            to: point(20.0, 0.0)
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::Line {
+            from: point(20.0, 0.0),
+            to: point(20.0, 20.0)
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::Line {
+            from: point(20.0, 20.0),
+            to: point(0.0, 20.0)
+        })
+    );
+    assert_eq!(
+        iter.next(),
+        Some(PathEvent::End {
+            last: point(0.0, 20.0),
+            first: point(0.0, 0.0),
+            close: false
+        })
+    );
+    assert_eq!(iter.next(), None);
 
-  assert_eq!(buffer.get(p1)[a], point(0.0, 10.0));
-  assert_eq!(buffer.get(p2)[b], point(0.0, 20.0));
+    assert_eq!(buffer.get(p1)[a], point(0.0, 10.0));
+    assert_eq!(buffer.get(p2)[b], point(0.0, 20.0));
 }

--- a/path/src/polygon.rs
+++ b/path/src/polygon.rs
@@ -1,8 +1,9 @@
 //! Specific path types for polygons.
 
 use crate::math::Point;
-use crate::{ControlPointId, EndpointId, Event, EventId, IdEvent, PathEvent, Position, PositionStore};
-
+use crate::{
+    ControlPointId, EndpointId, Event, EventId, IdEvent, PathEvent, Position, PositionStore,
+};
 
 /// A view over a sequence of endpoints forming a polygon.
 ///
@@ -87,7 +88,6 @@ impl<'l, T> std::ops::Index<EndpointId> for Polygon<'l, T> {
         &self.points[id.to_usize()]
     }
 }
-
 
 /// A view over a sequence of endpoint IDs forming a polygon.
 pub struct IdPolygon<'l> {

--- a/path/src/private.rs
+++ b/path/src/private.rs
@@ -2,8 +2,8 @@
 // but are exposed for use by other lyon crates.
 // Changing them doesn't necessarily imply semver breaking bumps.
 
-pub use crate::math::Point;
 pub use crate::geom::{CubicBezierSegment, QuadraticBezierSegment};
+pub use crate::math::Point;
 pub use crate::traits::PathBuilder;
 pub use crate::EndpointId;
 
@@ -24,7 +24,8 @@ impl DebugValidator {
 
     #[inline(always)]
     pub fn begin(&mut self) {
-        #[cfg(debug_assertions)] {
+        #[cfg(debug_assertions)]
+        {
             assert!(!self.in_subpath);
             self.in_subpath = true;
         }
@@ -32,7 +33,8 @@ impl DebugValidator {
 
     #[inline(always)]
     pub fn end(&mut self) {
-        #[cfg(debug_assertions)] {
+        #[cfg(debug_assertions)]
+        {
             assert!(self.in_subpath);
             self.in_subpath = false;
         }
@@ -40,19 +42,20 @@ impl DebugValidator {
 
     #[inline(always)]
     pub fn edge(&self) {
-        #[cfg(debug_assertions)] {
+        #[cfg(debug_assertions)]
+        {
             assert!(self.in_subpath);
         }
     }
 
     #[inline(always)]
     pub fn build(&self) {
-        #[cfg(debug_assertions)] {
+        #[cfg(debug_assertions)]
+        {
             assert!(!self.in_subpath);
         }
     }
 }
-
 
 pub fn flatten_quadratic_bezier(
     tolerance: f32,
@@ -61,7 +64,7 @@ pub fn flatten_quadratic_bezier(
     to: Point,
     builder: &mut impl PathBuilder,
 ) -> EndpointId {
-    let curve = QuadraticBezierSegment { from, ctrl, to, };
+    let curve = QuadraticBezierSegment { from, ctrl, to };
     let mut id = EndpointId::INVALID;
     curve.for_each_flattened(tolerance, &mut |point| {
         id = builder.line_to(point);
@@ -78,7 +81,12 @@ pub fn flatten_cubic_bezier(
     to: Point,
     builder: &mut impl PathBuilder,
 ) -> EndpointId {
-    let curve = CubicBezierSegment { from, ctrl1, ctrl2, to };
+    let curve = CubicBezierSegment {
+        from,
+        ctrl1,
+        ctrl2,
+        to,
+    };
     let mut id = EndpointId::INVALID;
     curve.for_each_flattened(tolerance, &mut |point| {
         id = builder.line_to(point);
@@ -86,4 +94,3 @@ pub fn flatten_cubic_bezier(
 
     id
 }
-

--- a/svg/src/path_utils.rs
+++ b/svg/src/path_utils.rs
@@ -1,4 +1,4 @@
-use crate::parser::{PathSegment, PathParser};
+use crate::parser::{PathParser, PathSegment};
 
 use crate::path::builder::*;
 use crate::path::geom::Arc;
@@ -214,7 +214,8 @@ impl PathSerializer {
             start_angle,
             sweep_angle,
             x_rotation,
-        }.to_svg_arc();
+        }
+        .to_svg_arc();
 
         self.path += &format!(
             "A {} {} {} {} {} {} {}",

--- a/tess2/src/flattened_path.rs
+++ b/tess2/src/flattened_path.rs
@@ -1,7 +1,7 @@
 use crate::math::*;
 use crate::path::builder::*;
+use crate::path::private::{flatten_cubic_bezier, flatten_quadratic_bezier};
 use crate::path::EndpointId;
-use crate::path::private::{flatten_quadratic_bezier, flatten_cubic_bezier};
 
 use std::ops::Range;
 
@@ -210,7 +210,14 @@ impl PathBuilder for Builder {
     }
 
     fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point) -> EndpointId {
-        flatten_cubic_bezier(self.tolerance, self.current_position(), ctrl1, ctrl2, to, self)
+        flatten_cubic_bezier(
+            self.tolerance,
+            self.current_position(),
+            ctrl1,
+            ctrl2,
+            to,
+            self,
+        )
     }
 }
 

--- a/tess2/src/lib.rs
+++ b/tess2/src/lib.rs
@@ -93,9 +93,9 @@ pub use crate::tessellation::FillOptions;
 pub use crate::tessellator::FillTessellator;
 
 pub mod geometry_builder {
-    pub use crate::tessellation::geometry_builder::{Positions, NoOutput, VertexBuffers};
-    pub use crate::tessellation::VertexId;
     use crate::math::Point;
+    pub use crate::tessellation::geometry_builder::{NoOutput, Positions, VertexBuffers};
+    pub use crate::tessellation::VertexId;
 
     /// An interface with similar goals to `GeometryBuilder` for algorithms that pre-build
     /// the vertex and index buffers.

--- a/tess2/src/tessellator.rs
+++ b/tess2/src/tessellator.rs
@@ -1,10 +1,10 @@
 use crate::flattened_path::FlattenedPath;
+use crate::geometry_builder::GeometryReceiver;
 use crate::math::*;
 use crate::path::builder::*;
 use crate::path::PathEvent;
 use crate::path::PathSlice;
 use crate::tessellation::{Count, FillOptions, FillRule};
-use crate::geometry_builder::GeometryReceiver;
 
 use std::os::raw::c_void;
 use std::ptr;

--- a/tessellation/src/event_queue.rs
+++ b/tessellation/src/event_queue.rs
@@ -1,8 +1,8 @@
 use crate::fill::{compare_positions, is_after};
 use crate::geom::{CubicBezierSegment, QuadraticBezierSegment};
 use crate::math::{point, Point};
-use crate::path::{EndpointId, IdEvent, PathEvent, PositionStore};
 use crate::path::private::DebugValidator;
+use crate::path::{EndpointId, IdEvent, PathEvent, PositionStore};
 use crate::Orientation;
 
 use std::cmp::Ordering;
@@ -185,7 +185,12 @@ impl EventQueue {
         after: TessEventId,
     ) -> TessEventId {
         debug_assert!(self.sorted);
-        debug_assert!(is_after(data.to, position), "{:?} should be after {:?}", data.to, position);
+        debug_assert!(
+            is_after(data.to, position),
+            "{:?} should be after {:?}",
+            data.to,
+            position
+        );
 
         let idx = self.events.len() as TessEventId;
         self.events.push(Event {
@@ -816,7 +821,13 @@ impl EventQueueBuilder {
         }
     }
 
-    pub fn cubic_bezier_segment(&mut self, ctrl1: Point, ctrl2: Point, to: Point, to_id: EndpointId) {
+    pub fn cubic_bezier_segment(
+        &mut self,
+        ctrl1: Point,
+        ctrl2: Point,
+        to: Point,
+        to_id: EndpointId,
+    ) {
         self.validator.edge();
         // Swap the curve so that it always goes downwards. This way if two
         // paths share the same edge with different windings, the flattening will

--- a/tessellation/src/fill_tests.rs
+++ b/tessellation/src/fill_tests.rs
@@ -1,17 +1,16 @@
 use crate::extra::rust_logo::build_logo_path;
-use crate::math::*;
 use crate::geometry_builder::*;
+use crate::math::*;
 use crate::path::builder::PathBuilder;
 use crate::path::{Path, PathSlice};
-use crate::{FillVertex, FillOptions, FillRule, FillTessellator, TessellationError, VertexId};
+use crate::{FillOptions, FillRule, FillTessellator, FillVertex, TessellationError, VertexId};
 
 use std::env;
 
 fn tessellate(path: PathSlice, fill_rule: FillRule, log: bool) -> Result<usize, TessellationError> {
     let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
     {
-        let options = FillOptions::tolerance(0.05)
-            .with_fill_rule(fill_rule);
+        let options = FillOptions::tolerance(0.05).with_fill_rule(fill_rule);
 
         use crate::path::iterator::*;
 
@@ -49,10 +48,7 @@ fn test_too_many_vertices() {
     }
 
     impl FillGeometryBuilder for Builder {
-        fn add_fill_vertex(
-            &mut self,
-            _: FillVertex,
-        ) -> Result<VertexId, GeometryBuilderError> {
+        fn add_fill_vertex(&mut self, _: FillVertex) -> Result<VertexId, GeometryBuilderError> {
             if self.max_vertices == 0 {
                 return Err(GeometryBuilderError::TooManyVertices);
             }
@@ -93,7 +89,11 @@ fn test_path_and_count_triangles(path: PathSlice, expected_triangle_count: usize
     test_path_internal(path, FillRule::NonZero, None);
 }
 
-fn test_path_internal(path: PathSlice, fill_rule: FillRule, expected_triangle_count: Option<usize>) {
+fn test_path_internal(
+    path: PathSlice,
+    fill_rule: FillRule,
+    expected_triangle_count: Option<usize>,
+) {
     let add_logging = env::var("LYON_ENABLE_LOGGING").is_ok();
     let find_test_case = env::var("LYON_REDUCED_TESTCASE").is_ok();
 
@@ -138,7 +138,11 @@ fn test_path_with_rotations(path: Path, step: f32, expected_triangle_count: Opti
 
         let tranformed_path = path.clone().transformed(&Rotation::new(angle));
 
-        test_path_internal(tranformed_path.as_slice(), FillRule::EvenOdd, expected_triangle_count);
+        test_path_internal(
+            tranformed_path.as_slice(),
+            FillRule::EvenOdd,
+            expected_triangle_count,
+        );
         test_path_internal(tranformed_path.as_slice(), FillRule::NonZero, None);
 
         angle.radians += step;
@@ -2402,5 +2406,6 @@ fn low_tolerance_01() {
         &path,
         &FillOptions::tolerance(0.00001),
         &mut simple_builder(&mut buffers),
-    ).unwrap();
+    )
+    .unwrap();
 }

--- a/tessellation/src/fuzz_tests.rs
+++ b/tessellation/src/fuzz_tests.rs
@@ -1,5 +1,5 @@
-use crate::math::*;
 use crate::geometry_builder::{simple_builder, VertexBuffers};
+use crate::math::*;
 use crate::path::iterator::*;
 use crate::path::{Path, PathSlice};
 use crate::{FillOptions, FillRule, FillTessellator, TessellationError};
@@ -7,8 +7,7 @@ use crate::{FillOptions, FillRule, FillTessellator, TessellationError};
 fn tessellate(path: PathSlice, fill_rule: FillRule, log: bool) -> Result<usize, TessellationError> {
     let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
     {
-        let options = FillOptions::tolerance(0.05)
-            .with_fill_rule(fill_rule);
+        let options = FillOptions::tolerance(0.05).with_fill_rule(fill_rule);
 
         let mut builder = Path::builder();
         for e in path.iter().flattened(0.05) {

--- a/tessellation/src/geometry_builder.rs
+++ b/tessellation/src/geometry_builder.rs
@@ -264,7 +264,8 @@ pub trait StrokeGeometryBuilder: GeometryBuilder {
     /// Returns a vertex id that is only valid between begin_geometry and end_geometry.
     ///
     /// This method can only be called between begin_geometry and end_geometry.
-    fn add_stroke_vertex(&mut self, vertex: StrokeVertex) -> Result<VertexId, GeometryBuilderError>;
+    fn add_stroke_vertex(&mut self, vertex: StrokeVertex)
+        -> Result<VertexId, GeometryBuilderError>;
 }
 
 /// Structure that holds the vertex and index data.
@@ -453,9 +454,9 @@ where
     Ctor: FillVertexConstructor<OutputVertex>,
 {
     fn add_fill_vertex(&mut self, vertex: FillVertex) -> Result<VertexId, GeometryBuilderError> {
-        self.buffers.vertices.push(
-            self.vertex_constructor.new_vertex(vertex)
-        );
+        self.buffers
+            .vertices
+            .push(self.vertex_constructor.new_vertex(vertex));
         let len = self.buffers.vertices.len();
         if len > OutputIndex::MAX {
             return Err(GeometryBuilderError::TooManyVertices);
@@ -471,10 +472,7 @@ where
     OutputIndex: Add + From<VertexId> + MaxIndex,
     Ctor: StrokeVertexConstructor<OutputVertex>,
 {
-    fn add_stroke_vertex(
-        &mut self,
-        v: StrokeVertex,
-    ) -> Result<VertexId, GeometryBuilderError> {
+    fn add_stroke_vertex(&mut self, v: StrokeVertex) -> Result<VertexId, GeometryBuilderError> {
         self.buffers
             .vertices
             .push(self.vertex_constructor.new_vertex(v));
@@ -525,10 +523,7 @@ impl GeometryBuilder for NoOutput {
 }
 
 impl FillGeometryBuilder for NoOutput {
-    fn add_fill_vertex(
-        &mut self,
-        _vertex: FillVertex,
-    ) -> Result<VertexId, GeometryBuilderError> {
+    fn add_fill_vertex(&mut self, _vertex: FillVertex) -> Result<VertexId, GeometryBuilderError> {
         if self.count.vertices >= std::u32::MAX {
             return Err(GeometryBuilderError::TooManyVertices);
         }
@@ -538,10 +533,7 @@ impl FillGeometryBuilder for NoOutput {
 }
 
 impl StrokeGeometryBuilder for NoOutput {
-    fn add_stroke_vertex(
-        &mut self,
-        _: StrokeVertex,
-    ) -> Result<VertexId, GeometryBuilderError> {
+    fn add_stroke_vertex(&mut self, _: StrokeVertex) -> Result<VertexId, GeometryBuilderError> {
         if self.count.vertices >= std::u32::MAX {
             return Err(GeometryBuilderError::TooManyVertices);
         }

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -218,9 +218,8 @@ pub use crate::stroke::*;
 
 #[doc(inline)]
 pub use crate::geometry_builder::{
-    BuffersBuilder, Count, FillGeometryBuilder,
-    FillVertexConstructor, GeometryBuilder, GeometryBuilderError,
-    StrokeGeometryBuilder, StrokeVertexConstructor, VertexBuffers,
+    BuffersBuilder, Count, FillGeometryBuilder, FillVertexConstructor, GeometryBuilder,
+    GeometryBuilderError, StrokeGeometryBuilder, StrokeVertexConstructor, VertexBuffers,
 };
 
 pub use crate::path::FillRule;
@@ -738,7 +737,7 @@ fn test_with_invalid_miter_limit() {
 
 #[test]
 fn test_line_width() {
-    use crate::math::{Point, point};
+    use crate::math::{point, Point};
     let mut builder = crate::path::Path::builder();
     builder.begin(point(0.0, 1.0));
     builder.line_to(point(2.0, 1.0));
@@ -747,20 +746,20 @@ fn test_line_width() {
 
     let options = StrokeOptions::DEFAULT.with_line_width(2.0);
     let mut geometry: VertexBuffers<Point, u16> = VertexBuffers::new();
-    StrokeTessellator::new().tessellate(
-        path.iter(),
-        &options,
-        &mut crate::geometry_builder::simple_builder(&mut geometry),
-    ).unwrap();
-
+    StrokeTessellator::new()
+        .tessellate(
+            path.iter(),
+            &options,
+            &mut crate::geometry_builder::simple_builder(&mut geometry),
+        )
+        .unwrap();
 
     for p in &geometry.vertices {
         assert!(
             *p == point(0.0, 0.0)
-            || *p == point(0.0, 2.0)
-            || *p == point(2.0, 0.0)
-            || *p == point(2.0, 2.0)
+                || *p == point(0.0, 2.0)
+                || *p == point(2.0, 0.0)
+                || *p == point(2.0, 2.0)
         );
     }
 }
-

--- a/tessellation/src/lib.rs
+++ b/tessellation/src/lib.rs
@@ -196,6 +196,7 @@ mod monotone;
 mod stroke;
 
 #[cfg(test)]
+#[rustfmt::skip]
 mod earcut_tests;
 #[cfg(test)]
 mod fill_tests;


### PR DESCRIPTION
This PR introduces the offical rust formatter `rustfmt` to lyon.

## Changes
In the first commit, the `rustfmt.toml` configuration file is added.
The style defined here is very open for discussion.
I just copied the configuration I use in my projects, so just tell me what you desire.

The second commit, formats the whole codebase.

The third commit adds a github action to check if the codebase was formatted correctly prior to commiting.

## Purpose

Having a formatter is very valuable, since it creates consistency all over the codebase and the style is the same for every contributor.
I think it also lowers the bar for contribution, because a familiar code formatting makes the code base more approchable.

I would also consider this to be part of the 1.0 milestone effort, since it is related to rust standard practices.
