### PR TITLE
Separate lyon's Cargo.toml from the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,39 +1,6 @@
-[package]
-name = "lyon"
-version = "0.17.5"
-description = "2D Graphics rendering on the GPU using tessellation."
-authors = [ "Nicolas Silva <nical@fastmail.com>" ]
-repository = "https://github.com/nical/lyon"
-documentation = "https://docs.rs/lyon/"
-keywords = ["2d", "graphics", "tessellation", "svg"]
-license = "MIT/Apache-2.0"
-
-[lib]
-name = "lyon"
-path = "crates/lyon/src/lib.rs"
-
-# Uncomment this when profiling.
-#[profile.release]
-#debug = true
-
-[features]
-serialization = ["lyon_tessellation/serialization"]
-debugger = ["lyon_tessellation/debugger"]
-experimental = ["lyon_tessellation/experimental"]
-svg = ["lyon_svg"]
-extra = ["lyon_extra"]
-libtess2 = ["lyon_tess2"]
-profiling = ["lyon_tessellation/profiling"]
-
-[dependencies]
-lyon_tessellation = { version = "0.17.5", path = "crates/tessellation/" }
-lyon_algorithms = { version = "0.17.1", path = "crates/algorithms/" }
-lyon_extra = { version = "0.17.1", optional = true, path = "crates/extra/" }
-lyon_svg = { version = "0.17.1", optional = true, path = "crates/svg/" }
-lyon_tess2 = { version = "0.17.1", optional = true, path = "crates/tess2/" }
-
 [workspace]
 members = [
+    "crates/lyon",
     "crates/path",
     "crates/tessellation",
     "crates/algorithms",
@@ -59,3 +26,6 @@ exclude = [
     "cli/*",
 ]
 
+# Uncomment this when profiling.
+#[profile.release]
+#debug = true

--- a/bench/geom/Cargo.toml
+++ b/bench/geom/Cargo.toml
@@ -8,5 +8,5 @@ workspace = "../.."
 name = "geom_bench"
 
 [dependencies]
-lyon = { path = "../../" }
+lyon = { path = "../../crates/lyon" }
 bencher = "0.1.1"

--- a/bench/path/Cargo.toml
+++ b/bench/path/Cargo.toml
@@ -8,5 +8,5 @@ workspace = "../.."
 name = "path_bench"
 
 [dependencies]
-lyon = { path = "../../", features = ["extra"] }
+lyon = { path = "../../crates/lyon", features = ["extra"] }
 bencher = "0.1.1"

--- a/bench/tess/Cargo.toml
+++ b/bench/tess/Cargo.toml
@@ -13,6 +13,6 @@ experimental = ["lyon/experimental"]
 profiling = ["lyon/profiling"]
 
 [dependencies]
-lyon = { path = "../../", features = ["extra"] }
+lyon = { path = "../../crates/lyon", features = ["extra"] }
 bencher = "0.1.1"
 tess2-sys = { version = "0.0.1", optional = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,7 @@ name = "lyon"
 path = "src/main.rs"
 
 [dependencies]
-lyon = { path = "../", features = ["svg", "extra", "libtess2", "debugger", "experimental"]}
+lyon = { path = "../crates/lyon", features = ["svg", "extra", "libtess2", "debugger", "experimental"]}
 clap = "2.32.0"
 rand = "0.6"
 env_logger = "0.7"

--- a/crates/lyon/Cargo.toml
+++ b/crates/lyon/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "lyon"
+version = "0.17.5"
+description = "2D Graphics rendering on the GPU using tessellation."
+authors = [ "Nicolas Silva <nical@fastmail.com>" ]
+repository = "https://github.com/nical/lyon"
+documentation = "https://docs.rs/lyon/"
+keywords = ["2d", "graphics", "tessellation", "svg"]
+license = "MIT/Apache-2.0"
+workspace = "../.."
+edition = "2018"
+
+[lib]
+name = "lyon"
+path = "src/lib.rs"
+
+[features]
+serialization = ["lyon_tessellation/serialization"]
+debugger = ["lyon_tessellation/debugger"]
+experimental = ["lyon_tessellation/experimental"]
+svg = ["lyon_svg"]
+extra = ["lyon_extra"]
+libtess2 = ["lyon_tess2"]
+profiling = ["lyon_tessellation/profiling"]
+
+[dependencies]
+lyon_tessellation = { version = "0.17.5", path = "../tessellation/" }
+lyon_algorithms = { version = "0.17.1", path = "../algorithms/" }
+lyon_extra = { version = "0.17.1", optional = true, path = "../extra/" }
+lyon_svg = { version = "0.17.1", optional = true, path = "../svg/" }
+lyon_tess2 = { version = "0.17.1", optional = true, path = "../tess2/" }

--- a/examples/wgpu/Cargo.toml
+++ b/examples/wgpu/Cargo.toml
@@ -10,7 +10,7 @@ name = "wgpu"
 path = "src/main.rs"
 
 [dependencies]
-lyon = { path = "../../", features = ["extra"] }
+lyon = { path = "../../crates/lyon", features = ["extra"] }
 env_logger = "0.7"
 log = "0.4"
 

--- a/examples/wgpu_svg/Cargo.toml
+++ b/examples/wgpu_svg/Cargo.toml
@@ -11,7 +11,7 @@ name = "wgpu_svg"
 path = "src/main.rs"
 
 [dependencies]
-lyon = { path = "../../", features = ["extra"] }
+lyon = { path = "../../crates/lyon", features = ["extra"] }
 
 clap = "2.32.0"
 wgpu = "0.6.0"

--- a/wasm_test/Cargo.toml
+++ b/wasm_test/Cargo.toml
@@ -12,4 +12,4 @@ name = "wasm_test"
 crate-type = ["cdylib"]
 
 [dependencies]
-lyon = { path = "../", features = ["extra"] }
+lyon = { path = "../crates/lyon", features = ["extra"] }


### PR DESCRIPTION
Now that the lyon crate isn't at the root of the repository it makes more sense to move its Cargo.toml to the crate directory and keep a separate Cargo.toml for the workspace at the root.