### PR TITLE
Fix example msaa argument

### DIFF
--- a/examples/wgpu_svg/src/main.rs
+++ b/examples/wgpu_svg/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
 
     let msaa_samples = if let Some(msaa) = app.value_of("MSAA") {
         match msaa.parse::<u32>() {
-            Ok(n) => n.min(1),
+            Ok(n) => n.max(1),
             Err(_) => {
                 println!("ERROR: `{}` is not a number", msaa);
                 std::process::exit(1);


### PR DESCRIPTION
The msaa argument was effectively ignored, because of a mixup of min and max to add a lower bound of 1.