### PR TITLE
Fix a path parsing bug in the wgpu_svg example

### DIFF
--- a/examples/wgpu_svg/src/main.rs
+++ b/examples/wgpu_svg/src/main.rs
@@ -679,6 +679,7 @@ impl<'l> Iterator for PathConvIter<'l> {
                     })
                 } else {
                     self.first = point(x, y);
+                    self.needs_end = true;
                     Some(PathEvent::Begin { at: self.first })
                 }
             }


### PR DESCRIPTION
Fortunately the bug is only in the example's code and doesn't affect the crates.

Fixes #657.