### PR TITLE
Fill tessellation fix for issue 599

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "arrayvec 0.5.2",
  "lyon_extra",

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_tessellation"
-version = "0.17.6"
+version = "0.17.7"
 description = "A low level path tessellation library."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"

--- a/crates/tessellation/src/event_queue.rs
+++ b/crates/tessellation/src/event_queue.rs
@@ -252,16 +252,18 @@ impl EventQueue {
                 debug_assert!(prev != current);
                 self.events[idx as usize].next_sibling = self.events[current as usize].next_sibling;
                 self.events[current as usize].next_sibling = idx;
-                break;
+                return;
             } else if is_after(pos, position) {
                 self.events[prev as usize].next_event = idx;
                 self.events[idx as usize].next_event = current;
-                break;
+                return;
             }
 
             prev = current;
             current = self.next_id(current);
         }
+
+        self.events[prev as usize].next_event = idx;
     }
 
     pub(crate) fn clear(&mut self) {

--- a/crates/tessellation/src/fill_tests.rs
+++ b/crates/tessellation/src/fill_tests.rs
@@ -2409,3 +2409,19 @@ fn low_tolerance_01() {
     )
     .unwrap();
 }
+
+#[test]
+fn issue_599() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(-0.044577092, 0.69268686));
+    builder.line_to(point(0.04457296, 0.69263));
+    builder.line_to(point(0.044570256, 0.69263405));
+    builder.line_to(point(-0.043470938, 0.6761849));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+
+    // SVG path syntax:
+    // "M -0.044577092 0.69268686 L 0.04457296 0.69263 L 0.044570256 0.69263405 L -0.043470938 0.6761849 Z"
+}


### PR DESCRIPTION
The bug was caused by the event queue not properly inserting intersection events if the intersection is lower than the rest of the geometry. In theory it should never happen since the intersection should be between two existing vertices. In practice the limited precision of float math when computing intersections can cause some geometry-bending configurations which either lead to this problem directly or can force the tessellator to nudge the intersection point down to untangle other invalid configurations. Either way, making sure that the event queue can insert new events at the very end of the queue fixes the issue.