### PR TITLE
Fix lyon_svg::path_utils::build_path not returning Err on invalid com…

### DIFF
--- a/crates/svg/src/path_utils.rs
+++ b/crates/svg/src/path_utils.rs
@@ -35,8 +35,9 @@ where
     Builder: SvgPathBuilder + Build,
 {
     for item in PathParser::from(src) {
-        if let Ok(segment) = item {
-            svg_event(&segment, &mut builder)
+        match item {
+            Ok(segment) => svg_event(&segment, &mut builder),
+            Err(_) => return Err(ParseError),
         }
     }
 
@@ -340,4 +341,11 @@ impl SvgPathBuilder for PathSerializer {
             to.y
         );
     }
+}
+
+#[test]
+fn test_parse_error() {
+    let invalid_commands = &"This is certainly not an SVG command string";
+    let svg_builder = lyon_path::Path::builder().with_svg();
+    assert!(build_path(svg_builder, invalid_commands).is_err());
 }


### PR DESCRIPTION
…mands

It's good behavior to let the caller know that the path building failed.

This helps with sixtyfpsui/sixtyfps#262