### PR TITLE
`&Vec<Vec<Polygons>>` → `&[Vec<Point>]`

### DIFF
--- a/crates/extra/src/debugging.rs
+++ b/crates/extra/src/debugging.rs
@@ -5,6 +5,7 @@ use path::{Path, PathSlice};
 use svg;
 
 pub type Polygons = Vec<Vec<Point>>;
+pub type PolygonsRef<'a> = &'a [Vec<Point>];
 
 pub fn path_to_polygons(path: PathSlice) -> Polygons {
     let mut polygons = Vec::new();
@@ -37,7 +38,7 @@ pub fn path_to_polygons(path: PathSlice) -> Polygons {
     return polygons;
 }
 
-pub fn polygons_to_path(polygons: &Polygons) -> Path {
+pub fn polygons_to_path(polygons: PolygonsRef) -> Path {
     let mut builder = Path::builder().flattened(0.05);
     for poly in polygons.iter() {
         builder.begin(poly[0]);

--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -1065,4 +1065,3 @@ fn negative_flattening_step() {
 
     assert!(flattened.len() > 1);
 }
-


### PR DESCRIPTION
This changes the argument in the `polygons_to_path` method to be a slice of vectors, instead of a reference to a vector of vectors. This makes the API silghtly more general at no cost whatsoever. This would be a breaking change, though in practice there should rarely be any noticeable difference.