### PR TITLE
`&self` to `self` in methods of the form `to_X` in `Copy` structs

### DIFF
--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -136,7 +136,7 @@ impl<S: Scalar> Arc<S> {
     }
 
     /// Convert to the SVG arc notation.
-    pub fn to_svg_arc(&self) -> SvgArc<S> {
+    pub fn to_svg_arc(self) -> SvgArc<S> {
         let from = self.sample(S::ZERO);
         let to = self.sample(S::ONE);
         let flags = ArcFlags {
@@ -487,8 +487,8 @@ impl<S: Scalar> Into<Arc<S>> for SvgArc<S> {
 
 impl<S: Scalar> SvgArc<S> {
     /// Converts this arc from endpoints to center notation.
-    pub fn to_arc(&self) -> Arc<S> {
-        Arc::from_svg_arc(self)
+    pub fn to_arc(self) -> Arc<S> {
+        Arc::from_svg_arc(&self)
     }
 
     /// Per SVG spec, this arc should be rendered as a line_to segment.
@@ -1065,4 +1065,3 @@ fn negative_flattening_step() {
 
     assert!(flattened.len() > 1);
 }
-

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -153,13 +153,13 @@ impl<S: Scalar> LineSegment<S> {
 
     /// Returns the vector between this segment's `from` and `to` points.
     #[inline]
-    pub fn to_vector(&self) -> Vector<S> {
+    pub fn to_vector(self) -> Vector<S> {
         self.to - self.from
     }
 
     /// Returns the line containing this segment.
     #[inline]
-    pub fn to_line(&self) -> Line<S> {
+    pub fn to_line(self) -> Line<S> {
         Line {
             point: self.from,
             vector: self.to - self.from,

--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -233,7 +233,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
     }
 
     /// Elevate this curve to a third order bézier.
-    pub fn to_cubic(&self) -> CubicBezierSegment<S> {
+    pub fn to_cubic(self) -> CubicBezierSegment<S> {
         CubicBezierSegment {
             from: self.from,
             ctrl1: (self.from + self.ctrl.to_vector() * S::TWO) / S::THREE,

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -230,7 +230,7 @@ pub struct EventId(#[doc(hidden)] pub u32);
 
 impl EventId {
     pub const INVALID: Self = EventId(std::u32::MAX);
-    pub fn to_usize(&self) -> usize {
+    pub fn to_usize(self) -> usize {
         self.0 as usize
     }
 }

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -653,7 +653,7 @@ impl VertexId {
         self.0
     }
 
-    pub fn to_usize(&self) -> usize {
+    pub fn to_usize(self) -> usize {
         self.0 as usize
     }
 


### PR DESCRIPTION
This is related to issue #85. This would be a breaking change, though in practice there would rarely be any noticeable difference.

The `to_arc` method in `SvgArc` is notable, since that one then goes on to call `from_svg_arc`, which also takes a reference. Perhaps we may want to make the latter take the value itself as well?