### PR TITLE
Adjust the behavior of intersections at endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_geom"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "arrayvec 0.5.2",
  "euclid 0.22.6",
@@ -1032,7 +1032,7 @@ dependencies = [
 name = "lyon_path"
 version = "0.17.4"
 dependencies = [
- "lyon_geom 0.17.2",
+ "lyon_geom 0.17.3",
  "serde",
 ]
 

--- a/crates/geom/Cargo.toml
+++ b/crates/geom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_geom"
-version = "0.17.2"
+version = "0.17.3"
 description = "2D quadratic and cubic bézier arcs and line segment math on top of euclid."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -959,3 +959,27 @@ fn horizontal_line_intersection() {
     assert_eq!(segment.horizontal_line_intersection_t(1.5), None);
     assert_eq!(segment.horizontal_line_intersection_t(3.5), None);
 }
+
+#[test]
+fn intersection_on_endpoint() {
+    let l1 = LineSegment {
+        from: point(0.0, 0.0),
+        to: point(0.0, 10.0),
+    };
+
+    let l2 = LineSegment {
+        from: point(0.0, 5.0),
+        to: point(10.0, 5.0),
+    };
+
+    assert_eq!(l1.intersection_t(&l2), Some((0.5, 0.0)));
+    assert_eq!(l2.intersection_t(&l1), Some((0.0, 0.5)));
+
+    let l3 = LineSegment {
+        from: point(10.0, 5.0),
+        to: point(0.0, 5.0),
+    };
+
+    assert_eq!(l1.intersection_t(&l3), Some((0.5, 1.0)));
+    assert_eq!(l3.intersection_t(&l1), Some((1.0, 0.5)));
+}


### PR DESCRIPTION
An intersection should be returned when it is exactly on the endpoint of one of the two segments, but not when it is exactly on endpoints of both segments. In other words we want to consider endpoints when looking for intersections, without causing two consecutive edges of a path to report intersections at their connecting endpoint.