### PR TITLE
Fix tessellation issue related to float precision.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75224bec9bfe1a65e2d34132933f2de7fe79900c96a0174307554244ece8150e"
 
 [[package]]
+name = "float_next_after"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1058,7 @@ name = "lyon_tessellation"
 version = "0.17.7"
 dependencies = [
  "arrayvec 0.5.2",
+ "float_next_after",
  "lyon_extra",
  "lyon_path",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "arrayvec 0.5.2",
  "float_next_after",

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_tessellation"
-version = "0.17.7"
+version = "0.17.8"
 description = "A low level path tessellation library."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -23,6 +23,7 @@ profiling = []
 [dependencies]
 lyon_path = { version = "0.17.1", path = "../path" }
 sid = "0.6"
+float_next_after = "0.1.5"
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 arrayvec = "0.5"
 

--- a/crates/tessellation/src/fill_tests.rs
+++ b/crates/tessellation/src/fill_tests.rs
@@ -2425,3 +2425,33 @@ fn issue_599() {
     // SVG path syntax:
     // "M -0.044577092 0.69268686 L 0.04457296 0.69263 L 0.044570256 0.69263405 L -0.043470938 0.6761849 Z"
 }
+
+#[test]
+fn issue_674() {
+    let mut builder = Path::builder();
+
+    builder.begin(point(-87887.734375, 73202.125));
+    builder.line_to(point(-79942.6640625, 73202.125));
+    builder.line_to(point(-79942.671875, 90023.078125));
+    builder.line_to(point(-79942.6640625, 86661.3046875));
+    builder.line_to(point(-87887.734375, 87599.5546875));
+    builder.line_to(point(-90541.25, 83022.0625));
+    builder.close();
+
+    let path = builder.build();
+
+    let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
+    let mut tess = FillTessellator::new();
+    tess.tessellate(
+        &path,
+        &FillOptions::tolerance(0.01),
+        &mut simple_builder(&mut buffers),
+    ).unwrap();
+
+    // The issue was happening with tolerance 0.01 and not with 0.05 used in test_path
+    // but run it anyway for good measure.
+    test_path(path.as_slice());
+
+    // SVG path syntax:
+    // "M -87887.734375 73202.125 L -79942.6640625 73202.125 L -79942.671875 90023.078125 L -79942.6640625 86661.3046875 L -87887.734375 87599.5546875 L -90541.25 83022.0625"
+}


### PR DESCRIPTION
The code that handles intersections has to move intersections point down when float precision cause it to be above the sweep line. Moving it down simply by adding a small increment can fail also due to float precision (86661.304687500 + 0.0001 == 86661.304687500). This commit moves the point down by incrementing the y value in a more principled way.

Fixes #674 