### PR TITLE
Fix imprecise quadratic/line intersection with large f32 values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_geom"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "arrayvec 0.5.2",
  "euclid 0.22.6",
@@ -1032,7 +1032,7 @@ dependencies = [
 name = "lyon_path"
 version = "0.17.4"
 dependencies = [
- "lyon_geom 0.17.3",
+ "lyon_geom 0.17.4",
  "serde",
 ]
 

--- a/crates/geom/Cargo.toml
+++ b/crates/geom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_geom"
-version = "0.17.3"
+version = "0.17.4"
 description = "2D quadratic and cubic bézier arcs and line segment math on top of euclid."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"

--- a/crates/geom/src/cubic_bezier_intersections.rs
+++ b/crates/geom/src/cubic_bezier_intersections.rs
@@ -529,6 +529,7 @@ fn add_point_curve_intersection<S: Scalar>(
     }
 }
 
+// TODO: replace with Scalar::epsilon_for?
 // If we're comparing distances between samples of curves, our epsilon should depend on how big the
 // points we're comparing are. This function returns an epsilon appropriate for the size of pt.
 fn epsilon_for_point<S: Scalar>(pt: &Point<S>) -> S {

--- a/crates/geom/src/flatten_cubic.rs
+++ b/crates/geom/src/flatten_cubic.rs
@@ -31,7 +31,7 @@ pub fn flatten_cubic_bezier_with_t<S: Scalar, F>(
 ) where
     F: FnMut(Point<S>, S),
 {
-    debug_assert!(tolerance >= S::EPSILON);
+    debug_assert!(tolerance >= S::EPSILON * S::EPSILON);
     let quadratics_tolerance = tolerance * S::value(0.2);
     let flattening_tolerance = tolerance * S::value(0.8);
 
@@ -70,7 +70,7 @@ pub struct Flattened<S: Scalar> {
 
 impl<S: Scalar> Flattened<S> {
     pub(crate) fn new(curve: &CubicBezierSegment<S>, tolerance: S) -> Self {
-        debug_assert!(tolerance >= S::EPSILON);
+        debug_assert!(tolerance >= S::EPSILON * S::EPSILON);
 
         let quadratics_tolerance = tolerance * S::value(0.2);
         let flattening_tolerance = tolerance * S::value(0.8);

--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -1129,3 +1129,29 @@ fn test_flattening_straight_line() {
     curve.for_each_flattened(0.1, &mut |_| count += 1);
     assert_eq!(count, 1);
 }
+
+#[test]
+fn issue_678() {
+    let points = [
+        [-7768.80859375f32, -35563.80859375],
+        [-38463.125, -10941.41796875],
+        [-21846.12890625, -13518.1953125],
+        [-11727.439453125, -22080.33203125],
+    ];
+
+    let quadratic = QuadraticBezierSegment {
+        from: Point::new(points[0][0], points[0][1]),
+        ctrl: Point::new(points[1][0], points[1][1]),
+        to: Point::new(points[2][0], points[2][1]),
+    };
+
+    let line = Line {
+        point: Point::new(points[3][0], points[3][1]),
+        vector: Vector::new(-0.5, -0.5).normalize(),
+    };
+
+    let intersections = quadratic.line_intersections(&line);
+    println!("{:?}", intersections);
+
+    assert_eq!(intersections.len(), 1);
+}

--- a/crates/geom/src/utils.rs
+++ b/crates/geom/src/utils.rs
@@ -62,9 +62,12 @@ pub fn directed_angle2<S: Scalar>(center: Point<S>, a: Point<S>, b: Point<S>) ->
 pub fn cubic_polynomial_roots<S: Scalar>(a: S, b: S, c: S, d: S) -> ArrayVec<[S; 3]> {
     let mut result = ArrayVec::new();
 
-    if S::abs(a) < S::EPSILON {
-        if S::abs(b) < S::EPSILON {
-            if S::abs(c) < S::EPSILON {
+    let m = a.abs().max(b.abs()).max(c.abs()).max(d.abs());
+    let epsilon = S::epsilon_for(m);
+
+    if S::abs(a) < epsilon {
+        if S::abs(b) < epsilon {
+            if S::abs(c) < epsilon {
                 return result;
             }
             // linear equation
@@ -77,7 +80,7 @@ pub fn cubic_polynomial_roots<S: Scalar>(a: S, b: S, c: S, d: S) -> ArrayVec<[S;
             let sqrt_delta = S::sqrt(delta);
             result.push((-c - sqrt_delta) / (S::TWO * b));
             result.push((-c + sqrt_delta) / (S::TWO * b));
-        } else if S::abs(delta) < S::EPSILON {
+        } else if S::abs(delta) < epsilon {
             result.push(-c / (S::TWO * b));
         }
         return result;
@@ -103,7 +106,7 @@ pub fn cubic_polynomial_roots<S: Scalar>(a: S, b: S, c: S, d: S) -> ArrayVec<[S;
         result.push(-bn * frac_1_3 + (s + t));
 
         // Don't add the repeated root when s + t == 0.
-        if S::abs(s - t) < S::EPSILON && S::abs(s + t) >= S::EPSILON {
+        if S::abs(s - t) < epsilon && S::abs(s + t) >= epsilon {
             result.push(-bn * frac_1_3 - (s + t) / S::TWO);
         }
     } else {


### PR DESCRIPTION
The problem was caused by catastrophic f32 precision when dividing large floats by small-ish ones (larger than the epsilon constant). The epsilon constant for floats was generally too small but to address this properly in a way that doesn't break small curves we need epsilons that depend on the magnitude of the coordinates.

This commit introduces Scalar::epsilon_for which takes the magnitude of a reference value into account to determine a sensible epsilon value. 

Fixes #678.