### PR TITLE
Add a few methods in lyon_geom

### DIFF
--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -8,7 +8,7 @@ use crate::segment::{BoundingRect, Segment};
 use crate::CubicBezierSegment;
 use crate::Line;
 use crate::QuadraticBezierSegment;
-use crate::{point, vector, Angle, Point, Rect, Rotation, Transform, Vector};
+use crate::{point, vector, Angle, Point, Rect, Rotation, Transform, Vector, Box2D};
 
 /// An elliptic arc curve segment.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -352,15 +352,20 @@ impl<S: Scalar> Arc<S> {
     }
 
     /// Returns a conservative rectangle that contains the curve.
-    pub fn fast_bounding_rect(&self) -> Rect<S> {
-        Transform::rotation(self.x_rotation).outer_transformed_rect(&Rect::new(
-            self.center - self.radii,
-            self.radii.to_size() * S::TWO,
-        ))
+    pub fn fast_bounding_box(&self) -> Box2D<S> {
+        Transform::rotation(self.x_rotation).outer_transformed_box(&Box2D {
+            min: self.center - self.radii,
+            max: self.center + self.radii,
+        })
     }
 
     /// Returns a conservative rectangle that contains the curve.
-    pub fn bounding_rect(&self) -> Rect<S> {
+    pub fn fast_bounding_rect(&self) -> Rect<S> {
+        self.fast_bounding_box().to_rect()
+    }
+
+    /// Returns a conservative rectangle that contains the curve.
+    pub fn bounding_box(&self) -> Box2D<S> {
         let from = self.from();
         let to = self.to();
         let mut min = Point::min(from, to);
@@ -376,10 +381,13 @@ impl<S: Scalar> Arc<S> {
             max.y = S::max(max.y, p.y);
         });
 
-        Rect {
-            origin: min,
-            size: (max - min).to_size(),
-        }
+        Box2D { min, max }
+    }
+
+    /// Returns a conservative rectangle that contains the curve.
+    #[inline]
+    pub fn bounding_rect(&self) -> Rect<S> {
+        self.bounding_box().to_rect()
     }
 
     pub fn for_each_local_x_extremum_t<F>(&self, cb: &mut F)

--- a/crates/geom/src/cubic_bezier.rs
+++ b/crates/geom/src/cubic_bezier.rs
@@ -7,7 +7,7 @@ use crate::scalar::Scalar;
 use crate::segment::{BoundingRect, Segment};
 use crate::traits::Transformation;
 use crate::utils::{cubic_polynomial_roots, min_max};
-use crate::{rect, Point, Rect, Vector};
+use crate::{Point, Rect, Vector, Box2D, point};
 use crate::{Line, LineEquation, LineSegment, QuadraticBezierSegment};
 use arrayvec::ArrayVec;
 
@@ -606,14 +606,19 @@ impl<S: Scalar> CubicBezierSegment<S> {
     /// Returns a conservative rectangle the curve is contained in.
     ///
     /// This method is faster than `bounding_rect` but more conservative.
-    pub fn fast_bounding_rect(&self) -> Rect<S> {
+    pub fn fast_bounding_box(&self) -> Box2D<S> {
         let (min_x, max_x) = self.fast_bounding_range_x();
         let (min_y, max_y) = self.fast_bounding_range_y();
 
-        rect(min_x, min_y, max_x - min_x, max_y - min_y)
+        Box2D { min: point(min_x, min_y), max: point(max_x, max_y) }
     }
 
-    /// Returns a conservative range of x this curve is contained in.
+    /// Returns a conservative rectangle that contains the curve.
+    pub fn fast_bounding_rect(&self) -> Rect<S> {
+        self.fast_bounding_box().to_rect()
+    }
+
+    /// Returns a conservative range of x that contains this curve.
     #[inline]
     pub fn fast_bounding_range_x(&self) -> (S, S) {
         let min_x = self
@@ -632,7 +637,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         (min_x, max_x)
     }
 
-    /// Returns a conservative range of y this curve is contained in.
+    /// Returns a conservative range of y that contains this curve.
     #[inline]
     pub fn fast_bounding_range_y(&self) -> (S, S) {
         let min_y = self
@@ -651,15 +656,22 @@ impl<S: Scalar> CubicBezierSegment<S> {
         (min_y, max_y)
     }
 
-    /// Returns the smallest rectangle the curve is contained in
-    pub fn bounding_rect(&self) -> Rect<S> {
+    /// Returns a conservative rectangle that contains the curve.
+    #[inline]
+    pub fn bounding_box(&self) -> Box2D<S> {
         let (min_x, max_x) = self.bounding_range_x();
         let (min_y, max_y) = self.bounding_range_y();
 
-        rect(min_x, min_y, max_x - min_x, max_y - min_y)
+        Box2D { min: point(min_x, min_y), max: point(max_x, max_y) }
     }
 
-    /// Returns the smallest range of x this curve is contained in.
+    /// Returns a conservative rectangle that contains the curve.
+    #[inline]
+    pub fn bounding_rect(&self) -> Rect<S> {
+        self.bounding_box().to_rect()
+    }
+
+    /// Returns the smallest range of x that contains this curve.
     #[inline]
     pub fn bounding_range_x(&self) -> (S, S) {
         let min_x = self.x(self.x_minimum_t());
@@ -668,7 +680,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         (min_x, max_x)
     }
 
-    /// Returns the smallest range of y this curve is contained in.
+    /// Returns the smallest range of y that contains this curve.
     #[inline]
     pub fn bounding_range_y(&self) -> (S, S) {
         let min_y = self.y(self.y_minimum_t());
@@ -944,6 +956,9 @@ impl<S: Scalar> BoundingRect for CubicBezierSegment<S> {
 
 /// A monotonically increasing in x and y quadratic bézier curve segment
 pub type MonotonicCubicBezierSegment<S> = Monotonic<CubicBezierSegment<S>>;
+
+#[cfg(test)]
+use crate::rect;
 
 #[test]
 fn fast_bounding_rect_for_cubic_bezier_segment() {

--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -246,6 +246,9 @@ pub use euclid::default::Size2D as Size;
 /// Alias for `euclid::default::Rect`
 pub use euclid::default::Rect;
 
+/// Alias for `euclid::default::Box2D`
+pub use euclid::default::Box2D;
+
 /// Alias for `euclid::default::Transform2D`
 pub type Transform<S> = euclid::default::Transform2D<S>;
 

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -3,7 +3,7 @@ use crate::scalar::Scalar;
 use crate::segment::{BoundingRect, Segment};
 use crate::traits::Transformation;
 use crate::utils::min_max;
-use crate::{point, vector, Point, Rect, Size, Vector};
+use crate::{point, vector, Point, Rect, Vector, Box2D};
 use std::mem::swap;
 
 use std::ops::Range;
@@ -130,15 +130,21 @@ impl<S: Scalar> LineSegment<S> {
         self.split(self.solve_t_for_x(x))
     }
 
-    /// Return the minimum bounding rectangle
+    /// Return the smallest rectangle containing this segment.
     #[inline]
-    pub fn bounding_rect(&self) -> Rect<S> {
+    pub fn bounding_box(&self) -> Box2D<S> {
         let (min_x, max_x) = self.bounding_range_x();
         let (min_y, max_y) = self.bounding_range_y();
 
-        let width = max_x - min_x;
-        let height = max_y - min_y;
-        Rect::new(Point::new(min_x, min_y), Size::new(width, height))
+        Box2D {
+            min: point(min_x, min_y),
+            max: point(max_x, max_y),
+        }
+    }
+
+    /// Return the smallest rectangle containing this segment.
+    pub fn bounding_rect(&self) -> Rect<S> {
+        self.bounding_box().to_rect()
     }
 
     #[inline]

--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -2,7 +2,7 @@ use crate::monotonic::Monotonic;
 use crate::scalar::Scalar;
 use crate::segment::{BoundingRect, Segment};
 use crate::traits::Transformation;
-use crate::{rect, Point, Rect, Vector};
+use crate::{Point, Rect, Vector, Box2D, point};
 use crate::{CubicBezierSegment, Line, LineEquation, LineSegment, Triangle};
 use arrayvec::ArrayVec;
 
@@ -448,14 +448,19 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
     }
 
     /// Returns a conservative rectangle that contains the curve.
-    pub fn fast_bounding_rect(&self) -> Rect<S> {
+    pub fn fast_bounding_box(&self) -> Box2D<S> {
         let (min_x, max_x) = self.fast_bounding_range_x();
         let (min_y, max_y) = self.fast_bounding_range_y();
 
-        rect(min_x, min_y, max_x - min_x, max_y - min_y)
+        Box2D { min: point(min_x, min_y), max: point(max_x, max_y) }
     }
 
-    /// Returns a conservative range of x this curve is contained in.
+    /// Returns a conservative rectangle that contains the curve.
+    pub fn fast_bounding_rect(&self) -> Rect<S> {
+        self.fast_bounding_box().to_rect()
+    }
+
+    /// Returns a conservative range of x that contains this curve.
     pub fn fast_bounding_range_x(&self) -> (S, S) {
         let min_x = self.from.x.min(self.ctrl.x).min(self.to.x);
         let max_x = self.from.x.max(self.ctrl.x).max(self.to.x);
@@ -463,7 +468,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
         (min_x, max_x)
     }
 
-    /// Returns a conservative range of y this curve is contained in.
+    /// Returns a conservative range of y that contains this curve.
     pub fn fast_bounding_range_y(&self) -> (S, S) {
         let min_y = self.from.y.min(self.ctrl.y).min(self.to.y);
         let max_y = self.from.y.max(self.ctrl.y).max(self.to.y);
@@ -472,14 +477,19 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
     }
 
     /// Returns the smallest rectangle the curve is contained in
-    pub fn bounding_rect(&self) -> Rect<S> {
+    pub fn bounding_box(&self) -> Box2D<S> {
         let (min_x, max_x) = self.bounding_range_x();
         let (min_y, max_y) = self.bounding_range_y();
 
-        rect(min_x, min_y, max_x - min_x, max_y - min_y)
+        Box2D { min: point(min_x, min_y), max: point(max_x, max_y) }
     }
 
-    /// Returns the smallest range of x this curve is contained in.
+    /// Returns the smallest rectangle the curve is contained in
+    pub fn bounding_rect(&self) -> Rect<S> {
+        self.bounding_box().to_rect()
+    }
+
+    /// Returns the smallest range of x that contains this curve.
     pub fn bounding_range_x(&self) -> (S, S) {
         let min_x = self.x(self.x_minimum_t());
         let max_x = self.x(self.x_maximum_t());
@@ -487,7 +497,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
         (min_x, max_x)
     }
 
-    /// Returns the smallest range of y this curve is contained in.
+    /// Returns the smallest range of y that contains this curve.
     pub fn bounding_range_y(&self) -> (S, S) {
         let min_y = self.y(self.y_minimum_t());
         let max_y = self.y(self.y_maximum_t());
@@ -797,6 +807,9 @@ impl<S: Scalar> BoundingRect for QuadraticBezierSegment<S> {
 
 /// A monotonically increasing in x and y quadratic bézier curve segment
 pub type MonotonicQuadraticBezierSegment<S> = Monotonic<QuadraticBezierSegment<S>>;
+
+#[cfg(test)]
+use crate::rect;
 
 #[test]
 fn bounding_rect_for_monotonic_quadratic_bezier_segment() {

--- a/crates/geom/src/segment.rs
+++ b/crates/geom/src/segment.rs
@@ -1,6 +1,6 @@
 use crate::scalar::Scalar;
 use crate::{CubicBezierSegment, LineSegment, QuadraticBezierSegment};
-use crate::{Point, Rect, Vector};
+use crate::{Point, Rect, Vector, Box2D, point};
 
 use std::ops::Range;
 
@@ -61,17 +61,44 @@ pub trait Segment: Copy + Sized {
     fn approximate_length(&self, tolerance: Self::Scalar) -> Self::Scalar;
 }
 
+// TODO: replace with BoundingBox trait.
 pub trait BoundingRect {
     type Scalar: Scalar;
 
-    /// Returns a rectangle that contains the curve.
-    fn bounding_rect(&self) -> Rect<Self::Scalar>;
+    /// Returns the smallest rectangle that contains the curve.
+    fn bounding_box(&self) -> Box2D<Self::Scalar> {
+        let (min_x, max_x) = self.bounding_range_x();
+        let (min_y, max_y) = self.bounding_range_y();
 
-    /// Returns a rectangle that contains the curve.
+        Box2D {
+            min: point(min_x, min_y),
+            max: point(max_x, max_y),
+        }
+    }
+
+    /// Returns the smallest rectangle that contains the curve.
+    fn bounding_rect(&self) -> Rect<Self::Scalar> {
+        self.bounding_box().to_rect()
+    }
+
+    /// Returns a conservative rectangle that contains the curve.
+    ///
+    /// This does not necessarily return the smallest possible bounding rectangle.
+    fn fast_bounding_box(&self) -> Box2D<Self::Scalar> {
+        let (min_x, max_x) = self.fast_bounding_range_x();
+        let (min_y, max_y) = self.fast_bounding_range_y();
+
+        Box2D {
+            min: point(min_x, min_y),
+            max: point(max_x, max_y),
+        }
+    }
+
+    /// Returns a conservative rectangle that contains the curve.
     ///
     /// This does not necessarily return the smallest possible bounding rectangle.
     fn fast_bounding_rect(&self) -> Rect<Self::Scalar> {
-        self.bounding_rect()
+        self.fast_bounding_box().to_rect()
     }
 
     /// Returns a range of x values that contains the curve.


### PR DESCRIPTION
 - `*_box` equivalents to `*_rect` methods (for example `bounding_box`) using the rectangle with min/max endpoints representation which is better than the origin + size one in a lot of cases.
 - `Line::intersects_box`
 - `LineSegment::clipped(&Box2D)`