### PR TITLE
Add further iterator support for paths

### DIFF
--- a/crates/path/src/iterator.rs
+++ b/crates/path/src/iterator.rs
@@ -201,6 +201,19 @@ where
             None => None,
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // At minimum, the inner iterator's size hint plus the flattening iterator's size hint can form the lower
+        // bracket.
+        // We can't determine a maximum limit.
+        let mut lo = self.it.size_hint().0;
+        match &self.current_curve {
+             TmpFlatteningIter::Quadratic(t) => { lo += t.size_hint().0; },
+             TmpFlatteningIter::Cubic(t) => { lo += t.size_hint().0; },
+             _ => {},
+        }
+        (lo, None)
+    }
 }
 
 /// Applies a 2D transform to a path iterator and yields the resulting path iterator.

--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -8,7 +8,7 @@ use crate::private::DebugValidator;
 use crate::{AttributeStore, ControlPointId, EndpointId, Event, IdEvent, PathEvent, PositionStore};
 
 use std::fmt;
-use std::iter::IntoIterator;
+use std::iter::{FromIterator, IntoIterator};
 use std::u32;
 
 /// Enumeration corresponding to the [Event](https://docs.rs/lyon_core/*/lyon_core/events/enum.Event.html) enum
@@ -182,6 +182,15 @@ impl Path {
                 IdEvent::End { .. } => {}
             }
         }
+    }
+}
+
+impl FromIterator<PathEvent> for Path {
+    fn from_iter<T: IntoIterator<Item = PathEvent>>(iter: T) -> Path {
+        iter.into_iter().fold(Path::builder(), |mut builder, event| {
+            builder.path_event(event);
+            builder
+        }).build()
     }
 }
 


### PR DESCRIPTION
This PR does the following:

- Implements `FromIterator` for `Path`, allowing it to be built from an iterator over `PathEvent`s without having to go through `Builder`.
- Adds a new `Iter` struct that iterates over the individual `PathSlice`s in a `PathBuffer`.
- Also implements `FromIterator` for `PathBuffer`.
- Adds the `size_hint` method to the `Flattened` iterator.