### PR TITLE
Arc::to_svg_arc: fix swapped ArcFlags

### DIFF
--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -140,8 +140,8 @@ impl<S: Scalar> Arc<S> {
         let from = self.sample(S::ZERO);
         let to = self.sample(S::ONE);
         let flags = ArcFlags {
-            sweep: S::abs(self.sweep_angle.get()) >= S::PI(),
-            large_arc: self.sweep_angle.get() >= S::ZERO,
+            sweep: self.sweep_angle.get() >= S::ZERO,
+            large_arc: S::abs(self.sweep_angle.get()) >= S::PI(),
         };
         SvgArc {
             from,


### PR DESCRIPTION
Based on https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands

large arc = sweep angle >= 180
sweep = sweep angle.is_positive()

But it looks like those two are flipped in the code. Running into some issues with curve splitting and flattening that works fine if I flip them back.