### PR TITLE
Reintroduce some basic shapes fast paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_tessellation"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "arrayvec",
  "float_next_after",

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_tessellation"
-version = "0.17.8"
+version = "0.17.9"
 description = "A low level path tessellation library."
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
 repository = "https://github.com/nical/lyon"

--- a/crates/tessellation/src/basic_shapes.rs
+++ b/crates/tessellation/src/basic_shapes.rs
@@ -1,0 +1,257 @@
+use crate::{FillVertex, VertexId, FillOptions, FillGeometryBuilder, TessellationResult, TessellationError};
+use crate::event_queue::{EventQueue, INVALID_EVENT_ID};
+use crate::math::*;
+
+use std::f32::consts::PI;
+
+pub fn fill_rectangle(
+    rect: &Rect,
+    output: &mut dyn FillGeometryBuilder,
+) -> TessellationResult {
+    output.begin_geometry();
+
+    let dummy_queue = EventQueue::new();
+
+    let vertex = &mut |position| {
+        output.add_fill_vertex(FillVertex {
+            position,
+            events: &dummy_queue,
+            current_event: INVALID_EVENT_ID,
+            attrib_store: None,
+            attrib_buffer: &mut [],
+        })            
+    };
+
+    let a = vertex(rect.origin)?;
+    let b = vertex(bottom_left(&rect))?;
+    let c = vertex(bottom_right(&rect))?;
+    let d = vertex(top_right(&rect))?;
+
+    output.add_triangle(a, b, c);
+    output.add_triangle(a, c, d);
+
+    Ok(output.end_geometry())
+}
+
+pub fn fill_circle(
+    center: Point,
+    radius: f32,
+    options: &FillOptions,
+    output: &mut dyn FillGeometryBuilder,
+) -> TessellationResult {
+    output.begin_geometry();
+
+    let radius = radius.abs();
+    if radius == 0.0 {
+        return Ok(output.end_geometry());
+    }
+
+    let up = vector(0.0, -1.0);
+    let down = vector(0.0, 1.0);
+    let left = vector(-1.0, 0.0);
+    let right = vector(1.0, 0.0);
+
+    let events = &EventQueue::new();
+    let attrib_store = None;
+    let current_event = INVALID_EVENT_ID;
+
+    let v = [
+        output.add_fill_vertex(FillVertex {
+            position: center + (left * radius),
+            events,
+            current_event,
+            attrib_store,
+            attrib_buffer: &mut[]
+        })?,
+        output.add_fill_vertex(FillVertex {
+            position: center + (up * radius),
+            events,
+            current_event,
+            attrib_store,
+            attrib_buffer: &mut[]
+        })?,
+        output.add_fill_vertex(FillVertex {
+            position: center + (right * radius),
+            events,
+            current_event,
+            attrib_store,
+            attrib_buffer: &mut[]
+        })?,
+        output.add_fill_vertex(FillVertex {
+            position: center + (down * radius),
+            events,
+            current_event,
+            attrib_store,
+            attrib_buffer: &mut[]
+        })?,
+    ];
+
+    output.add_triangle(v[0], v[3], v[1]);
+    output.add_triangle(v[1], v[3], v[2]);
+
+    let angles = [
+        (PI, 1.5 * PI),
+        (1.5 * PI, 2.0 * PI),
+        (0.0, PI * 0.5),
+        (PI * 0.5, PI),
+    ];
+
+    let arc_len = 0.5 * PI * radius;
+    let step = circle_flattening_step(radius, options.tolerance);
+    let num_segments = (arc_len / step).ceil();
+    let num_recursions = num_segments.log2() as u32;
+
+    for i in 0..4 {
+        fill_border_radius(
+            center,
+            angles[i],
+            radius,
+            v[i],
+            v[(i + 1) % 4],
+            num_recursions,
+            events,
+            output,
+        )?;
+    }
+
+    Ok(output.end_geometry())
+}
+
+fn bottom_left(rect: &Rect) -> Point {
+    point(rect.min_x(), rect.max_y())
+}
+
+fn top_right(rect: &Rect) -> Point {
+    point(rect.max_x(), rect.min_y())
+}
+
+fn bottom_right(rect: &Rect) -> Point {
+    rect.max()
+}
+
+
+// Returns the maximum length of individual line segments when approximating a
+// circle.
+//
+// From pythagora's theorem:
+// r² = (d/2)² + (r - t)²
+// r² = d²/4 + r² + t² - 2 * e * r
+// d² = 4 * (2 * t * r - t²)
+// d = 2 * sqrt(2 * t * r - t²)
+//
+// With:
+//  r: the radius
+//  t: the tolerance threshold
+//  d: the line segment length
+pub(crate) fn circle_flattening_step(radius: f32, mut tolerance: f32) -> f32 {
+    // Don't allow high tolerance values (compared to the radius) to avoid edge cases.
+    tolerance = f32::min(tolerance, radius);
+    2.0 * f32::sqrt(2.0 * tolerance * radius - tolerance * tolerance)
+}
+
+// recursively tessellate the rounded corners.
+fn fill_border_radius(
+    center: Point,
+    angle: (f32, f32),
+    radius: f32,
+    va: VertexId,
+    vb: VertexId,
+    num_recursions: u32,
+    dummy_queue: &EventQueue,
+    output: &mut dyn FillGeometryBuilder,
+) -> Result<(), TessellationError> {
+    if num_recursions == 0 {
+        return Ok(());
+    }
+
+    let mid_angle = (angle.0 + angle.1) * 0.5;
+
+    let normal = vector(mid_angle.cos(), mid_angle.sin());
+    let position = center + normal * radius;
+
+    let vertex = output.add_fill_vertex(FillVertex {
+        position,
+        events: &dummy_queue,
+        current_event: INVALID_EVENT_ID,
+        attrib_store: None,
+        attrib_buffer: &mut [],
+    })?;
+
+    output.add_triangle(vb, vertex, va);
+
+    fill_border_radius(
+        center,
+        (angle.0, mid_angle),
+        radius,
+        va,
+        vertex,
+        num_recursions - 1,
+        dummy_queue,
+        output,
+    )?;
+    fill_border_radius(
+        center,
+        (mid_angle, angle.1),
+        radius,
+        vertex,
+        vb,
+        num_recursions - 1,
+        dummy_queue,
+        output,
+    )
+}
+
+
+#[test]
+fn basic_shapes() {
+    use crate::{GeometryBuilderError, Count};
+
+    let mut tess = crate::FillTessellator::new();
+
+    tess.tessellate_rectangle(
+        &Rect { origin: point(0.0, 1.0), size: size(2.0, 3.0 ) },
+        &FillOptions::DEFAULT,
+        &mut Builder { next_vertex: 0 },
+    ).unwrap();
+
+
+    tess.tessellate_circle(
+        point(1.0, 2.0),
+        100.0,
+        &FillOptions::DEFAULT,
+        &mut Builder { next_vertex: 0 },
+    ).unwrap();
+
+
+    struct Builder {
+        next_vertex: u32,
+    }
+
+    impl crate::GeometryBuilder for Builder {
+        fn begin_geometry(&mut self) {}
+        fn end_geometry(&mut self) -> Count {
+            Count {
+                vertices: self.next_vertex,
+                indices: 0,
+            }
+        }
+        fn abort_geometry(&mut self) {}
+        fn add_triangle(&mut self, _: VertexId, _: VertexId, _: VertexId) {}
+    }
+
+    impl crate::FillGeometryBuilder for Builder {
+        fn add_fill_vertex(
+            &mut self,
+            vertex: FillVertex,
+        ) -> Result<VertexId, GeometryBuilderError> {
+            let _pos = vertex.position();
+            assert!(vertex.sources().next().is_none());
+            assert!(vertex.as_endpoint_id().is_none());
+
+            let id = self.next_vertex;
+            self.next_vertex += 1;
+
+            Ok(VertexId(id))
+        }
+    }
+}

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -627,13 +627,10 @@ impl FillTessellator {
     pub fn tessellate_rectangle(
         &mut self,
         rect: &Rect,
-        options: &FillOptions,
+        _options: &FillOptions,
         output: &mut dyn FillGeometryBuilder,
     ) -> TessellationResult {
-        let mut builder = self.builder(options, output);
-        builder.add_rectangle(rect, Winding::Positive);
-
-        builder.build()
+        crate::basic_shapes::fill_rectangle(rect, output)
     }
 
     /// Tessellate a circle.
@@ -644,10 +641,7 @@ impl FillTessellator {
         options: &FillOptions,
         output: &mut dyn FillGeometryBuilder,
     ) -> TessellationResult {
-        let mut builder = self.builder(options, output);
-        builder.add_circle(center, radius, Winding::Positive);
-
-        builder.build()
+        crate::basic_shapes::fill_circle(center, radius, options, output)
     }
 
     /// Tessellate an ellipse.
@@ -660,7 +654,9 @@ impl FillTessellator {
         options: &FillOptions,
         output: &mut dyn FillGeometryBuilder,
     ) -> TessellationResult {
-        let mut builder = self.builder(options, output);
+        let options = options.clone().with_intersections(false);
+
+        let mut builder = self.builder(&options, output);
         builder.add_ellipse(center, radii, x_rotation, winding);
 
         builder.build()
@@ -2092,11 +2088,11 @@ fn reorient(p: Point) -> Point {
 
 /// Extra vertex information from the `FillTessellator`, accessible when building vertices.
 pub struct FillVertex<'l> {
-    position: Point,
-    events: &'l EventQueue,
-    current_event: TessEventId,
-    attrib_buffer: &'l mut [f32],
-    attrib_store: Option<&'l dyn AttributeStore>,
+    pub(crate) position: Point,
+    pub(crate) events: &'l EventQueue,
+    pub(crate) current_event: TessEventId,
+    pub(crate) attrib_buffer: &'l mut [f32],
+    pub(crate) attrib_store: Option<&'l dyn AttributeStore>,
 }
 
 impl<'l> FillVertex<'l> {

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -195,6 +195,7 @@ pub mod geometry_builder;
 mod math_utils;
 mod monotone;
 mod stroke;
+mod basic_shapes;
 
 #[cfg(test)]
 #[rustfmt::skip]


### PR DESCRIPTION
These use the old custom routines with the same `FillVertex` API as the fill tessellator. The vertex structure points to an empty event queue which doesn't need allocation and should gracefully fall back to providing nothing when querying vertex sources.

The main downside I see so far is that this conflicts with the way I hoped to partially support computing normals in #633 so most likely either fast basic shapes or vertex normals will make it.