### PR TITLE
Add missing `serde::` prefix when enabling serialization in a few crates

### DIFF
--- a/crates/algorithms/src/hatching.rs
+++ b/crates/algorithms/src/hatching.rs
@@ -39,7 +39,10 @@ use std::mem;
 
 /// Parameters for the hatcher.
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[non_exhaustive]
 pub struct HatchingOptions {
     /// Maximum allowed distance to the path when building an approximation.
@@ -116,7 +119,10 @@ impl HatchingOptions {
 
 /// Parameters for generating dot patterns.
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[non_exhaustive]
 pub struct DotOptions {
     /// Maximum allowed distance to the path when building an approximation.

--- a/crates/tess2/src/flattened_path.rs
+++ b/crates/tess2/src/flattened_path.rs
@@ -6,14 +6,20 @@ use crate::path::EndpointId;
 use std::ops::Range;
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 struct SubPathInfo {
     range: Range<usize>,
     is_closed: bool,
 }
 
 /// A path data structure for pre-flattened paths and polygons.
-#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(Clone, Default)]
 pub struct FlattenedPath {
     points: Vec<Point>,


### PR DESCRIPTION
If you tried to compile with `cargo build --all-features`, this would fail because of the unprefixed `Serialize`/`Deserialize` derive macros.