### PR TITLE
Remove unused dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,11 +26,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-
       - name: Test
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,6 @@ dependencies = [
  "env_logger 0.7.1",
  "futures",
  "itertools",
- "log",
  "lyon",
  "rand",
  "regex",
@@ -1227,12 +1226,10 @@ dependencies = [
 name = "lyon_tessellation"
 version = "0.17.9"
 dependencies = [
- "arrayvec",
  "float_next_after",
  "lyon_extra",
  "lyon_path",
  "serde",
- "sid",
 ]
 
 [[package]]
@@ -2446,7 +2443,6 @@ dependencies = [
  "bytemuck",
  "env_logger 0.9.0",
  "futures",
- "log",
  "lyon",
  "wgpu",
  "winit",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,6 @@ lyon = { path = "../crates/lyon", features = ["svg", "extra", "libtess2", "debug
 clap = "2.32.0"
 rand = "0.6"
 env_logger = "0.7"
-log = "0.4"
 wgpu = "0.9.0"
 winit = "0.25"
 futures = "0.3.5"

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -22,10 +22,8 @@ profiling = []
 
 [dependencies]
 lyon_path = { version = "0.17.1", path = "../path" }
-sid = "0.6"
 float_next_after = "0.1.5"
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
-arrayvec = "0.5"
 
 [dev-dependencies]
 lyon_extra = { version = "0.17.1", path = "../extra" }

--- a/examples/wgpu/Cargo.toml
+++ b/examples/wgpu/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/main.rs"
 [dependencies]
 lyon = { path = "../../crates/lyon", features = ["extra"] }
 env_logger = "0.9.0"
-log = "0.4"
 
 wgpu = "0.9.0"
 winit = "0.25"


### PR DESCRIPTION
This doesn't lower the size of the Cargo.lock file, but it may change
the crate compilation order, and give cargo more opportunities for
compilation parallelism.