### PR TITLE
Rename Side::Left/Right into Side::Positive/Negative.

### DIFF
--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -199,34 +199,58 @@ pub enum LineJoin {
     MiterClip,
     /// A round corner is to be used to join path segments.
     Round,
-    /// A bevelled corner is to be used to join path segments.
+    /// A beveled corner is to be used to join path segments.
     /// The bevel shape is a triangle that fills the area between the two stroked
     /// segments.
     Bevel,
 }
 
-/// Left or right.
+/// The positive or negative side of a vector or segment.
+///
+/// Given a reference vector `v0`, a vector `v1` is on the positive side
+/// if the sign of the cross product `v0 x v1` is positive.
+///
+/// This type does not use the left/right terminology to avoid confusion with
+/// left-handed / right-handed coordinate systems. Right-handed coordinate systems
+/// seem to be what a lot of people are most familiar with (especially in 2D), however
+/// most vector graphics specifications use y-down left-handed coordinate systems.
+/// Unfortunately mirroring the y axis inverts the meaning of "left" and "right", which
+/// causes confusion. In practice:
+///
+/// - In a y-down left-handed coordinate system such as `SVG`'s, `Side::Positive` is the right side.
+/// - In a y-up right-handed coordinate system, `Side::Positive` is the left side.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum Side {
-    Left,
-    Right,
+    Positive,
+    Negative,
 }
 
 impl Side {
+    #[inline]
     pub fn opposite(self) -> Self {
         match self {
-            Side::Left => Side::Right,
-            Side::Right => Side::Left,
+            Side::Positive => Side::Negative,
+            Side::Negative => Side::Positive,
         }
     }
 
-    pub fn is_left(self) -> bool {
-        self == Side::Left
+    #[inline]
+    pub fn is_positive(self) -> bool {
+        self == Side::Positive
     }
 
-    pub fn is_right(self) -> bool {
-        self == Side::Right
+    #[inline]
+    pub fn is_negative(self) -> bool {
+        self == Side::Negative
+    }
+
+    #[inline]
+    pub fn to_f32(self) -> f32 {
+        match self {
+            Side::Positive => 1.0,
+            Side::Negative => -1.0,
+        }
     }
 }
 

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -9,7 +9,7 @@ use crate::path::{
 };
 use crate::{FillGeometryBuilder, Orientation, VertexId};
 use crate::{
-    FillOptions, InternalError, Side, TessellationError, TessellationResult, VertexSource,
+    FillOptions, InternalError, TessellationError, TessellationResult, VertexSource,
 };
 use std::cmp::Ordering;
 use std::f32;
@@ -19,6 +19,29 @@ use float_next_after::NextAfter;
 
 #[cfg(debug_assertions)]
 use std::env;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Side {
+    Left,
+    Right
+}
+
+impl Side {
+    pub fn opposite(self) -> Self {
+        match self {
+            Side::Left => Side::Right,
+            Side::Right => Side::Left,
+        }
+    }
+
+    pub fn is_left(self) -> bool {
+        self == Side::Left
+    }
+
+    pub fn is_right(self) -> bool {
+        self == Side::Right
+    }
+}
 
 type SpanIdx = i32;
 type ActiveEdgeIdx = usize;

--- a/crates/tessellation/src/math_utils.rs
+++ b/crates/tessellation/src/math_utils.rs
@@ -7,7 +7,7 @@ use crate::math::*;
 /// The resulting vector is not normalized. The length is such that extruding the shape
 /// would yield parallel segments exactly 1 unit away from their original. (useful
 /// for generating strokes and vertex-aa).
-/// The normal points towards the left side of e1.
+/// The normal points towards the positive side of e1.
 ///
 /// v1 and v2 are expected to be normalized.
 pub fn compute_normal(v1: Vector, v2: Vector) -> Vector {
@@ -47,6 +47,10 @@ fn test_compute_normal() {
     assert_almost_eq(
         compute_normal(vector(1.0, 0.0), vector(0.0, 1.0)),
         vector(-1.0, 1.0),
+    );
+    assert_almost_eq(
+        compute_normal(vector(1.0, 0.0), vector(0.0, -1.0)),
+        vector(1.0, 1.0),
     );
     assert_almost_eq(
         compute_normal(vector(1.0, 0.0), vector(1.0, 0.0)),

--- a/crates/tessellation/src/monotone.rs
+++ b/crates/tessellation/src/monotone.rs
@@ -1,6 +1,5 @@
-use crate::fill::is_after;
+use crate::fill::{is_after, Side};
 use crate::math::{point, Point};
-use crate::Side;
 use crate::{FillGeometryBuilder, VertexId};
 
 /// Helper class that generates a triangulation from a sequence of vertices describing a monotone
@@ -211,7 +210,7 @@ impl SideEvents {
     }
 }
 
-pub struct AdvancedMonotoneTessellator {
+pub(crate) struct AdvancedMonotoneTessellator {
     tess: BasicMonotoneTessellator,
     left: SideEvents,
     right: SideEvents,
@@ -402,4 +401,4 @@ fn flush_side(
     Some(side.last)
 }
 
-pub type MonotoneTessellator = AdvancedMonotoneTessellator;
+pub(crate) type MonotoneTessellator = AdvancedMonotoneTessellator;


### PR DESCRIPTION
What one might think of left or right depends on the coordinate system. A lot of people are used to right-handed y-up coordinate systems whereas most vector graphics specification work in a y-down left-handed coordinate system, as a result left/right becomes very confusing.

This removes the problem by using the Positive/Negative terminology which, while less natural, is completely unambiguous: given a reference vector or edge v1, all vectors such as the sign of the cross product v1 x v1 is positive, are considered to be on the positive side.

This PR also fixes some of the left/right inconsistencies in the stroking code.