### PR TITLE
Expose custom attributes in the PathBuilder trait

### DIFF
--- a/bench/path/src/main.rs
+++ b/bench/path/src/main.rs
@@ -7,7 +7,7 @@ use lyon::math::point;
 use lyon::path::commands;
 use lyon::path::traits::*;
 use lyon::path::PathBuffer;
-use lyon::path::{ControlPointId, EndpointId, Event, IdEvent, Path, PathEvent};
+use lyon::path::{ControlPointId, EndpointId, Event, IdEvent, Path, PathEvent, Attributes};
 
 use bencher::Bencher;
 
@@ -196,11 +196,11 @@ fn no_attrib_iter(bench: &mut Bencher) {
         let mut path = Path::builder_with_attributes(0);
         for _ in 0..N {
             for _ in 0..10 {
-                path.begin(point(0.0, 0.0), &[]);
+                path.begin(point(0.0, 0.0), Attributes::NONE);
                 for _ in 0..1_000 {
-                    path.line_to(point(1.0, 0.0), &[]);
-                    path.cubic_bezier_to(point(2.0, 0.0), point(2.0, 1.0), point(2.0, 2.0), &[]);
-                    path.quadratic_bezier_to(point(2.0, 0.0), point(2.0, 1.0), &[]);
+                    path.line_to(point(1.0, 0.0), Attributes::NONE);
+                    path.cubic_bezier_to(point(2.0, 0.0), point(2.0, 1.0), point(2.0, 2.0), Attributes::NONE);
+                    path.quadratic_bezier_to(point(2.0, 0.0), point(2.0, 1.0), Attributes::NONE);
                 }
                 path.end(true);
             }
@@ -228,16 +228,16 @@ fn f32x2_attrib_iter(bench: &mut Bencher) {
         let mut path = Path::builder_with_attributes(2);
         for _ in 0..N {
             for _ in 0..10 {
-                path.begin(point(0.0, 0.0), &[0.0, 1.0]);
+                path.begin(point(0.0, 0.0), Attributes(&[0.0, 1.0]));
                 for _ in 0..1_000 {
-                    path.line_to(point(1.0, 0.0), &[0.0, 1.0]);
+                    path.line_to(point(1.0, 0.0), Attributes(&[0.0, 1.0]));
                     path.cubic_bezier_to(
                         point(2.0, 0.0),
                         point(2.0, 1.0),
                         point(2.0, 2.0),
-                        &[0.0, 1.0],
+                        Attributes(&[0.0, 1.0]),
                     );
-                    path.quadratic_bezier_to(point(2.0, 0.0), point(2.0, 1.0), &[0.0, 1.0]);
+                    path.quadratic_bezier_to(point(2.0, 0.0), point(2.0, 1.0), Attributes(&[0.0, 1.0]));
                 }
                 path.end(true);
             }

--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -8,7 +8,7 @@ use lyon::extra::rust_logo::build_logo_path;
 use lyon::math::Point;
 use lyon::path::builder::*;
 use lyon::path::iterator::PathIterator;
-use lyon::path::Path;
+use lyon::path::{Path, Attributes};
 use lyon::tessellation::geometry_builder::{simple_builder, VertexBuffers};
 use lyon::tessellation::{EventQueue, FillTessellator};
 use lyon::tessellation::{FillOptions, LineJoin};
@@ -59,7 +59,7 @@ fn flattening_03_logo_builder(bench: &mut Bencher) {
         let mut builder = Path::builder().flattened(0.05);
         for _ in 0..N {
             for evt in path.iter() {
-                builder.path_event(evt);
+                builder.path_event(evt, Attributes::NONE);
             }
         }
     })

--- a/cli/src/fuzzing.rs
+++ b/cli/src/fuzzing.rs
@@ -4,7 +4,7 @@ use lyon::extra::debugging::find_reduced_test_case;
 use lyon::geom::LineSegment;
 use lyon::math::*;
 use lyon::path::traits::PathBuilder;
-use lyon::path::Path;
+use lyon::path::{Path, Attributes};
 use lyon::tess2;
 use lyon::tessellation::geometry_builder::NoOutput;
 use lyon::tessellation::{FillTessellator, StrokeTessellator};
@@ -117,7 +117,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
                         builder.add_line_segment(&LineSegment {
                             from: segment.a.position,
                             to: segment.b.position,
-                        });
+                        }, Attributes::NONE);
                     },
                 },
             );
@@ -134,7 +134,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
                     row_interval: dots.spacing,
                     column_interval: dots.spacing,
                     callback: &mut |dot: &Dot| {
-                        builder.add_point(dot.position);
+                        builder.add_point(dot.position, Attributes::NONE);
                     },
                 },
             );

--- a/cli/src/reduce.rs
+++ b/cli/src/reduce.rs
@@ -1,13 +1,13 @@
 use crate::commands::{TessellateCmd, Tessellator};
 use lyon::path::traits::*;
-use lyon::path::Path;
+use lyon::path::{Path, Attributes};
 use lyon::tessellation::geometry_builder::*;
 use lyon::tessellation::{FillTessellator, StrokeTessellator};
 
 pub fn reduce_testcase(cmd: TessellateCmd) {
     if let Some(options) = cmd.stroke {
         let mut flattener = Path::builder().flattened(options.tolerance);
-        flattener.extend(cmd.path.iter());
+        flattener.extend(cmd.path.iter(), Attributes::NONE);
         let path = flattener.build();
 
         lyon::extra::debugging::find_reduced_test_case(path.as_slice(), &|path: Path| {
@@ -27,7 +27,7 @@ pub fn reduce_testcase(cmd: TessellateCmd) {
 
     if let Some(options) = cmd.fill {
         let mut flattener = Path::builder().flattened(options.tolerance);
-        flattener.extend(cmd.path.iter());
+        flattener.extend(cmd.path.iter(), Attributes::NONE);
         let path = flattener.build();
 
         match cmd.tessellator {

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -15,7 +15,7 @@ use lyon::algorithms::hatching::*;
 use lyon::geom::LineSegment;
 use lyon::math::*;
 use lyon::path::builder::PathBuilder;
-use lyon::path::Path;
+use lyon::path::{Path, Attributes};
 use lyon::tess2;
 use lyon::tessellation;
 use lyon::tessellation::geometry_builder::*;
@@ -159,7 +159,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
                     path.add_line_segment(&LineSegment {
                         from: segment.a.position,
                         to: segment.b.position,
-                    });
+                    }, Attributes::NONE);
                 },
             },
         );
@@ -184,7 +184,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
                 row_interval: dots.spacing,
                 column_interval: dots.spacing,
                 callback: &mut |dot: &Dot| {
-                    path.add_point(dot.position);
+                    path.add_point(dot.position, Attributes::NONE);
                 },
             },
         );

--- a/crates/algorithms/src/hatching.rs
+++ b/crates/algorithms/src/hatching.rs
@@ -30,7 +30,7 @@ use crate::geom::LineSegment;
 use crate::math::{point, vector, Angle, Point, Rotation, Vector};
 use crate::path::builder::{Build, PathBuilder};
 use crate::path::private::DebugValidator;
-use crate::path::{self, EndpointId, PathEvent};
+use crate::path::{self, EndpointId, PathEvent, Attributes};
 use std::marker::PhantomData;
 
 use std::cmp::Ordering;
@@ -514,7 +514,7 @@ impl Build for EventsBuilder {
 impl PathBuilder for EventsBuilder {
     fn num_attributes(&self) -> usize { 0 }
 
-    fn begin(&mut self, to: Point, _attributes: &[f32]) -> EndpointId {
+    fn begin(&mut self, to: Point, _attributes: Attributes) -> EndpointId {
         self.validator.begin();
         self.first = to;
         self.current = to;
@@ -527,7 +527,7 @@ impl PathBuilder for EventsBuilder {
         self.add_edge(self.current, self.first);
     }
 
-    fn line_to(&mut self, to: Point, _attributes: &[f32]) -> EndpointId {
+    fn line_to(&mut self, to: Point, _attributes: Attributes) -> EndpointId {
         self.validator.edge();
         self.add_edge(self.current, to);
         self.current = to;
@@ -535,12 +535,31 @@ impl PathBuilder for EventsBuilder {
         EndpointId::INVALID
     }
 
-    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, _attributes: &[f32]) -> EndpointId {
-        path::private::flatten_quadratic_bezier(self.tolerance, self.current, ctrl, to, &[], &[], self, &mut[])
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, _attributes: Attributes) -> EndpointId {
+        path::private::flatten_quadratic_bezier(
+            self.tolerance,
+            self.current,
+            ctrl,
+            to,
+            Attributes::NONE,
+            Attributes::NONE,
+            self,
+            &mut[],
+        )
     }
 
-    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, _attributes: &[f32]) -> EndpointId {
-        path::private::flatten_cubic_bezier(self.tolerance, self.current, ctrl1, ctrl2, to, &[], &[], self, &mut[])
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, _attributes: Attributes) -> EndpointId {
+        path::private::flatten_cubic_bezier(
+            self.tolerance,
+            self.current,
+            ctrl1,
+            ctrl2,
+            to,
+            Attributes::NONE,
+            Attributes::NONE,
+            self,
+            &mut[],
+        )
     }
 }
 
@@ -554,7 +573,7 @@ impl HatchingEvents {
         builder.edges = mem::take(&mut self.edges);
 
         for evt in it {
-            builder.path_event(evt, &[]);
+            builder.path_event(evt, Attributes::NONE);
         }
         mem::swap(self, &mut builder.build());
     }
@@ -714,7 +733,7 @@ fn simple_hatching() {
                 hatches.add_line_segment(&LineSegment {
                     from: segment.a.position,
                     to: segment.b.position,
-                }, &[]);
+                }, Attributes::NONE);
             },
         },
     );

--- a/crates/algorithms/src/hatching.rs
+++ b/crates/algorithms/src/hatching.rs
@@ -512,7 +512,9 @@ impl Build for EventsBuilder {
 }
 
 impl PathBuilder for EventsBuilder {
-    fn begin(&mut self, to: Point) -> EndpointId {
+    fn num_attributes(&self) -> usize { 0 }
+
+    fn begin(&mut self, to: Point, _attributes: &[f32]) -> EndpointId {
         self.validator.begin();
         self.first = to;
         self.current = to;
@@ -525,7 +527,7 @@ impl PathBuilder for EventsBuilder {
         self.add_edge(self.current, self.first);
     }
 
-    fn line_to(&mut self, to: Point) -> EndpointId {
+    fn line_to(&mut self, to: Point, _attributes: &[f32]) -> EndpointId {
         self.validator.edge();
         self.add_edge(self.current, to);
         self.current = to;
@@ -533,12 +535,12 @@ impl PathBuilder for EventsBuilder {
         EndpointId::INVALID
     }
 
-    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point) -> EndpointId {
-        path::private::flatten_quadratic_bezier(self.tolerance, self.current, ctrl, to, self)
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, _attributes: &[f32]) -> EndpointId {
+        path::private::flatten_quadratic_bezier(self.tolerance, self.current, ctrl, to, &[], &[], self, &mut[])
     }
 
-    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point) -> EndpointId {
-        path::private::flatten_cubic_bezier(self.tolerance, self.current, ctrl1, ctrl2, to, self)
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, _attributes: &[f32]) -> EndpointId {
+        path::private::flatten_cubic_bezier(self.tolerance, self.current, ctrl1, ctrl2, to, &[], &[], self, &mut[])
     }
 }
 
@@ -552,7 +554,7 @@ impl HatchingEvents {
         builder.edges = mem::take(&mut self.edges);
 
         for evt in it {
-            builder.path_event(evt);
+            builder.path_event(evt, &[]);
         }
         mem::swap(self, &mut builder.build());
     }
@@ -712,7 +714,7 @@ fn simple_hatching() {
                 hatches.add_line_segment(&LineSegment {
                     from: segment.a.position,
                     to: segment.b.position,
-                });
+                }, &[]);
             },
         },
     );

--- a/crates/extra/src/debugging.rs
+++ b/crates/extra/src/debugging.rs
@@ -41,9 +41,9 @@ pub fn polygons_to_path(polygons: PolygonsRef) -> Path {
     let mut builder = Path::builder().flattened(0.05);
     for poly in polygons.iter() {
         let mut poly_iter = poly.iter();
-        builder.begin(*poly_iter.next().unwrap());
+        builder.begin(*poly_iter.next().unwrap(), &[]);
         for v in poly_iter {
-            builder.line_to(*v);
+            builder.line_to(*v, &[]);
         }
         builder.close();
     }

--- a/crates/extra/src/debugging.rs
+++ b/crates/extra/src/debugging.rs
@@ -1,7 +1,7 @@
 use path::builder::*;
 use path::math::Point;
 use path::PathEvent;
-use path::{Path, PathSlice};
+use path::{Path, PathSlice, Attributes};
 
 pub type Polygons = Vec<Vec<Point>>;
 pub type PolygonsRef<'a> = &'a [Vec<Point>];
@@ -41,9 +41,9 @@ pub fn polygons_to_path(polygons: PolygonsRef) -> Path {
     let mut builder = Path::builder().flattened(0.05);
     for poly in polygons.iter() {
         let mut poly_iter = poly.iter();
-        builder.begin(*poly_iter.next().unwrap(), &[]);
+        builder.begin(*poly_iter.next().unwrap(), Attributes::NONE);
         for v in poly_iter {
-            builder.line_to(*v, &[]);
+            builder.line_to(*v, Attributes::NONE);
         }
         builder.close();
     }

--- a/crates/extra/src/parser.rs
+++ b/crates/extra/src/parser.rs
@@ -1,4 +1,5 @@
 use path::{
+    Attributes,
     math::{Angle, Point, point, vector},
     path::BuilderWithAttributes,
     geom::{SvgArc, ArcFlags},
@@ -211,7 +212,7 @@ impl PathParser {
             match cmd {
                 'l' | 'L' => {
                     let to = self.parse_endpoint(is_relatve, src)?;
-                    output.line_to(to, &self.attribute_buffer);
+                    output.line_to(to, Attributes(&self.attribute_buffer));
                 }
                 'h' | 'H' => {
                     let mut x = self.parse_number(src)?;
@@ -221,7 +222,7 @@ impl PathParser {
                     let to = point(x, self.current_position.y);
                     self.current_position = to;
                     self.parse_attributes(src)?;
-                    output.line_to(to, &self.attribute_buffer);
+                    output.line_to(to, Attributes(&self.attribute_buffer));
                 }
                 'v' | 'V' => {
                     let mut y = self.parse_number(src)?;
@@ -231,33 +232,33 @@ impl PathParser {
                     let to = point(self.current_position.x, y);
                     self.current_position = to;
                     self.parse_attributes(src)?;
-                    output.line_to(to, &self.attribute_buffer);
+                    output.line_to(to, Attributes(&self.attribute_buffer));
                 }
                 'q' | 'Q' => {
                     let ctrl = self.parse_point(is_relatve, src)?;
                     let to = self.parse_endpoint(is_relatve, src)?;
                     prev_quadratic_ctrl = Some(ctrl);
-                    output.quadratic_bezier_to(ctrl, to, &self.attribute_buffer);
+                    output.quadratic_bezier_to(ctrl, to, Attributes(&self.attribute_buffer));
                 }
                 't' | 'T' => {
                     let ctrl = self.get_smooth_ctrl(prev_quadratic_ctrl);
                     let to = self.parse_endpoint(is_relatve, src)?;
                     prev_quadratic_ctrl = Some(ctrl);
-                    output.quadratic_bezier_to(ctrl, to, &self.attribute_buffer);
+                    output.quadratic_bezier_to(ctrl, to, Attributes(&self.attribute_buffer));
                 }
                 'c' | 'C' => {
                     let ctrl1 = self.parse_point(is_relatve, src)?;
                     let ctrl2 = self.parse_point(is_relatve, src)?;
                     let to = self.parse_endpoint(is_relatve, src)?;
                     prev_cubic_ctrl = Some(ctrl2);
-                    output.cubic_bezier_to(ctrl1, ctrl2, to, &self.attribute_buffer);
+                    output.cubic_bezier_to(ctrl1, ctrl2, to, Attributes(&self.attribute_buffer));
                 }
                 's' | 'S' => {
                     let ctrl1 = self.get_smooth_ctrl(prev_cubic_ctrl);
                     let ctrl2 = self.parse_point(is_relatve, src)?;
                     let to = self.parse_endpoint(is_relatve, src)?;
                     prev_cubic_ctrl = Some(ctrl2);
-                    output.cubic_bezier_to(ctrl1, ctrl2, to, &self.attribute_buffer);
+                    output.cubic_bezier_to(ctrl1, ctrl2, to, Attributes(&self.attribute_buffer));
                 }
                 'a' | 'A' => {
                     let prev_attributes = self.attribute_buffer.clone();
@@ -286,7 +287,7 @@ impl PathParser {
                             interpolated_attributes[i] = prev_attributes[i] * (1.0 - range.end)
                                 + self.attribute_buffer[i] * range.end;
                         }
-                        output.quadratic_bezier_to(curve.ctrl, curve.to, &interpolated_attributes);
+                        output.quadratic_bezier_to(curve.ctrl, curve.to, Attributes(&interpolated_attributes));
                     });
                 }
                 'm' | 'M' => {
@@ -296,7 +297,7 @@ impl PathParser {
 
                     let to = self.parse_endpoint(is_relatve, src)?;
                     first_position = to;
-                    output.begin(to, &self.attribute_buffer);
+                    output.begin(to, Attributes(&self.attribute_buffer));
                     self.need_end = true;
                     need_start = false;
                 }

--- a/crates/lyon/src/lib.rs
+++ b/crates/lyon/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! ```
 //! use lyon::math::{Box2D, Point, point};
-//! use lyon::path::{builder::*, Winding};
+//! use lyon::path::{builder::*, Winding, Attributes};
 //! use lyon::tessellation::{FillTessellator, FillOptions, VertexBuffers};
 //! use lyon::tessellation::geometry_builder::simple_builder;
 //!
@@ -101,7 +101,8 @@
 //!             bottom_left: 20.0,
 //!             bottom_right: 25.0,
 //!         },
-//!         Winding::Positive
+//!         Winding::Positive,
+//!         Attributes::NONE,
 //!     );
 //!
 //!     builder.build();

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -395,7 +395,7 @@ pub trait AttributeStore {
     /// Returns the endpoint's custom attributes as a slice of 32 bits floats.
     ///
     /// The size of the slice must be equal to the result of `num_attributes()`.
-    fn get(&self, id: EndpointId) -> &[f32];
+    fn get(&self, id: EndpointId) -> Attributes;
 
     /// Returns the number of float attributes per endpoint.
     ///
@@ -407,8 +407,9 @@ impl AttributeStore for () {
     fn num_attributes(&self) -> usize {
         0
     }
-    fn get(&self, _: EndpointId) -> &[f32] {
-        &[]
+
+    fn get(&self, _: EndpointId) -> Attributes {
+        Attributes(&[])
     }
 }
 
@@ -428,13 +429,59 @@ impl<'l> AttributeSlice<'l> {
 }
 
 impl<'l> AttributeStore for AttributeSlice<'l> {
-    fn get(&self, id: EndpointId) -> &[f32] {
+    fn get(&self, id: EndpointId) -> Attributes {
         let start = id.to_usize() * self.stride;
         let end = start + self.stride;
-        &self.data[start..end]
+        Attributes(&self.data[start..end])
     }
 
     fn num_attributes(&self) -> usize {
         self.stride
     }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct AttributeIndex(pub u8);
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Attributes<'l>(pub &'l[f32]);
+
+impl<'l> Attributes<'l> {
+    pub const NONE: Attributes<'static> = Attributes(&[]);
+
+    #[inline]
+    pub fn len(&self) -> usize { self.0.len() }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[f32] { self.0 }
+}
+
+impl<'l> Default for Attributes<'l> {
+    fn default() -> Self {
+        Attributes::NONE
+    }
+}
+
+impl<'l> std::ops::Index<AttributeIndex> for Attributes<'l> {
+    type Output = f32;
+    #[inline]
+    fn index(&self, idx: AttributeIndex) -> &f32 {
+        &self.0[idx.0 as usize]
+    }
+}
+
+impl<'l> std::ops::Index<usize> for Attributes<'l> {
+    type Output = f32;
+    #[inline]
+    fn index(&self, idx: usize) -> &f32 {
+        &self.0[idx]
+    }
+}
+
+impl<'l> From<&'l[f32]> for Attributes<'l> {
+    fn from(slice: &'l[f32]) -> Attributes<'l> { Attributes(slice) }
+}
+
+impl<'l> Into<&'l[f32]> for Attributes<'l> {
+    fn into(self) -> &'l[f32] { self.0 }
 }

--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -537,7 +537,9 @@ impl Builder {
 }
 
 impl PathBuilder for Builder {
-    fn begin(&mut self, at: Point) -> EndpointId {
+    fn num_attributes(&self) -> usize { 0 }
+
+    fn begin(&mut self, at: Point, _attributes: &[f32]) -> EndpointId {
         self.begin(at)
     }
 
@@ -545,15 +547,15 @@ impl PathBuilder for Builder {
         self.end(close);
     }
 
-    fn line_to(&mut self, to: Point) -> EndpointId {
+    fn line_to(&mut self, to: Point, _attributes: &[f32]) -> EndpointId {
         self.line_to(to)
     }
 
-    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point) -> EndpointId {
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, _attributes: &[f32]) -> EndpointId {
         self.quadratic_bezier_to(ctrl, to)
     }
 
-    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point) -> EndpointId {
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, _attributes: &[f32]) -> EndpointId {
         self.cubic_bezier_to(ctrl1, ctrl2, to)
     }
 
@@ -561,6 +563,7 @@ impl PathBuilder for Builder {
         self.reserve(endpoints, ctrl_points);
     }
 }
+
 
 impl Build for Builder {
     type PathType = Path;
@@ -681,6 +684,35 @@ impl BuilderWithAttributes {
         }
     }
 }
+
+impl PathBuilder for BuilderWithAttributes {
+    fn num_attributes(&self) -> usize { self.num_attributes }
+
+    fn begin(&mut self, at: Point, attributes: &[f32]) -> EndpointId {
+        self.begin(at, attributes)
+    }
+
+    fn end(&mut self, close: bool) {
+        self.end(close);
+    }
+
+    fn line_to(&mut self, to: Point, attributes: &[f32]) -> EndpointId {
+        self.line_to(to, attributes)
+    }
+
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, attributes: &[f32]) -> EndpointId {
+        self.quadratic_bezier_to(ctrl, to, attributes)
+    }
+
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, attributes: &[f32]) -> EndpointId {
+        self.cubic_bezier_to(ctrl1, ctrl2, to, attributes)
+    }
+
+    fn reserve(&mut self, endpoints: usize, ctrl_points: usize) {
+        self.reserve(endpoints, ctrl_points);
+    }
+}
+
 
 #[inline]
 fn nan_check(p: Point) {

--- a/crates/path/src/path_buffer.rs
+++ b/crates/path/src/path_buffer.rs
@@ -111,7 +111,7 @@ impl<'l> FromIterator<PathSlice<'l>> for PathBuffer {
          iter.into_iter().fold(PathBuffer::new(), |mut buffer, path| {
              let builder = buffer.builder();
              path.iter().fold(builder, |mut builder, event| {
-                 builder.path_event(event);
+                 builder.path_event(event, &[]);
                  builder
              }).build();
              buffer
@@ -279,7 +279,12 @@ impl<'l> Builder<'l> {
 
 impl<'l> PathBuilder for Builder<'l> {
     #[inline]
-    fn begin(&mut self, at: Point) -> EndpointId {
+    fn num_attributes(&self) -> usize {
+        self.builder.num_attributes()
+    }
+
+    #[inline]
+    fn begin(&mut self, at: Point, _attributes: &[f32]) -> EndpointId {
         self.begin(at)
     }
 
@@ -289,17 +294,17 @@ impl<'l> PathBuilder for Builder<'l> {
     }
 
     #[inline]
-    fn line_to(&mut self, to: Point) -> EndpointId {
+    fn line_to(&mut self, to: Point, _attributes: &[f32]) -> EndpointId {
         self.line_to(to)
     }
 
     #[inline]
-    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point) -> EndpointId {
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, _attributes: &[f32]) -> EndpointId {
         self.quadratic_bezier_to(ctrl, to)
     }
 
     #[inline]
-    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point) -> EndpointId {
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, _attributes: &[f32]) -> EndpointId {
         self.cubic_bezier_to(ctrl1, ctrl2, to)
     }
 
@@ -412,6 +417,51 @@ impl<'l> BuilderWithAttributes<'l> {
         self.builder.reserve(endpoints, ctrl_points);
     }
 }
+
+impl<'l> PathBuilder for BuilderWithAttributes<'l> {
+    #[inline]
+    fn num_attributes(&self) -> usize {
+        self.builder.num_attributes()
+    }
+
+    #[inline]
+    fn begin(&mut self, at: Point, attributes: &[f32]) -> EndpointId {
+        self.begin(at, attributes)
+    }
+
+    #[inline]
+    fn end(&mut self, close: bool) {
+        self.end(close);
+    }
+
+    #[inline]
+    fn line_to(&mut self, to: Point, attributes: &[f32]) -> EndpointId {
+        self.line_to(to, attributes)
+    }
+
+    #[inline]
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, attributes: &[f32]) -> EndpointId {
+        self.quadratic_bezier_to(ctrl, to, attributes)
+    }
+
+    #[inline]
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, attributes: &[f32]) -> EndpointId {
+        self.cubic_bezier_to(ctrl1, ctrl2, to, attributes)
+    }
+
+    #[inline]
+    fn reserve(&mut self, endpoints: usize, ctrl_points: usize) {
+        self.reserve(endpoints, ctrl_points);
+    }
+}
+
+impl<'l> Build for BuilderWithAttributes<'l> {
+    type PathType = usize;
+    fn build(self) -> usize {
+        self.build()
+    }
+}
+
 
 /// Iterator over the paths in a [`PathBufferSlice`].
 #[derive(Clone)]

--- a/crates/path/src/path_buffer.rs
+++ b/crates/path/src/path_buffer.rs
@@ -3,7 +3,7 @@
 use crate::builder::*;
 use crate::math::*;
 use crate::path;
-use crate::{EndpointId, PathSlice};
+use crate::{EndpointId, PathSlice, Attributes};
 
 use std::fmt;
 use std::iter::{FusedIterator, FromIterator, IntoIterator};
@@ -111,7 +111,7 @@ impl<'l> FromIterator<PathSlice<'l>> for PathBuffer {
          iter.into_iter().fold(PathBuffer::new(), |mut buffer, path| {
              let builder = buffer.builder();
              path.iter().fold(builder, |mut builder, event| {
-                 builder.path_event(event, &[]);
+                 builder.path_event(event, Attributes::NONE);
                  builder
              }).build();
              buffer
@@ -284,7 +284,7 @@ impl<'l> PathBuilder for Builder<'l> {
     }
 
     #[inline]
-    fn begin(&mut self, at: Point, _attributes: &[f32]) -> EndpointId {
+    fn begin(&mut self, at: Point, _attributes: Attributes) -> EndpointId {
         self.begin(at)
     }
 
@@ -294,17 +294,17 @@ impl<'l> PathBuilder for Builder<'l> {
     }
 
     #[inline]
-    fn line_to(&mut self, to: Point, _attributes: &[f32]) -> EndpointId {
+    fn line_to(&mut self, to: Point, _attributes: Attributes) -> EndpointId {
         self.line_to(to)
     }
 
     #[inline]
-    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, _attributes: &[f32]) -> EndpointId {
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, _attributes: Attributes) -> EndpointId {
         self.quadratic_bezier_to(ctrl, to)
     }
 
     #[inline]
-    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, _attributes: &[f32]) -> EndpointId {
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, _attributes: Attributes) -> EndpointId {
         self.cubic_bezier_to(ctrl1, ctrl2, to)
     }
 
@@ -373,7 +373,7 @@ impl<'l> BuilderWithAttributes<'l> {
     }
 
     #[inline]
-    pub fn begin(&mut self, at: Point, attributes: &[f32]) -> EndpointId {
+    pub fn begin(&mut self, at: Point, attributes: Attributes) -> EndpointId {
         let id = self.builder.begin(at, attributes);
         self.adjust_id(id)
     }
@@ -384,7 +384,7 @@ impl<'l> BuilderWithAttributes<'l> {
     }
 
     #[inline]
-    pub fn line_to(&mut self, to: Point, attributes: &[f32]) -> EndpointId {
+    pub fn line_to(&mut self, to: Point, attributes: Attributes) -> EndpointId {
         let id = self.builder.line_to(to, attributes);
         self.adjust_id(id)
     }
@@ -394,7 +394,7 @@ impl<'l> BuilderWithAttributes<'l> {
         &mut self,
         ctrl: Point,
         to: Point,
-        attributes: &[f32],
+        attributes: Attributes,
     ) -> EndpointId {
         let id = self.builder.quadratic_bezier_to(ctrl, to, attributes);
         self.adjust_id(id)
@@ -406,7 +406,7 @@ impl<'l> BuilderWithAttributes<'l> {
         ctrl1: Point,
         ctrl2: Point,
         to: Point,
-        attributes: &[f32],
+        attributes: Attributes,
     ) -> EndpointId {
         let id = self.builder.cubic_bezier_to(ctrl1, ctrl2, to, attributes);
         self.adjust_id(id)
@@ -425,7 +425,7 @@ impl<'l> PathBuilder for BuilderWithAttributes<'l> {
     }
 
     #[inline]
-    fn begin(&mut self, at: Point, attributes: &[f32]) -> EndpointId {
+    fn begin(&mut self, at: Point, attributes: Attributes) -> EndpointId {
         self.begin(at, attributes)
     }
 
@@ -435,17 +435,17 @@ impl<'l> PathBuilder for BuilderWithAttributes<'l> {
     }
 
     #[inline]
-    fn line_to(&mut self, to: Point, attributes: &[f32]) -> EndpointId {
+    fn line_to(&mut self, to: Point, attributes: Attributes) -> EndpointId {
         self.line_to(to, attributes)
     }
 
     #[inline]
-    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, attributes: &[f32]) -> EndpointId {
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, attributes: Attributes) -> EndpointId {
         self.quadratic_bezier_to(ctrl, to, attributes)
     }
 
     #[inline]
-    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, attributes: &[f32]) -> EndpointId {
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, attributes: Attributes) -> EndpointId {
         self.cubic_bezier_to(ctrl1, ctrl2, to, attributes)
     }
 

--- a/crates/path/src/private.rs
+++ b/crates/path/src/private.rs
@@ -5,7 +5,7 @@
 pub use crate::geom::{CubicBezierSegment, QuadraticBezierSegment};
 pub use crate::math::Point;
 pub use crate::traits::PathBuilder;
-pub use crate::EndpointId;
+pub use crate::{EndpointId, Attributes};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct DebugValidator {
@@ -68,8 +68,8 @@ pub fn flatten_quadratic_bezier(
     from: Point,
     ctrl: Point,
     to: Point,
-    attributes: &[f32],
-    prev_attributes: &[f32],
+    attributes: Attributes,
+    prev_attributes: Attributes,
     builder: &mut impl PathBuilder,
     buffer: &mut [f32],
 ) -> EndpointId {
@@ -83,7 +83,7 @@ pub fn flatten_quadratic_bezier(
             for i in 0..n {
                 buffer[i] = prev_attributes[i] * (1.0 - t) + attributes[i] * t;
             }
-            &buffer[..]
+            Attributes(&buffer[..])
         };
         id = builder.line_to(point, attr);
     });
@@ -97,8 +97,8 @@ pub fn flatten_cubic_bezier(
     ctrl1: Point,
     ctrl2: Point,
     to: Point,
-    attributes: &[f32],
-    prev_attributes: &[f32],
+    attributes: Attributes,
+    prev_attributes: Attributes,
     builder: &mut impl PathBuilder,
     buffer: &mut [f32],
 ) -> EndpointId {
@@ -117,7 +117,7 @@ pub fn flatten_cubic_bezier(
             for i in 0..n {
                 buffer[i] = prev_attributes[i] * (1.0 - t) + attributes[i] * t;
             }
-            &buffer[..]
+            Attributes(&buffer[..])
         };
         id = builder.line_to(point, attr);
     });

--- a/crates/tess2/src/flattened_path.rs
+++ b/crates/tess2/src/flattened_path.rs
@@ -1,7 +1,7 @@
 use crate::math::*;
 use crate::path::builder::*;
 use crate::path::private::{flatten_cubic_bezier, flatten_quadratic_bezier};
-use crate::path::EndpointId;
+use crate::path::{EndpointId, Attributes};
 
 use std::ops::Range;
 
@@ -177,7 +177,9 @@ impl Build for Builder {
 }
 
 impl PathBuilder for Builder {
-    fn begin(&mut self, to: Point) -> EndpointId {
+    fn num_attributes(&self) -> usize { 0 }
+
+    fn begin(&mut self, to: Point, _: Attributes) -> EndpointId {
         nan_check(to);
         let sp_end = self.points.len();
         if self.sp_start != sp_end {
@@ -192,7 +194,7 @@ impl PathBuilder for Builder {
         EndpointId(sp_end as u32)
     }
 
-    fn line_to(&mut self, to: Point) -> EndpointId {
+    fn line_to(&mut self, to: Point, _: Attributes) -> EndpointId {
         nan_check(to);
         let id = EndpointId(self.points.len() as u32);
         self.points.push(to);
@@ -211,18 +213,30 @@ impl PathBuilder for Builder {
         self.sp_start = sp_end;
     }
 
-    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point) -> EndpointId {
-        flatten_quadratic_bezier(self.tolerance, self.current_position(), ctrl, to, self)
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, _: Attributes) -> EndpointId {
+        flatten_quadratic_bezier(
+            self.tolerance,
+            self.current_position(),
+            ctrl,
+            to,
+            Attributes::NONE,
+            Attributes::NONE,
+            self,
+            &mut []
+        )
     }
 
-    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point) -> EndpointId {
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, _: Attributes) -> EndpointId {
         flatten_cubic_bezier(
             self.tolerance,
             self.current_position(),
             ctrl1,
             ctrl2,
             to,
+            Attributes::NONE,
+            Attributes::NONE,
             self,
+            &mut []
         )
     }
 }

--- a/crates/tess2/src/tessellator.rs
+++ b/crates/tess2/src/tessellator.rs
@@ -2,8 +2,7 @@ use crate::flattened_path::FlattenedPath;
 use crate::geometry_builder::GeometryReceiver;
 use crate::math::*;
 use crate::path::builder::*;
-use crate::path::PathEvent;
-use crate::path::PathSlice;
+use crate::path::{PathEvent, PathSlice, Attributes};
 use crate::tessellation::{Count, FillOptions, FillRule};
 
 use std::os::raw::c_void;
@@ -55,7 +54,7 @@ impl FillTessellator {
         let mut builder = FlattenedPath::builder(options.tolerance);
 
         for evt in it {
-            builder.path_event(evt);
+            builder.path_event(evt, Attributes::NONE);
         }
 
         let flattened_path = builder.build();

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -225,7 +225,7 @@ pub use crate::geometry_builder::{
     GeometryBuilderError, StrokeGeometryBuilder, StrokeVertexConstructor, VertexBuffers,
 };
 
-pub use crate::path::{FillRule, LineJoin, LineCap, Side};
+pub use crate::path::{FillRule, LineJoin, LineCap, Side, Attributes, AttributeIndex};
 
 use crate::path::EndpointId;
 
@@ -355,7 +355,7 @@ pub struct StrokeOptions {
     /// factor to modulate the line width.
     ///
     /// Default value: `None`.
-    pub variable_line_width: Option<u32>,
+    pub variable_line_width: Option<AttributeIndex>,
 
     /// See the SVG specification.
     ///
@@ -444,8 +444,8 @@ impl StrokeOptions {
     }
 
     #[inline]
-    pub fn with_variable_line_width(mut self, attribute_index: u32) -> Self {
-        self.variable_line_width = Some(attribute_index);
+    pub fn with_variable_line_width(mut self, idx: AttributeIndex) -> Self {
+        self.variable_line_width = Some(idx);
         self
     }
 }
@@ -640,10 +640,10 @@ pub(crate) struct SimpleAttributeStore {
 }
 
 impl path::AttributeStore for SimpleAttributeStore {
-    fn get(&self, id: EndpointId) -> &[f32] {
+    fn get(&self, id: EndpointId) -> Attributes {
         let start = id.0 as usize * self.num_attributes;
         let end = start + self.num_attributes;
-        &self.data[start..end]
+        Attributes(&self.data[start..end])
     }
 
     fn num_attributes(&self) -> usize { self.num_attributes }
@@ -664,9 +664,9 @@ impl SimpleAttributeStore {
         }
     }
 
-    pub fn add(&mut self, attributes: &[f32]) -> EndpointId {
+    pub fn add(&mut self, attributes: Attributes) -> EndpointId {
         debug_assert_eq!(attributes.len(), self.num_attributes);
-        self.data.extend_from_slice(attributes);
+        self.data.extend_from_slice(attributes.as_slice());
         let id = self.next_id;
         self.next_id.0 += 1;
         id

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -633,6 +633,57 @@ impl From<VertexId> for usize {
     }
 }
 
+pub(crate) struct SimpleAttributeStore {
+    data: Vec<f32>,
+    num_attributes: usize,
+    next_id: EndpointId,
+}
+
+impl path::AttributeStore for SimpleAttributeStore {
+    fn get(&self, id: EndpointId) -> &[f32] {
+        let start = id.0 as usize * self.num_attributes;
+        let end = start + self.num_attributes;
+        &self.data[start..end]
+    }
+
+    fn num_attributes(&self) -> usize { self.num_attributes }
+}
+
+impl Default for SimpleAttributeStore {
+    fn default() -> Self {
+        SimpleAttributeStore::new(0)
+    }
+}
+
+impl SimpleAttributeStore {
+    pub fn new(num_attributes: usize) -> Self {
+        SimpleAttributeStore {
+            data: Vec::new(),
+            num_attributes,
+            next_id: EndpointId(0),
+        }
+    }
+
+    pub fn add(&mut self, attributes: &[f32]) -> EndpointId {
+        debug_assert_eq!(attributes.len(), self.num_attributes);
+        self.data.extend_from_slice(attributes);
+        let id = self.next_id;
+        self.next_id.0 += 1;
+        id
+    }
+
+    pub fn reserve(&mut self, n: usize) {
+        self.data.reserve(n * self.num_attributes);
+    }
+
+    pub fn reset(&mut self, num_attributes: usize) {
+        self.data.clear();
+        self.next_id = EndpointId(0);
+        self.num_attributes = num_attributes;
+    }
+}
+
+
 #[test]
 fn test_without_miter_limit() {
     let expected_limit = 4.0;

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -13,7 +13,7 @@ use crate::{
     SimpleAttributeStore,
 };
 use crate::{StrokeGeometryBuilder, VertexId};
-use crate::variable_stroke::VariableStrokeBuilderImpl;
+use crate::variable_stroke::{VariableStrokeBuilder, VariableStrokeBuilderImpl};
 
 /// A Context object that can tessellate stroke operations for complex paths.
 ///
@@ -275,23 +275,20 @@ impl StrokeTessellator {
         num_attributes: usize,
         options: &'l StrokeOptions,
         output: &'l mut dyn StrokeGeometryBuilder,
-    ) -> StrokeBuilder<'l> {
-        assert!(options.variable_line_width.is_none()); // TODO
+    ) -> VariableStrokeBuilder<'l> {
 
         self.builder_attrib_store.reset(num_attributes);
         self.attrib_buffer.clear();
         for _ in 0..num_attributes {
             self.attrib_buffer.push(0.0);
         }
-        StrokeBuilder {
-            builder: StrokeBuilderImpl::new(
-                options,
-                &mut self.attrib_buffer,
-                output,
-            ),
-            attrib_store: &mut self.builder_attrib_store,
-            validator: DebugValidator::new(),
-        }
+
+        VariableStrokeBuilder::new(
+            options,
+            &mut self.attrib_buffer,
+            &mut self.builder_attrib_store,
+            output,
+        )
     }
 
     /// Tessellate the stroke for a `Polygon`.

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -596,7 +596,7 @@ fn main() {
             path.iter().flattened(0.01),
             offset,
             &mut walk::RepeatedPattern {
-                callback: |pos: Point, tangent: Vector, _| {
+                callback: |event: walk::WalkerEvent| {
                     if arrow_count + num_instances as usize + 1 >= PRIM_BUFFER_LEN {
                         // Don't want to overflow the primitive buffer,
                         // just skip the remaining arrows.
@@ -604,8 +604,8 @@ fn main() {
                     }
                     cpu_primitives[arrows_prim_id as usize + arrow_count] = Primitive {
                         color: [0.7, 0.9, 0.8, 1.0],
-                        translate: (pos * 2.3 - vector(80.0, 80.0)).to_array(),
-                        angle: tangent.angle_from_x_axis().get(),
+                        translate: (event.position * 2.3 - vector(80.0, 80.0)).to_array(),
+                        angle: event.tangent.angle_from_x_axis().get(),
                         scale: 2.0,
                         z_index: arrows_prim_id as i32,
                         ..Primitive::DEFAULT


### PR DESCRIPTION
This turned into a rather large changeset. The main change is that custom attributes are now passed in the `PathBuilder` trait. As a result, all composable builders now deal with custom attributes which unlocks a lot of features when using custom attributes. The downside is that while custom attributes weren't very visible to people whoe weren't using them, they are all over the API now.