### PR TITLE
Improve the API ergonomics around PathBuilder

### DIFF
--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -6,9 +6,8 @@ extern crate tess2_sys as tess2;
 
 use lyon::extra::rust_logo::build_logo_path;
 use lyon::math::Point;
-use lyon::path::builder::*;
 use lyon::path::iterator::PathIterator;
-use lyon::path::{Path, Attributes};
+use lyon::path::Path;
 use lyon::tessellation::geometry_builder::{simple_builder, VertexBuffers};
 use lyon::tessellation::{EventQueue, FillTessellator};
 use lyon::tessellation::{FillOptions, LineJoin};
@@ -59,7 +58,7 @@ fn flattening_03_logo_builder(bench: &mut Bencher) {
         let mut builder = Path::builder().flattened(0.05);
         for _ in 0..N {
             for evt in path.iter() {
-                builder.path_event(evt, Attributes::NONE);
+                builder.path_event(evt);
             }
         }
     })

--- a/cli/src/fuzzing.rs
+++ b/cli/src/fuzzing.rs
@@ -3,8 +3,7 @@ use lyon::algorithms::hatching::*;
 use lyon::extra::debugging::find_reduced_test_case;
 use lyon::geom::LineSegment;
 use lyon::math::*;
-use lyon::path::traits::PathBuilder;
-use lyon::path::{Path, Attributes};
+use lyon::path::Path;
 use lyon::tess2;
 use lyon::tessellation::geometry_builder::NoOutput;
 use lyon::tessellation::{FillTessellator, StrokeTessellator};
@@ -117,7 +116,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
                         builder.add_line_segment(&LineSegment {
                             from: segment.a.position,
                             to: segment.b.position,
-                        }, Attributes::NONE);
+                        });
                     },
                 },
             );
@@ -134,7 +133,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
                     row_interval: dots.spacing,
                     column_interval: dots.spacing,
                     callback: &mut |dot: &Dot| {
-                        builder.add_point(dot.position, Attributes::NONE);
+                        builder.add_point(dot.position);
                     },
                 },
             );

--- a/cli/src/reduce.rs
+++ b/cli/src/reduce.rs
@@ -1,13 +1,12 @@
 use crate::commands::{TessellateCmd, Tessellator};
-use lyon::path::traits::*;
-use lyon::path::{Path, Attributes};
+use lyon::path::Path;
 use lyon::tessellation::geometry_builder::*;
 use lyon::tessellation::{FillTessellator, StrokeTessellator};
 
 pub fn reduce_testcase(cmd: TessellateCmd) {
     if let Some(options) = cmd.stroke {
         let mut flattener = Path::builder().flattened(options.tolerance);
-        flattener.extend(cmd.path.iter(), Attributes::NONE);
+        flattener.extend(cmd.path.iter());
         let path = flattener.build();
 
         lyon::extra::debugging::find_reduced_test_case(path.as_slice(), &|path: Path| {
@@ -27,7 +26,7 @@ pub fn reduce_testcase(cmd: TessellateCmd) {
 
     if let Some(options) = cmd.fill {
         let mut flattener = Path::builder().flattened(options.tolerance);
-        flattener.extend(cmd.path.iter(), Attributes::NONE);
+        flattener.extend(cmd.path.iter());
         let path = flattener.build();
 
         match cmd.tessellator {

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -14,8 +14,7 @@ use lyon::algorithms::aabb::bounding_box;
 use lyon::algorithms::hatching::*;
 use lyon::geom::LineSegment;
 use lyon::math::*;
-use lyon::path::builder::PathBuilder;
-use lyon::path::{Path, Attributes};
+use lyon::path::Path;
 use lyon::tess2;
 use lyon::tessellation;
 use lyon::tessellation::geometry_builder::*;
@@ -159,7 +158,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
                     path.add_line_segment(&LineSegment {
                         from: segment.a.position,
                         to: segment.b.position,
-                    }, Attributes::NONE);
+                    });
                 },
             },
         );
@@ -184,7 +183,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
                 row_interval: dots.spacing,
                 column_interval: dots.spacing,
                 callback: &mut |dot: &Dot| {
-                    path.add_point(dot.position, Attributes::NONE);
+                    path.add_point(dot.position);
                 },
             },
         );

--- a/crates/algorithms/src/hatching.rs
+++ b/crates/algorithms/src/hatching.rs
@@ -733,7 +733,7 @@ fn simple_hatching() {
                 hatches.add_line_segment(&LineSegment {
                     from: segment.a.position,
                     to: segment.b.position,
-                }, Attributes::NONE);
+                });
             },
         },
     );

--- a/crates/extra/src/debugging.rs
+++ b/crates/extra/src/debugging.rs
@@ -1,7 +1,6 @@
-use path::builder::*;
 use path::math::Point;
 use path::PathEvent;
-use path::{Path, PathSlice, Attributes};
+use path::{Path, PathSlice};
 
 pub type Polygons = Vec<Vec<Point>>;
 pub type PolygonsRef<'a> = &'a [Vec<Point>];
@@ -41,9 +40,9 @@ pub fn polygons_to_path(polygons: PolygonsRef) -> Path {
     let mut builder = Path::builder().flattened(0.05);
     for poly in polygons.iter() {
         let mut poly_iter = poly.iter();
-        builder.begin(*poly_iter.next().unwrap(), Attributes::NONE);
+        builder.begin(*poly_iter.next().unwrap());
         for v in poly_iter {
-            builder.line_to(*v, Attributes::NONE);
+            builder.line_to(*v);
         }
         builder.close();
     }

--- a/crates/lyon/src/lib.rs
+++ b/crates/lyon/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! ```
 //! use lyon::math::{Box2D, Point, point};
-//! use lyon::path::{builder::*, Winding, Attributes};
+//! use lyon::path::{Winding, builder::BorderRadii};
 //! use lyon::tessellation::{FillTessellator, FillOptions, VertexBuffers};
 //! use lyon::tessellation::geometry_builder::simple_builder;
 //!
@@ -102,7 +102,6 @@
 //!             bottom_right: 25.0,
 //!         },
 //!         Winding::Positive,
-//!         Attributes::NONE,
 //!     );
 //!
 //!     builder.build();

--- a/crates/tessellation/src/fill_tests.rs
+++ b/crates/tessellation/src/fill_tests.rs
@@ -1,7 +1,6 @@
 use crate::extra::rust_logo::build_logo_path;
 use crate::geometry_builder::*;
 use crate::math::*;
-use crate::path::builder::PathBuilder;
 use crate::path::{Path, PathSlice};
 use crate::{FillOptions, FillRule, FillTessellator, FillVertex, TessellationError, VertexId};
 

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -2,7 +2,7 @@ use crate::geom::utils::{normalized_tangent, tangent};
 use crate::geom::{CubicBezierSegment, Line, LineSegment, QuadraticBezierSegment};
 use crate::math::*;
 use crate::math_utils::compute_normal;
-use crate::path::builder::{Build, PathBuilder};
+use crate::path::builder::{Build, PathBuilder, NoAttributes};
 use crate::path::polygon::Polygon;
 use crate::path::private::DebugValidator;
 use crate::path::{
@@ -226,7 +226,6 @@ impl StrokeTessellator {
     /// ```rust
     /// use lyon_tessellation::{StrokeTessellator, StrokeOptions};
     /// use lyon_tessellation::geometry_builder::{simple_builder, VertexBuffers};
-    /// use lyon_tessellation::path::{traits::*, Attributes};
     /// use lyon_tessellation::math::{Point, point};
     ///
     /// let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
@@ -239,10 +238,10 @@ impl StrokeTessellator {
     ///
     /// // Build the path directly in the tessellator, skipping an intermediate data
     /// // structure.
-    /// builder.begin(point(0.0, 0.0), Attributes::NONE);
-    /// builder.line_to(point(10.0, 0.0), Attributes::NONE);
-    /// builder.line_to(point(10.0, 10.0), Attributes::NONE);
-    /// builder.line_to(point(0.0, 10.0), Attributes::NONE);
+    /// builder.begin(point(0.0, 0.0));
+    /// builder.line_to(point(10.0, 0.0));
+    /// builder.line_to(point(10.0, 10.0));
+    /// builder.line_to(point(0.0, 10.0));
     /// builder.end(true);
     ///
     /// // Finish the tessellation and get the result.
@@ -254,16 +253,16 @@ impl StrokeTessellator {
         &'l mut self,
         options: &'l StrokeOptions,
         output: &'l mut dyn StrokeGeometryBuilder,
-    ) -> StrokeBuilder<'l> {
+    ) -> NoAttributes<StrokeBuilder<'l>> {
         assert!(options.variable_line_width.is_none()); // TODO
 
         self.builder_attrib_store.reset(0);
         self.attrib_buffer.clear();
-        StrokeBuilder {
+        NoAttributes::wrap(StrokeBuilder {
             builder: StrokeBuilderImpl::new(options, &mut self.attrib_buffer, output),
             attrib_store: &mut self.builder_attrib_store,
             validator: DebugValidator::new(),
-        }
+        })
     }
 
     /// Tessellate directly from a sequence of `PathBuilder` commands, without
@@ -311,7 +310,7 @@ impl StrokeTessellator {
         assert!(options.variable_line_width.is_none());
 
         let mut builder = self.builder(options, output);
-        builder.add_rectangle(rect, Winding::Positive, Attributes::NONE);
+        builder.add_rectangle(rect, Winding::Positive);
 
         builder.build()
     }
@@ -325,7 +324,7 @@ impl StrokeTessellator {
         output: &mut dyn StrokeGeometryBuilder,
     ) -> TessellationResult {
         let mut builder = self.builder(options, output);
-        builder.add_circle(center, radius, Winding::Positive, Attributes::NONE);
+        builder.add_circle(center, radius, Winding::Positive);
 
         builder.build()
     }
@@ -341,7 +340,7 @@ impl StrokeTessellator {
         output: &mut dyn StrokeGeometryBuilder,
     ) -> TessellationResult {
         let mut builder = self.builder(options, output);
-        builder.add_ellipse(center, radii, x_rotation, winding, Attributes::NONE);
+        builder.add_ellipse(center, radii, x_rotation, winding);
 
         builder.build()
     }
@@ -399,23 +398,14 @@ impl<'l> StrokeBuilder<'l> {
     #[inline]
     pub fn set_miter_limit(&mut self, limit: f32) {
         self.builder.options.miter_limit = limit;
-    }    
-}
-
-impl<'l> Build for StrokeBuilder<'l> {
-    type PathType = TessellationResult;
-
-    fn build(self) -> TessellationResult {
-        self.builder.build()
     }
-}
 
-impl<'l> PathBuilder for StrokeBuilder<'l> {
-    fn num_attributes(&self) -> usize {
+    #[inline]
+    pub fn num_attributes(&self) -> usize {
         self.attrib_store.num_attributes()
     }
 
-    fn begin(&mut self, to: Point, attributes: Attributes) -> EndpointId {
+    pub fn begin(&mut self, to: Point, attributes: Attributes) -> EndpointId {
         self.validator.begin();
         let id = self.attrib_store.add(attributes);
         self.builder.begin(to, id);
@@ -423,12 +413,12 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         id
     }
 
-    fn end(&mut self, close: bool) {
+    pub fn end(&mut self, close: bool) {
         self.validator.end();
         self.builder.end(close, self.attrib_store);
     }
 
-    fn line_to(&mut self, to: Point, attributes: Attributes) -> EndpointId {
+    pub fn line_to(&mut self, to: Point, attributes: Attributes) -> EndpointId {
         let id = self.attrib_store.add(attributes);
         self.validator.edge();
         self.builder.edge_to(to, id, 1.0, true, self.attrib_store);
@@ -436,7 +426,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         id
     }
 
-    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, attributes: Attributes) -> EndpointId {
+    pub fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, attributes: Attributes) -> EndpointId {
         self.validator.edge();
         let id = self.attrib_store.add(attributes);
         self.builder.quadratic_bezier_to(ctrl, to, id, self.attrib_store);
@@ -444,7 +434,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         id
     }
 
-    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, attributes: Attributes) -> EndpointId {
+    pub fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, attributes: Attributes) -> EndpointId {
         self.validator.edge();
         let id = self.attrib_store.add(attributes);
         self.builder.cubic_bezier_to(ctrl1, ctrl2, to, id, self.attrib_store);
@@ -452,7 +442,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         id
     }
 
-    fn add_rectangle(&mut self, rect: &Box2D, winding: Winding, attributes: Attributes) {
+    pub fn add_rectangle(&mut self, rect: &Box2D, winding: Winding, attributes: Attributes) {
         // The thin rectangle approximation for works best with miter joins. We
         // only use it with other joins if the rectangle is much smaller than the
         // line width.
@@ -492,6 +482,48 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
                 attributes,
             ),
         };
+    }
+
+    pub fn build(self) -> TessellationResult {
+        self.builder.build()
+    }
+}
+
+impl<'l> Build for StrokeBuilder<'l> {
+    type PathType = TessellationResult;
+
+    fn build(self) -> TessellationResult {
+        self.builder.build()
+    }
+}
+
+impl<'l> PathBuilder for StrokeBuilder<'l> {
+    fn num_attributes(&self) -> usize {
+        self.num_attributes()
+    }
+
+    fn begin(&mut self, to: Point, attributes: Attributes) -> EndpointId {
+        self.begin(to, attributes)
+    }
+
+    fn end(&mut self, close: bool) {
+        self.end(close)
+    }
+
+    fn line_to(&mut self, to: Point, attributes: Attributes) -> EndpointId {
+        self.line_to(to, attributes)
+    }
+
+    fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point, attributes: Attributes) -> EndpointId {
+        self.quadratic_bezier_to(ctrl, to, attributes)
+    }
+
+    fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point, attributes: Attributes) -> EndpointId {
+        self.cubic_bezier_to(ctrl1, ctrl2, to, attributes)
+    }
+
+    fn add_rectangle(&mut self, rect: &Box2D, winding: Winding, attributes: Attributes) {
+        self.add_rectangle(rect, winding, attributes)
     }
 }
 
@@ -1749,9 +1781,9 @@ fn test_empty_path() {
 fn test_empty_caps() {
     let mut builder = Path::builder();
 
-    builder.add_point(point(1.0, 0.0), Attributes::NONE);
-    builder.add_point(point(2.0, 0.0), Attributes::NONE);
-    builder.add_point(point(3.0, 0.0), Attributes::NONE);
+    builder.add_point(point(1.0, 0.0));
+    builder.add_point(point(2.0, 0.0));
+    builder.add_point(point(3.0, 0.0));
 
     let path = builder.build();
 


### PR DESCRIPTION
Add two wrapper types `NoAttributes<B>` and `WithAttributes<B>` that reexpose the `PathBuilder` API, the former without taking the `Attributes` argument. Their other advantage is that they can be used without importing `PathBuilder` into scope.

The downside is that some types become a bit messy, for example `path::Builder` becomes an alias to `path::NoAttributes<BuilderImpl>` which makes the docs a bit less clear.

I might remove `WithAttributes<B>` since its only purpose is to avoid having to import `PathBuilder` which is not that big of a deal. 