### PR TITLE
Allow flattening bézier curves excluding the endpoints

### DIFF
--- a/crates/geom/src/cubic_bezier.rs
+++ b/crates/geom/src/cubic_bezier.rs
@@ -412,15 +412,25 @@ impl<S: Scalar> CubicBezierSegment<S> {
         cubic_to_monotonic_quadratics(self, tolerance, cb);
     }
 
-    /// Iterates through the curve invoking a callback at each point.
+    /// Compute a flattened approximation of the curve, invoking a callback at
+    /// each step.
     pub fn for_each_flattened<F: FnMut(Point<S>)>(&self, tolerance: S, callback: &mut F) {
-        flatten_cubic_bezier_with_t(self, tolerance, &mut |point, _| {
-            callback(point);
-        });
+        flatten_cubic_bezier_with_t(self, tolerance, &mut |point, _| callback(point));
+
+        callback(self.to);
     }
 
-    /// Iterates through the curve invoking a callback at each point.
+    /// Compute a flattened approximation of the curve, invoking a callback at
+    /// each step, including the final endpoint.
     pub fn for_each_flattened_with_t<F: FnMut(Point<S>, S)>(&self, tolerance: S, callback: &mut F) {
+        flatten_cubic_bezier_with_t(self, tolerance, callback);
+
+        callback(self.to, S::ONE);
+    }
+
+    /// Compute a flattened approximation of the curve, invoking a callback at
+    /// each step, excluding the final endpoint.
+    pub fn for_each_flattened_with_t_intermediate<F: FnMut(Point<S>, S)>(&self, tolerance: S, callback: &mut F) {
         flatten_cubic_bezier_with_t(self, tolerance, callback);
     }
 

--- a/crates/geom/src/flatten_cubic.rs
+++ b/crates/geom/src/flatten_cubic.rs
@@ -53,7 +53,7 @@ pub fn flatten_cubic_bezier_with_t<S: Scalar, F>(
 
     // Do the last step manually to make sure we finish at t = 1.0 exactly.
     let quadratic = single_curve_approximation(&curve.split_range(t0..S::ONE));
-    quadratic.for_each_flattened_with_t(flattening_tolerance, &mut |point, t_sub| {
+    quadratic.for_each_flattened_with_t_intermediate(flattening_tolerance, &mut |point, t_sub| {
         let t = t0 + step * t_sub;
         callback(point, t);
     });


### PR DESCRIPTION
In some cases the endpoints need separate logic, in which case it's more convenient to have flattening methods that stop before the endpoint than to compare t at each step.