### PR TITLE
Fix the triangle winding issue

### DIFF
--- a/crates/tessellation/src/geometry_builder.rs
+++ b/crates/tessellation/src/geometry_builder.rs
@@ -373,7 +373,7 @@ impl<B: GeometryBuilder> GeometryBuilder for OffsetVertices<B> {
 
     fn add_triangle(&mut self, a: VertexId, b: VertexId, c: VertexId) {
         // Invert the triangle winding by flipping b and c.
-        self.0.add_triangle(a + self.1, c + self.1, b + self.1);
+        self.0.add_triangle(a + self.1, b + self.1, c + self.1);
     }
 
     fn abort_geometry(&mut self) {


### PR DESCRIPTION
 and deal with stroking sharp turns in quadratic béziers in more cases.

The triangle winding issue wasn't actually in the tessellators, but in the With_vertex_offset adapter fro BuffersBuilder.