### PR TITLE
Remove Count

### DIFF
--- a/crates/tess2/src/tessellator.rs
+++ b/crates/tess2/src/tessellator.rs
@@ -3,7 +3,7 @@ use crate::geometry_builder::GeometryReceiver;
 use crate::math::*;
 use crate::path::builder::*;
 use crate::path::{Attributes, PathEvent, PathSlice};
-use crate::tessellation::{Count, FillOptions, FillRule};
+use crate::tessellation::{FillOptions, FillRule};
 
 use std::os::raw::c_void;
 use std::ptr;
@@ -47,7 +47,7 @@ impl FillTessellator {
         it: Iter,
         options: &FillOptions,
         output: &mut dyn GeometryReceiver,
-    ) -> Result<Count, TessellationError>
+    ) -> Result<(), TessellationError>
     where
         Iter: IntoIterator<Item = PathEvent>,
     {
@@ -68,7 +68,7 @@ impl FillTessellator {
         path: &FlattenedPath,
         options: &FillOptions,
         output: &mut dyn GeometryReceiver,
-    ) -> Result<Count, TessellationError> {
+    ) -> Result<(), TessellationError> {
         self.prepare_path(path);
 
         if !self.do_tessellate(options) {
@@ -84,7 +84,7 @@ impl FillTessellator {
         path: impl Into<PathSlice<'l>>,
         options: &'l FillOptions,
         output: &mut dyn GeometryReceiver,
-    ) -> Result<Count, TessellationError> {
+    ) -> Result<(), TessellationError> {
         self.tessellate(path.into().iter(), options, output)
     }
 
@@ -124,7 +124,7 @@ impl FillTessellator {
         }
     }
 
-    fn process_output(&mut self, output: &mut dyn GeometryReceiver) -> Count {
+    fn process_output(&mut self, output: &mut dyn GeometryReceiver) {
         unsafe {
             let num_indices = tessGetElementCount(self.tess) as usize * 3;
             let num_vertices = tessGetElementCount(self.tess) as usize;
@@ -135,11 +135,6 @@ impl FillTessellator {
                 slice::from_raw_parts(tessGetElements(self.tess) as *const u32, num_indices);
 
             output.set_geometry(vertices, indices);
-
-            Count {
-                vertices: num_indices as u32,
-                indices: num_indices as u32,
-            }
         }
     }
 }

--- a/crates/tessellation/src/basic_shapes.rs
+++ b/crates/tessellation/src/basic_shapes.rs
@@ -201,7 +201,7 @@ fn fill_border_radius(
 
 #[test]
 fn basic_shapes() {
-    use crate::{Count, GeometryBuilderError};
+    use crate::{GeometryBuilderError};
 
     let mut tess = crate::FillTessellator::new();
 
@@ -228,14 +228,6 @@ fn basic_shapes() {
     }
 
     impl crate::GeometryBuilder for Builder {
-        fn begin_geometry(&mut self) {}
-        fn end_geometry(&mut self) -> Count {
-            Count {
-                vertices: self.next_vertex,
-                indices: 0,
-            }
-        }
-        fn abort_geometry(&mut self) {}
         fn add_triangle(&mut self, _: VertexId, _: VertexId, _: VertexId) {}
     }
 

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -2686,13 +2686,6 @@ fn fill_vertex_source_01() {
     }
 
     impl GeometryBuilder for CheckVertexSources {
-        fn begin_geometry(&mut self) {}
-        fn end_geometry(&mut self) -> Count {
-            Count {
-                vertices: self.next_vertex,
-                indices: 0,
-            }
-        }
         fn abort_geometry(&mut self) {}
         fn add_triangle(&mut self, _: VertexId, _: VertexId, _: VertexId) {}
     }
@@ -2797,14 +2790,6 @@ fn fill_vertex_source_02() {
     }
 
     impl GeometryBuilder for CheckVertexSources {
-        fn begin_geometry(&mut self) {}
-        fn end_geometry(&mut self) -> Count {
-            Count {
-                vertices: self.next_vertex,
-                indices: 0,
-            }
-        }
-        fn abort_geometry(&mut self) {}
         fn add_triangle(&mut self, _: VertexId, _: VertexId, _: VertexId) {}
     }
 
@@ -2956,14 +2941,6 @@ fn fill_vertex_source_03() {
     }
 
     impl GeometryBuilder for CheckVertexSources {
-        fn begin_geometry(&mut self) {}
-        fn end_geometry(&mut self) -> Count {
-            Count {
-                vertices: self.next_vertex,
-                indices: 0,
-            }
-        }
-        fn abort_geometry(&mut self) {}
         fn add_triangle(&mut self, _: VertexId, _: VertexId, _: VertexId) {}
     }
 
@@ -3008,14 +2985,6 @@ fn fill_builder_vertex_source() {
     }
 
     impl GeometryBuilder for CheckVertexSources {
-        fn begin_geometry(&mut self) {}
-        fn end_geometry(&mut self) -> Count {
-            Count {
-                vertices: self.next_vertex,
-                indices: 0,
-            }
-        }
-        fn abort_geometry(&mut self) {}
         fn add_triangle(&mut self, _: VertexId, _: VertexId, _: VertexId) {}
     }
 

--- a/crates/tessellation/src/fill_tests.rs
+++ b/crates/tessellation/src/fill_tests.rs
@@ -35,15 +35,7 @@ fn test_too_many_vertices() {
         max_vertices: u32,
     }
     impl GeometryBuilder for Builder {
-        fn begin_geometry(&mut self) {}
         fn add_triangle(&mut self, _a: VertexId, _b: VertexId, _c: VertexId) {}
-        fn end_geometry(&mut self) -> Count {
-            Count {
-                vertices: 0,
-                indices: 0,
-            }
-        }
-        fn abort_geometry(&mut self) {}
     }
 
     impl FillGeometryBuilder for Builder {
@@ -2464,7 +2456,7 @@ fn issue_674() {
 
 #[test]
 fn test_triangle_winding() {
-    use crate::math::{point, Point};
+    use crate::math::Point;
     use crate::extra::rust_logo::build_logo_path;
     use crate::GeometryBuilder;
 
@@ -2473,14 +2465,6 @@ fn test_triangle_winding() {
     }
 
     impl GeometryBuilder for Builder {
-        fn begin_geometry(&mut self) {}
-        fn abort_geometry(&mut self) {}
-        fn end_geometry(&mut self) -> Count {
-            Count {
-                vertices: 0,
-                indices: 0,
-            }
-        }
         fn add_triangle(&mut self, a: VertexId, b: VertexId, c: VertexId) {
             let a = self.vertices[a.to_usize()];
             let b = self.vertices[b.to_usize()];
@@ -2505,5 +2489,5 @@ fn test_triangle_winding() {
     let mut tess = FillTessellator::new();
     let options = FillOptions::tolerance(0.05);
 
-    tess.tessellate(&path, &options, &mut Builder { vertices: Vec::new() });
+    tess.tessellate(&path, &options, &mut Builder { vertices: Vec::new() }).unwrap();
 }

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -220,7 +220,7 @@ pub use crate::stroke::*;
 
 #[doc(inline)]
 pub use crate::geometry_builder::{
-    BuffersBuilder, Count, FillGeometryBuilder, FillVertexConstructor, GeometryBuilder,
+    BuffersBuilder, FillGeometryBuilder, FillVertexConstructor, GeometryBuilder,
     GeometryBuilderError, StrokeGeometryBuilder, StrokeVertexConstructor, VertexBuffers,
 };
 
@@ -232,7 +232,7 @@ use std::ops::{Add, Sub};
 use std::u32;
 
 /// The fill tessellator's result type.
-pub type TessellationResult = Result<Count, TessellationError>;
+pub type TessellationResult = Result<(), TessellationError>;
 
 /// Describes an unexpected error happening during tessellation.
 ///


### PR DESCRIPTION
It's that useful because users can look at the vertex and index count before/after tessellating, and it doesn't always make sense (for example when doing some sort of clustering scheme or producing the output in some other fancy format.