### PR TITLE
for_each_x/y_monotonic

### DIFF
--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -383,7 +383,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
         F: FnMut(S),
     {
         let mut t0 = self.local_x_extremum_t();
-        let mut t1 = self.local_x_extremum_t();
+        let mut t1 = self.local_y_extremum_t();
 
         let swap = match (t0, t1) {
             (None, Some(_)) => true,


### PR DESCRIPTION
- Add a few methods to split curves into x or y-monotonic sub-curves.
- Remove for_each_monotonic_t which is a bit confusing since it is only called between sub-sucrves.
