### PR TITLE
Better quadratic bézier length computation.

### DIFF
--- a/crates/geom/src/cubic_bezier.rs
+++ b/crates/geom/src/cubic_bezier.rs
@@ -592,14 +592,13 @@ impl<S: Scalar> CubicBezierSegment<S> {
 
     /// Compute the length of the segment using a flattened approximation.
     pub fn approximate_length(&self, tolerance: S) -> S {
-        let mut from = self.from;
-        let mut len = S::ZERO;
-        self.for_each_flattened(tolerance, &mut |to| {
-            len += (to - from).length();
-            from = to;
+        let mut length = S::ZERO;
+
+        self.for_each_quadratic_bezier(tolerance, &mut|quad| {
+            length += quad.length();
         });
 
-        len
+        length
     }
 
     /// Invokes a callback at each inflection point if any.
@@ -1271,7 +1270,6 @@ impl<S: Scalar> CubicBezierSegment<S> {
             to: self.to,
         }
     }
-
 }
 
 impl<S: Scalar> Segment for CubicBezierSegment<S> {


### PR DESCRIPTION
Credit goes to Raph Levien for the work he put into building a fast and precise solution to this problem, described in https://raphlinus.github.io/curves/2018/12/28/bezier-arclength.html

This commit is mostly a port of Raph's implementation in kurbo.