### PR TITLE
Improve the flattening APIs

### DIFF
--- a/crates/algorithms/src/hit_test.rs
+++ b/crates/algorithms/src/hit_test.rs
@@ -59,15 +59,8 @@ where
                 if min > point.y || max < point.y {
                     continue;
                 }
-                let mut prev = segment.from;
-                segment.for_each_flattened(tolerance, &mut |p| {
-                    test_segment(
-                        *point,
-                        &LineSegment { from: prev, to: p },
-                        &mut winding,
-                        &mut prev_winding,
-                    );
-                    prev = p;
+                segment.for_each_flattened(tolerance, &mut |line| {
+                    test_segment(*point, line, &mut winding, &mut prev_winding);
                 });
             }
             PathEvent::Cubic {
@@ -86,15 +79,8 @@ where
                 if min > point.y || max < point.y {
                     continue;
                 }
-                let mut prev = segment.from;
-                segment.for_each_flattened(tolerance, &mut |p| {
-                    test_segment(
-                        *point,
-                        &LineSegment { from: prev, to: p },
-                        &mut winding,
-                        &mut prev_winding,
-                    );
-                    prev = p;
+                segment.for_each_flattened(tolerance, &mut |line| {
+                    test_segment(*point, line, &mut winding, &mut prev_winding);
                 });
             }
         }

--- a/crates/algorithms/src/raycast.rs
+++ b/crates/algorithms/src/raycast.rs
@@ -55,10 +55,8 @@ where
                 );
             }
             PathEvent::Quadratic { from, ctrl, to } => {
-                let mut prev = from;
-                QuadraticBezierSegment { from, ctrl, to }.for_each_flattened(tolerance, &mut |p| {
-                    test_segment(&mut state, &LineSegment { from: prev, to: p });
-                    prev = p;
+                QuadraticBezierSegment { from, ctrl, to }.for_each_flattened(tolerance, &mut |line| {
+                    test_segment(&mut state, line);
                 });
             }
             PathEvent::Cubic {
@@ -67,16 +65,14 @@ where
                 ctrl2,
                 to,
             } => {
-                let mut prev = from;
                 CubicBezierSegment {
                     from,
                     ctrl1,
                     ctrl2,
                     to,
                 }
-                .for_each_flattened(tolerance, &mut |p| {
-                    test_segment(&mut state, &LineSegment { from: prev, to: p });
-                    prev = p;
+                .for_each_flattened(tolerance, &mut |line| {
+                    test_segment(&mut state, line);
                 });
             }
         }

--- a/crates/algorithms/src/walk.rs
+++ b/crates/algorithms/src/walk.rs
@@ -242,8 +242,8 @@ impl<'l> PathWalker<'l> {
             ctrl,
             to,
         };
-        curve.for_each_flattened_with_t(self.tolerance, &mut |p, t| {
-            self.edge(p, t, attributes);
+        curve.for_each_flattened_with_t(self.tolerance, &mut |line, t| {
+            self.edge(line.to, t.end, attributes);
         });
 
         self.prev_attributes.copy_from_slice(attributes.as_slice());
@@ -265,8 +265,8 @@ impl<'l> PathWalker<'l> {
             to,
         };
 
-        curve.for_each_flattened_with_t(self.tolerance, &mut |p, t| {
-            self.edge(p, t, attributes);
+        curve.for_each_flattened_with_t(self.tolerance, &mut |line, t| {
+            self.edge(line.to, t.end, attributes);
         });
 
         self.prev_attributes.copy_from_slice(attributes.as_slice());

--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -951,26 +951,24 @@ impl<'l> IterWithAttributes<'l> {
                         ctrl,
                         to: to.0,
                     };
-                    let mut prev_pos = from.0;
                     let mut offset = num_attributes;
                     buffer[0..num_attributes].copy_from_slice(from_attr.as_slice());
-                    curve.for_each_flattened_with_t(tolerance, &mut |pos, t| {
+                    curve.for_each_flattened_with_t(tolerance, &mut |line, t| {
                         for i in 0..num_attributes {
-                            buffer[offset + i] = (1.0 - t) * from_attr[i] + t * to_attr[i];
+                            buffer[offset + i] = (1.0 - t.end) * from_attr[i] + t.end * to_attr[i];
                         }
 
                         let next_offset = if offset == 0 { num_attributes } else { 0 };
 
                         callback(&Event::Line {
                             from: (
-                                prev_pos,
+                                line.from,
                                 Attributes(&buffer[next_offset..(next_offset + num_attributes)]),
                             ),
-                            to: (pos, Attributes(&buffer[offset..(offset + num_attributes)])),
+                            to: (line.to, Attributes(&buffer[offset..(offset + num_attributes)])),
                         });
 
                         offset = next_offset;
-                        prev_pos = pos;
                     });
                 }
                 Event::Cubic {
@@ -987,26 +985,24 @@ impl<'l> IterWithAttributes<'l> {
                         ctrl2,
                         to: to.0,
                     };
-                    let mut prev_pos = from.0;
                     let mut offset = num_attributes;
                     buffer[0..num_attributes].copy_from_slice(from_attr.as_slice());
-                    curve.for_each_flattened_with_t(tolerance, &mut |pos, t| {
+                    curve.for_each_flattened_with_t(tolerance, &mut |line, t| {
                         for i in 0..num_attributes {
-                            buffer[offset + i] = (1.0 - t) * from_attr[i] + t * to_attr[i];
+                            buffer[offset + i] = (1.0 - t.end) * from_attr[i] + t.end * to_attr[i];
                         }
 
                         let next_offset = if offset == 0 { num_attributes } else { 0 };
 
                         callback(&Event::Line {
                             from: (
-                                prev_pos,
+                                line.from,
                                 Attributes(&buffer[next_offset..(next_offset + num_attributes)]),
                             ),
-                            to: (pos, Attributes(&buffer[offset..(offset + num_attributes)])),
+                            to: (line.to, Attributes(&buffer[offset..(offset + num_attributes)])),
                         });
 
                         offset = next_offset;
-                        prev_pos = pos;
                     });
                 }
             }

--- a/crates/path/src/private.rs
+++ b/crates/path/src/private.rs
@@ -78,16 +78,16 @@ pub fn flatten_quadratic_bezier(
     let curve = QuadraticBezierSegment { from, ctrl, to };
     let n = attributes.len();
     let mut id = EndpointId::INVALID;
-    curve.for_each_flattened_with_t(tolerance, &mut |point, t| {
-        let attr = if t == 1.0 {
+    curve.for_each_flattened_with_t(tolerance, &mut |line, t| {
+        let attr = if t.end == 1.0 {
             attributes
         } else {
             for i in 0..n {
-                buffer[i] = prev_attributes[i] * (1.0 - t) + attributes[i] * t;
+                buffer[i] = prev_attributes[i] * (1.0 - t.end) + attributes[i] * t.end;
             }
             Attributes(&buffer[..])
         };
-        id = builder.line_to(point, attr);
+        id = builder.line_to(line.to, attr);
     });
 
     id
@@ -112,16 +112,16 @@ pub fn flatten_cubic_bezier(
     };
     let n = attributes.len();
     let mut id = EndpointId::INVALID;
-    curve.for_each_flattened_with_t(tolerance, &mut |point, t| {
-        let attr = if t == 1.0 {
+    curve.for_each_flattened_with_t(tolerance, &mut |line, t| {
+        let attr = if t.end == 1.0 {
             attributes
         } else {
             for i in 0..n {
-                buffer[i] = prev_attributes[i] * (1.0 - t) + attributes[i] * t;
+                buffer[i] = prev_attributes[i] * (1.0 - t.end) + attributes[i] * t.end;
             }
             Attributes(&buffer[..])
         };
-        id = builder.line_to(point, attr);
+        id = builder.line_to(line.to, attr);
     });
 
     id

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -1,6 +1,5 @@
 use lyon::extra::rust_logo::build_logo_path;
 use lyon::math::*;
-use lyon::path::iterator::PathIterator;
 use lyon::path::Path;
 use lyon::tessellation;
 use lyon::tessellation::geometry_builder::*;


### PR DESCRIPTION
Code that looked like

```
let mut t0 = 0.0;
let mut from = curve.from;
curve.for_each_flattened_with_t(0.1, &mut|to, t1| {
    do_something(from, to, t0, t1);
    t0 = t1;
    from = to;
});
```

Now looks like:

```
curve.for_each_flattened_with_t(0.1, &mut |segment, t| {
    do_something(segment.from, segment.to, t.start, t.end);
});
```

It was a common pattern to keep track of the previous step to get the
start of the flattened line segment, it is now provided directly.
Incidentally, this came with a minor but consistent speedup on the
tessellation benchmarks.