### PR TITLE
Improve the precision of the path walker

### DIFF
--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -606,7 +606,7 @@ fn main() {
         walk::walk_along_path(
             path.iter(),
             offset,
-            0.01,
+            0.1,
             &mut walk::RepeatedPattern {
                 callback: |event: walk::WalkerEvent| {
                     if arrow_count + num_instances as usize + 1 >= PRIM_BUFFER_LEN {


### PR DESCRIPTION
Before this commit, the path walker was positionning and orienting its events along the flattened approximation of the path.

Now events are reprojected on the path and the direction is analytically computed, so positions are always exactly on the path and the tolerance theshold only affects the precision of the walking distances.