### PR TITLE
Provide access to a path's first and last endpoint

### DIFF
--- a/crates/path/src/path_buffer.rs
+++ b/crates/path/src/path_buffer.rs
@@ -219,6 +219,7 @@ impl<'l> Builder<'l> {
             builder: path::BuilderWithAttributes {
                 builder: self.builder.into_inner(),
                 num_attributes,
+                first_attributes: vec![0.0; num_attributes],
             },
             points_start: self.points_start,
             verbs_start: self.verbs_start,
@@ -363,6 +364,7 @@ impl<'l> BuilderWithAttributes<'l> {
             builder: path::BuilderWithAttributes {
                 builder,
                 num_attributes,
+                first_attributes: vec![0.0; num_attributes],
             },
             points_start,
             verbs_start,


### PR DESCRIPTION
In order to do that the close operation now pushes the start of the the sub-path at the end of the point buffer. An added benefit is that reverse_path now starts closed sub-paths where it was closed instead of at the last endpoint before that, which makes more sense.