### PR TITLE
Fix a bug in StrokeBuilder and a typo in PathMeasure.

### DIFF
--- a/crates/algorithms/src/measure.rs
+++ b/crates/algorithms/src/measure.rs
@@ -39,8 +39,8 @@ use crate::path::{
 use std::ops::Range;
 
 #[doc(hidden)]
-pub struct EmptyAttribtueStore;
-impl AttributeStore for EmptyAttribtueStore {
+pub struct EmptyAttributeStore;
+impl AttributeStore for EmptyAttributeStore {
     fn get(&self, _: EndpointId) -> Attributes {
         Attributes::NONE
     }
@@ -525,16 +525,16 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
     }
 }
 
-impl<'l, PS: PositionStore> PathMeasure<'l, PS, EmptyAttribtueStore> {
+impl<'l, PS: PositionStore> PathMeasure<'l, PS, EmptyAttributeStore> {
     pub fn new<Iter>(path: Iter, tolerance: f32, points: &'l PS) -> Self
     where
         Iter: IntoIterator<Item = IdEvent>,
     {
-        Self::with_attributes(0, path, tolerance, points, &EmptyAttribtueStore)
+        Self::with_attributes(0, path, tolerance, points, &EmptyAttributeStore)
     }
 }
 
-impl<'l> PathMeasure<'l, Path, EmptyAttribtueStore> {
+impl<'l> PathMeasure<'l, Path, EmptyAttributeStore> {
     #[must_use]
     pub fn from_path(path: &'l Path, tolerance: f32) -> Self {
         Self::new(path.id_iter(), tolerance, path)
@@ -547,7 +547,7 @@ impl<'l> PathMeasure<'l, Path, Path> {
     }
 }
 
-impl<'l> PathMeasure<'l, PathSlice<'l>, EmptyAttribtueStore> {
+impl<'l> PathMeasure<'l, PathSlice<'l>, EmptyAttributeStore> {
     pub fn from_slice(path: &'l PathSlice, tolerance: f32) -> Self {
         Self::new(path.id_iter(), tolerance, path)
     }

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -413,8 +413,10 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         if let Some(attrib_index) = self.builder.options.variable_line_width {
             let width = self.builder.options.line_width * attributes[attrib_index];
             self.builder.begin(to, id, width, self.attrib_store);
+            self.prev = (to, id, width);
         } else {
             self.builder.begin_fw(to, id, self.attrib_store);
+            self.prev = (to, id, self.builder.options.line_width);
         }
 
         id


### PR DESCRIPTION
In `StrokeBuilder`, `prev` is not set in `begin`. This could lead to unexpected behavior. For example, `StrokeTessellator::tessellate_circle` would call `begin`, `cubic_bezier_to` and so on sequently. If `prev` is not set after `begin` is called, the start point of the cubic bezier would be undefined and it indeed resulted in weird outcomes in my test.

BTW, a typo in my recent pr is fixed.