### PR TITLE
Fix a bug in StrokeBuilder.

### DIFF
--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -413,8 +413,10 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         if let Some(attrib_index) = self.builder.options.variable_line_width {
             let width = self.builder.options.line_width * attributes[attrib_index];
             self.builder.begin(to, id, width, self.attrib_store);
+            self.prev = (to, id, width);
         } else {
             self.builder.begin_fw(to, id, self.attrib_store);
+            self.prev = (to, id, self.builder.options.line_width);
         }
 
         id


### PR DESCRIPTION
In `StrokeBuilder`, `prev` is not set in `begin`. This could lead to unexpected behavior. For example, `StrokeTessellator::tessellate_circle` would call `begin`, `cubic_bezier_to` and so on sequently. If `prev` is not set after `begin` is called, the start point of the cubic bezier would be undefined and it indeed resulted in weird outcomes in my test.

Since I'm unfamiliar with git so I just closed my last pr to open a new one.