### PR TITLE
Refactor the PathMeasure API

### DIFF
--- a/cli/src/reduce.rs
+++ b/cli/src/reduce.rs
@@ -6,7 +6,9 @@ use lyon::tessellation::{FillTessellator, StrokeTessellator};
 pub fn reduce_testcase(cmd: TessellateCmd) {
     if let Some(options) = cmd.stroke {
         let mut flattener = Path::builder().flattened(options.tolerance);
-        flattener.extend(cmd.path.iter());
+        for evt in cmd.path.iter() {
+            flattener.path_event(evt);
+        }
         let path = flattener.build();
 
         lyon::extra::debugging::find_reduced_test_case(path.as_slice(), &|path: Path| {
@@ -26,7 +28,9 @@ pub fn reduce_testcase(cmd: TessellateCmd) {
 
     if let Some(options) = cmd.fill {
         let mut flattener = Path::builder().flattened(options.tolerance);
-        flattener.extend(cmd.path.iter());
+        for evt in cmd.path.iter() {
+            flattener.path_event(evt);
+        }
         let path = flattener.build();
 
         lyon::extra::debugging::find_reduced_test_case(path.as_slice(), &|path: Path| {

--- a/crates/algorithms/src/measure.rs
+++ b/crates/algorithms/src/measure.rs
@@ -1,53 +1,18 @@
 //! Perform cached measurements and split operations on a path.
 //!
-//! # Path measuring
-//!
-//! ## Example
-//!
-//! ```
-//! use lyon_algorithms::math::point;
-//! use lyon_algorithms::path::Path;
-//! use lyon_algorithms::{
-//!     length::approximate_length,
-//!     measure::{MeasureResult, PathMeasure},
-//! };
-//!
-//! fn main() {
-//!     let mut path = Path::builder();
-//!     path.begin(point(0.0, 0.0));
-//!     path.quadratic_bezier_to(point(1.0, 1.0), point(2.0, 0.0));
-//!     path.end(false);
-//!     let path = path.build();
-//!     let mut measure = PathMeasure::from_path(&path, 1e-3);
-//!
-//!     let MeasureResult {
-//!         position, tangent, ..
-//!     } = measure.measure(0.5);
-//!     println!("Mid-point position: {:?}, tangent: {:?}", position, tangent);
-//!
-//!     let last_half = measure.split(0.5..1.0);
-//!     assert!((measure.length() / 2.0 - approximate_length(&last_half, 1e-3)).abs() < 1e-3);
-//! }
-//! ```
-//!
 use crate::geom::{CubicBezierSegment, LineSegment, QuadraticBezierSegment, Segment};
 use crate::math::*;
 use crate::path::{
-    path::BuilderWithAttributes, AttributeStore, Attributes, EndpointId, IdEvent, Path, PathSlice,
+    builder::PathBuilder, AttributeStore, Attributes, EndpointId, IdEvent, Path, PathSlice,
     PositionStore,
 };
 use std::ops::Range;
 
-#[doc(hidden)]
-pub struct EmptyAttribtueStore;
-impl AttributeStore for EmptyAttribtueStore {
-    fn get(&self, _: EndpointId) -> Attributes {
-        Attributes::NONE
-    }
-
-    fn num_attributes(&self) -> usize {
-        0
-    }
+/// Whether to measure real or normalized (between 0 and 1) distances.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum SampleType {
+    Distance,
+    Normalized,
 }
 
 type EndpointPair = (EndpointId, EndpointId);
@@ -70,13 +35,6 @@ impl SegmentWrapper {
     }
 }
 
-#[derive(Debug)]
-pub struct MeasureResult<'l> {
-    pub position: Point,
-    pub tangent: Vector,
-    pub attributes_store: Attributes<'l>,
-}
-
 struct Edge {
     // distance from the beginning of the path
     distance: f32,
@@ -86,107 +44,148 @@ struct Edge {
     t: f32,
 }
 
-/// A struct storing necessary information to perform cached measurements on a path.
-///
-/// Note that PathMeasure borrows the path instead of storing it.
-pub struct PathMeasure<'l, PS: PositionStore, AS: AttributeStore> {
-    events: Box<[IdEvent]>,
-    attribute_buffer: Box<[f32]>,
-    position_store: &'l PS,
-    attributes_store: &'l AS,
-
-    edges: Box<[Edge]>,
-
-    // This points to the edge where last query takes place (default to 0).
-    // With the help of this we can achieve better performance when queries are continuous.
-    ptr: usize,
+/// The result of sampling a path.
+#[derive(Debug)]
+pub struct PathSample<'l> {
+    position: Point,
+    tangent: Vector,
+    attributes: Attributes<'l>,
 }
 
-impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
-    fn to_segment(&self, event: IdEvent) -> SegmentWrapper {
-        macro_rules! endpoints {
-            ($($t:ident),*) => (
-                $(let $t = self.position_store.get_endpoint($t);)*
-            )
-        }
-        macro_rules! ctrl_points {
-            ($($t:ident),*) => (
-                $(let $t = self.position_store.get_control_point($t);)*
-            )
-        }
-        match event {
-            IdEvent::Line { from, to } => {
-                let pair = (from, to);
-                endpoints!(from, to);
-                SegmentWrapper::Line(LineSegment { from, to }, pair)
-            }
-            IdEvent::Quadratic { from, ctrl, to } => {
-                let pair = (from, to);
-                endpoints!(from, to);
-                ctrl_points!(ctrl);
-                SegmentWrapper::Quadratic(QuadraticBezierSegment { from, ctrl, to }, pair)
-            }
-            IdEvent::Cubic {
-                from,
-                ctrl1,
-                ctrl2,
-                to,
-            } => {
-                let pair = (from, to);
-                endpoints!(from, to);
-                ctrl_points!(ctrl1, ctrl2);
-                SegmentWrapper::Cubic(
-                    CubicBezierSegment {
-                        from,
-                        ctrl1,
-                        ctrl2,
-                        to,
-                    },
-                    pair,
-                )
-            }
-            IdEvent::End {
-                last,
-                first,
-                close: true,
-            } => {
-                let pair = (last, first);
-                endpoints!(last, first);
-                SegmentWrapper::Line(
-                    LineSegment {
-                        from: last,
-                        to: first,
-                    },
-                    pair,
-                )
-            }
-            _ => SegmentWrapper::Empty,
+impl<'l> PathSample<'l> {
+    #[inline]
+    pub fn position(&self) -> Point {
+        self.position
+    }
+
+    #[inline]
+    pub fn tangent(&self) -> Vector {
+        self.tangent
+    }
+
+    // Takes &mut self to allow interpolating attributes lazily (like the stroke tessellator) without changing
+    // the API.
+    #[inline]
+    pub fn attributes(&mut self) -> Attributes<'l> {
+        self.attributes
+    }
+}
+
+/// An acceleration structure for sampling distances along a specific path.
+///
+/// Building the path measurements can be an expensive operation depending on the complexity of the
+/// measured path, so it is usually a good idea to cache and reuse it whenever possible.
+///
+/// Queries on path measurements are made via a sampler object (see `PathSampler`) which can be configured
+/// to measure real distance or normalzied ones (values between 0 and 1 with zero indicating the start
+/// of the path and 1 indicating the end).
+///
+/// ## Differences with the `PathWalker`
+///
+/// The `walker` module provides a similar functionality via the `PathWalker`. The main differences are:
+///  - The path walker does all of its computation on the fly without storing any information for later use.
+///  - `PathMeasurements` stores potentially large amounts of data to speed up sample queries.
+///  - The cost of creating `PathMeasurements` is similar to that of walking the entire path once.
+///  - Once the `PathMeasurements` have been created, random samples on the path are much faster than path walking.
+///  - The PathWalker does not handle normalized distances since the length of the path cannot be known without
+///    traversing the entire path at least once.
+///
+/// Prefer `PathMeasurements` over `PathWalker` if the measurements can be cached and reused for a large number of
+/// queries.
+///
+/// ## Example
+///
+/// ```
+/// use lyon_algorithms::{
+///     math::point,
+///     path::Path,
+///     length::approximate_length,
+///     measure::{PathMeasurements, SampleType},
+/// };
+///
+/// fn main() {
+///     let mut path = Path::builder();
+///     path.begin(point(0.0, 0.0));
+///     path.quadratic_bezier_to(point(1.0, 1.0), point(2.0, 0.0));
+///     path.end(false);
+///     let path = path.build();
+///
+///     // Build the acceleration structure.
+///     let measurements = PathMeasurements::from_path(&path, 1e-3);
+///     let mut sampler = measurements.create_sampler(&path, SampleType::Normalized);
+///
+///     let sample  = sampler.sample(0.5);
+///     println!("Mid-point position: {:?}, tangent: {:?}", sample.position(), sample.tangent());
+///
+///     let mut second_half = Path::builder();
+///     sampler.split(0.5..1.0, &mut second_half);
+///     let second_half = second_half.build();
+///     assert!((sampler.length() / 2.0 - approximate_length(&second_half, 1e-3)).abs() < 1e-3);
+/// }
+/// ```
+///
+pub struct PathMeasurements {
+    events: Vec<IdEvent>,
+    edges: Vec<Edge>,
+}
+
+impl PathMeasurements {
+    /// Create empty path measurements.
+    ///
+    /// The measurements cannot be used until it has been initialized.
+    pub fn empty() -> Self {
+        PathMeasurements {
+            events: Vec::new(),
+            edges: Vec::new(),
         }
     }
 
-    pub fn with_attributes<Iter>(
-        num_attributes: usize,
-        path: Iter,
-        tolerance: f32,
-        position_store: &'l PS,
-        attributes_store: &'l AS,
-    ) -> Self
+    /// Create path measurements initialized with a `Path`.
+    pub fn from_path(path: &Path, tolerance: f32) -> Self {
+        let mut m = Self::empty();
+        m.initialize(path.id_iter(), path, tolerance);
+
+        m
+    }
+
+    /// Create path measurements initialized with a `PathSlice`.
+    pub fn from_path_slice(path: &PathSlice, tolerance: f32) -> Self {
+        let mut m = Self::empty();
+        m.initialize(path.id_iter(), path, tolerance);
+
+        m
+    }
+
+    /// Create path measurements initialized with a generic iterator and position store.
+    pub fn from_iter<Iter, PS>(path: Iter, positions: &PS, tolerance: f32) -> Self
     where
         Iter: IntoIterator<Item = IdEvent>,
+        PS: PositionStore,
     {
-        macro_rules! endpoints {
-            ($($t:ident),*) => (
-                $(let $t = position_store.get_endpoint($t);)*
-            )
-        }
-        macro_rules! ctrl_points {
-            ($($t:ident),*) => (
-                $(let $t = position_store.get_control_point($t);)*
-            )
-        }
+        let mut m = Self::empty();
+        m.initialize(path, positions, tolerance);
+
+        m
+    }
+
+    /// Initialize the path measurements with a path.
+    pub fn initialize<Iter, PS>(
+        &mut self,
+        path: Iter,
+        position_store: &PS,
+        tolerance: f32,
+    )
+    where
+        Iter: IntoIterator<Item = IdEvent>,
+        PS: PositionStore,
+    {
         let tolerance = tolerance.max(1e-4);
-        let events = path.into_iter().collect::<Vec<_>>().into_boxed_slice();
-        let mut edges = Vec::new();
+        let mut events = std::mem::take(&mut self.events);
+        events.clear();
+        events.extend(path.into_iter());
+        let mut edges = std::mem::take(&mut self.edges);
+        edges.clear();
+
         let mut distance = 0.0;
         for (index, event) in events.iter().cloned().enumerate() {
             match event {
@@ -198,7 +197,8 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
                     });
                 }
                 IdEvent::Line { from, to } => {
-                    endpoints!(from, to);
+                    let from = position_store.get_endpoint(from);
+                    let to = position_store.get_endpoint(to);
                     distance += (from - to).length();
                     edges.push(Edge {
                         distance,
@@ -207,8 +207,9 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
                     })
                 }
                 IdEvent::Quadratic { from, ctrl, to } => {
-                    endpoints!(from, to);
-                    ctrl_points!(ctrl);
+                    let from = position_store.get_endpoint(from);
+                    let to = position_store.get_endpoint(to);
+                    let ctrl = position_store.get_control_point(ctrl);
                     let segment = QuadraticBezierSegment { from, ctrl, to };
                     segment.for_each_flattened_with_t(tolerance, &mut |line, t| {
                         distance += line.length();
@@ -220,8 +221,10 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
                     });
                 }
                 IdEvent::Cubic { from, ctrl1, ctrl2, to } => {
-                    endpoints!(from, to);
-                    ctrl_points!(ctrl1, ctrl2);
+                    let from = position_store.get_endpoint(from);
+                    let to = position_store.get_endpoint(to);
+                    let ctrl1 = position_store.get_control_point(ctrl1);
+                    let ctrl2 = position_store.get_control_point(ctrl2);
                     let segment = CubicBezierSegment { from, ctrl1, ctrl2, to };
                     segment.for_each_flattened_with_t(tolerance, &mut |line, t| {
                         distance += line.length();
@@ -233,7 +236,8 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
                     });
                 }
                 IdEvent::End { last, first, close: true } => {
-                    endpoints!(last, first);
+                    let last = position_store.get_endpoint(last);
+                    let first = position_store.get_endpoint(first);
                     distance += (last - first).length();
                     edges.push(Edge {
                         distance,
@@ -244,24 +248,26 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
                 _ => {}
             }
         }
+
         if !edges.is_empty() {
             debug_assert_eq!(edges.first().unwrap().distance, 0.0);
         }
-        PathMeasure {
-            events,
-            attribute_buffer: vec![0.0; num_attributes].into_boxed_slice(),
-            position_store,
-            attributes_store,
-            edges: edges.into_boxed_slice(),
-            ptr: 0,
-        }
+
+        self.events = events;
+        self.edges = edges;
     }
 
-    pub fn num_attributes(&self) -> usize {
-        self.attribute_buffer.len()
+    /// Initialize the path measurements with a path.
+    pub fn initialize_with_path(&mut self, path: &Path, tolerance: f32) {
+        self.initialize_with_path_slice(path.as_slice(), tolerance)
     }
 
-    /// Returns the (approximate) length of the path.
+    /// Initialize the path measurements with a path.
+    pub fn initialize_with_path_slice(&mut self, path: PathSlice, tolerance: f32) {
+        self.initialize(path.id_iter(), &path, tolerance)
+    }
+
+    /// Returns the approximate length of the path.
     pub fn length(&self) -> f32 {
         if self.edges.is_empty() {
             0.0
@@ -270,24 +276,151 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
         }
     }
 
-    fn require_not_empty(&self) {
-        if self.length() == 0.0 {
-            panic!("Attempt to measure an empty path");
+    /// Create an object that can perform fast sample queries on a path using the cached measurements.
+    ///
+    /// The returned sampler does not compute interpolated attributes.
+    pub fn create_sampler<'l ,PS: PositionStore>(&'l self, positions: &'l PS, ty: SampleType) -> PathSampler<'l, PS, ()> {
+        let attr: &'static () = &();
+        PathSampler::new(self, positions, attr, ty)
+    }
+
+    /// Create an object that can perform fast sample queries on a path using the cached measurements.
+    ///
+    /// The returned sampler computes interpolated attributes.
+    pub fn create_sampler_with_attributes<'l, PS, AS>(&'l self, positions: &'l PS, attributes: &'l AS, ty: SampleType) -> PathSampler<'l, PS, AS>
+    where
+        PS: PositionStore,
+        AS: AttributeStore,
+    {
+        PathSampler::new(self, positions, attributes, ty)
+    }
+}
+
+/// Performs fast sample queries on a path with cached measurements.
+///
+/// This object contains the mutable state necessary for speeding up the queries, this allows the
+/// path measurements to be immutable and accessible concurrently from multiple threads if needed.
+///
+/// Reusing a sampler over multiple queries saves a memory allocation if there are custom attributes,
+/// And speeds up queries if they are sequentially ordered along the path.
+pub struct PathSampler<'l, PS, AS> {
+    events: &'l[IdEvent],
+    edges: &'l[Edge],
+    positions: &'l PS,
+    attributes: &'l AS,
+    attribute_buffer: Vec<f32>,
+    cursor: usize,
+    sample_type: SampleType,
+}
+
+impl<'l, PS: PositionStore, AS: AttributeStore> PathSampler<'l, PS, AS> {
+    /// Create a sampler.
+    ///
+    /// The provided positions must be the ones provided when initializing the path measurements.
+    pub fn new(measurements: &'l PathMeasurements, positions: &'l PS, attributes: &'l AS, sample_type: SampleType) -> Self {
+        PathSampler {
+            events: &measurements.events,
+            edges: &measurements.edges,
+            positions,
+            attributes,
+            attribute_buffer: vec![0.0; attributes.num_attributes()],
+            cursor: 0,
+            sample_type,
+        }
+    }
+
+    /// Sample at a given distance along the path.
+    ///
+    /// The path measurements must have beeen initialized with the same path.
+    /// The distance is clamped to the beginning and end of the path.
+    /// Panics if the path is empty.
+    pub fn sample(&mut self, dist: f32) -> PathSample {
+        if self.edges.is_empty() {
+            let attr: &'static[f32] = &[];
+            return PathSample {
+                position: point(std::f32::NAN, std::f32::NAN),
+                tangent: vector(std::f32::NAN, std::f32::NAN),
+                attributes: Attributes(attr),
+            }
+        }
+
+        self.sample_impl(dist, self.sample_type)
+    }
+
+    /// Construct a path for a specific sub-range of the measured path.
+    ///
+    /// The path measurements must have beeen initialized with the same path.
+    /// The distance is clamped to the beginning and end of the path.
+    /// Panics if the path is empty.
+    pub fn split(&mut self, range: Range<f32>, output: &mut dyn PathBuilder) {
+        self.split_impl(range, output)
+    }
+
+    /// Returns the approximate length of the path.
+    pub fn length(&self) -> f32 {
+        if self.edges.is_empty() {
+            0.0
+        } else {
+            self.edges.last().unwrap().distance
+        }
+    }
+
+    fn to_segment(&self, event: IdEvent) -> SegmentWrapper {
+        match event {
+            IdEvent::Line { from, to } => {
+                SegmentWrapper::Line(
+                    LineSegment {
+                        from: self.positions.get_endpoint(from),
+                        to: self.positions.get_endpoint(to),
+                    },
+                    (from, to)
+                )
+            }
+            IdEvent::Quadratic { from, ctrl, to } => {
+                SegmentWrapper::Quadratic(
+                    QuadraticBezierSegment {
+                        from: self.positions.get_endpoint(from),
+                        to: self.positions.get_endpoint(to),
+                        ctrl: self.positions.get_control_point(ctrl),
+                    },
+                    (from, to)
+                )
+            }
+            IdEvent::Cubic { from, ctrl1, ctrl2, to } => {
+                SegmentWrapper::Cubic(
+                    CubicBezierSegment {
+                        from: self.positions.get_endpoint(from),
+                        to: self.positions.get_endpoint(to),
+                        ctrl1: self.positions.get_control_point(ctrl1),
+                        ctrl2: self.positions.get_control_point(ctrl2),
+                    },
+                    (from, to),
+                )
+            }
+            IdEvent::End { last, first, close: true } => {
+                SegmentWrapper::Line(
+                    LineSegment {
+                        from: self.positions.get_endpoint(last),
+                        to: self.positions.get_endpoint(first),
+                    },
+                    (last, first),
+                )
+            }
+            _ => SegmentWrapper::Empty,
         }
     }
 
     fn in_bounds(&self, dist: f32) -> bool {
-        self.ptr != 0 && self.edges[self.ptr - 1].distance <= dist && dist <= self.edges[self.ptr].distance
+        if self.cursor > 0 {
+            println!("edge dist {} .. {}", self.edges[self.cursor - 1].distance, self.edges[self.cursor].distance);
+        }
+        self.cursor != 0 && self.edges[self.cursor - 1].distance <= dist && dist <= self.edges[self.cursor].distance
     }
 
     /// Move the pointer so the given point is on the current segment.
-    fn move_ptr(&mut self, dist: f32) {
-        self.require_not_empty();
-        if dist < 0.0 || dist > self.length() {
-            panic!("Illegal distance: {}", dist);
-        }
+    fn move_cursor(&mut self, dist: f32) {
         if dist == 0.0 {
-            self.ptr = 1;
+            self.cursor = 1;
             return;
         }
         if self.in_bounds(dist) {
@@ -298,7 +431,7 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
         // Performs on [first, last)
         // ...TTFFF...
         //      ^
-        //      find this point
+        //      sample this point
         fn partition_point(first: usize, last: usize, pred: impl Fn(usize) -> bool) -> usize {
             let mut l = first;
             let mut r = last;
@@ -328,78 +461,74 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
         //
         // According to the benchmark, this method works well in both cases and has low overhead in relative to Method 1 & 2.
         // Benchmark code: https://gist.github.com/Mivik/5f67ae5a72eae3884b2f386370554966
-        let start = self.edges[self.ptr].distance;
+        let start = self.edges[self.cursor].distance;
         if start < dist {
-            let (len, num) = (self.length() - start, self.edges.len() - self.ptr - 1);
+            let (len, num) = (self.length() - start, self.edges.len() - self.cursor - 1);
             debug_assert_ne!(num, 0);
             if (dist - start) / len * (num as f32) < floor_log2(num) as f32 {
                 loop {
-                    self.ptr += 1;
-                    if dist <= self.edges[self.ptr].distance {
+                    self.cursor += 1;
+                    if dist <= self.edges[self.cursor].distance {
                         break;
                     }
                 }
             } else {
-                self.ptr = partition_point(self.ptr + 1, self.edges.len(), |p| {
+                self.cursor = partition_point(self.cursor + 1, self.edges.len(), |p| {
                     self.edges[p].distance < dist
                 });
             }
         } else {
-            let (len, num) = (start, self.ptr + 1);
+            let (len, num) = (start, self.cursor + 1);
             debug_assert_ne!(num, 0);
             if (start - dist) / len * (num as f32) < floor_log2(num) as f32 {
                 loop {
-                    self.ptr -= 1;
-                    if self.ptr == 0 || self.edges[self.ptr - 1].distance < dist {
+                    self.cursor -= 1;
+                    if self.cursor == 0 || self.edges[self.cursor - 1].distance < dist {
                         break;
                     }
                 }
             } else {
-                self.ptr = partition_point(0, self.ptr, |p| self.edges[p].distance < dist);
+                self.cursor = partition_point(0, self.cursor, |p| self.edges[p].distance < dist);
             }
         }
+
         debug_assert!(self.in_bounds(dist));
     }
 
-    /// Linear interpolation between attributes_store.
-    fn lerp<'a>(
-        from: Attributes,
-        to: Attributes,
+    /// Interpolate the custom attributes.
+    fn interpolate_attributes(
+        &mut self,
+        from: EndpointId,
+        to: EndpointId,
         t: f32,
-        buffer: &'a mut Box<[f32]>,
-    ) -> Attributes<'a> {
-        for i in 0..buffer.len() {
-            buffer[i] = from[i] * (1.0 - t) + to[i] * t;
+    ) {
+        let from = self.attributes.get(from);
+        let to = self.attributes.get(to);
+        for i in 0..self.attribute_buffer.len() {
+            self.attribute_buffer[i] = from[i] * (1.0 - t) + to[i] * t;
         }
-        Attributes(&buffer[..])
     }
 
     /// Returns the relative position (0 ~ 1) of the given point on the current segment.
     fn t(&self, dist: f32) -> f32 {
+        println!("dist {:?} cursor: {:?}", dist, self.cursor);
         debug_assert!(self.in_bounds(dist));
-        let prev = &self.edges[self.ptr - 1];
-        let cur = &self.edges[self.ptr];
+        let prev = &self.edges[self.cursor - 1];
+        let cur = &self.edges[self.cursor];
         let t_begin = if prev.index == cur.index { prev.t } else { 0.0 };
         let t_end = cur.t;
         t_begin + (t_end - t_begin) * ((dist - prev.distance) / (cur.distance - prev.distance))
     }
 
-    /// Measures a given point by its relative distance on the path. See [`PathMeasure::measure_by_distance`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if t is not in [0.0, 1.0] or the path is empty.
-    pub fn measure(&mut self, t: f32) -> MeasureResult {
-        self.measure_by_distance(t * self.length())
-    }
+    fn sample_impl(&mut self, mut dist: f32, sample_type: SampleType) -> PathSample {
+        let length = self.length();
+        if sample_type == SampleType::Normalized {
+            dist *= length;
+        }
+        dist = dist.max(0.0);
+        dist = dist.min(length);
 
-    /// Measures a given point by its distance from the beginning on the path. See [`PathMeasure::measure`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if t is not in [0.0, `self.length()`] or the path is empty.
-    pub fn measure_by_distance(&mut self, dist: f32) -> MeasureResult {
-        self.move_ptr(dist);
+        self.move_cursor(dist);
         let t = self.t(dist);
         macro_rules! dispatched_call {
             ([$v:expr] ($seg:ident, $pair:ident) => $code:block) => {
@@ -412,13 +541,16 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
                 }
             };
         }
-        dispatched_call!([self.to_segment(self.events[self.edges[self.ptr].index])] (segment, pair) => {
-            return MeasureResult {
+
+        dispatched_call!([self.to_segment(self.events[self.edges[self.cursor].index])] (segment, pair) => {
+            self.interpolate_attributes(pair.0, pair.1, t);
+            return PathSample {
                 position: segment.sample(t),
                 tangent: segment.derivative(t).normalize(),
-                attributes_store: Self::lerp(self.attributes_store.get(pair.0), self.attributes_store.get(pair.1), t, &mut self.attribute_buffer),
+                attributes: Attributes(&self.attribute_buffer),
             }
         });
+
         unreachable!();
     }
 
@@ -426,7 +558,7 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
         &mut self,
         ptr: usize,
         range: Option<Range<f32>>,
-        dest: &mut BuilderWithAttributes,
+        dest: &mut dyn PathBuilder,
     ) {
         let segment = self.to_segment(self.events[ptr]);
         let segment = match range.clone() {
@@ -438,20 +570,17 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
                 match range {
                     Some(range) => {
                         if range.end == 1.0 {
-                            self.attributes_store.get($p.1)
+                            self.attributes.get($p.1)
                         } else {
-                            Self::lerp(
-                                self.attributes_store.get($p.0),
-                                self.attributes_store.get($p.1),
-                                range.end,
-                                &mut self.attribute_buffer,
-                            )
+                            self.interpolate_attributes($p.0, $p.1, range.end);
+                            Attributes(&mut self.attribute_buffer)
                         }
                     }
-                    None => self.attributes_store.get($p.1),
+                    None => self.attributes.get($p.1),
                 }
             };
         }
+
         match segment {
             SegmentWrapper::Line(LineSegment { to, .. }, pair) => {
                 dest.line_to(to, obtain_attrs!(pair));
@@ -471,91 +600,48 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathMeasure<'l, PS, AS> {
         }
     }
 
-    /// Return the curve inside a given range of relative distance. See [`PathMeasure::split_by_distance`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `range` is not in [0.0, 1] or the path is empty.
-    pub fn split(&mut self, range: Range<f32>) -> Path {
-        let len = self.length();
-        self.split_by_distance((range.start * len)..(range.end * len))
-    }
+    fn split_impl(&mut self, mut range: Range<f32>, output: &mut dyn PathBuilder) {
+        let length = self.length();
+        if self.sample_type == SampleType::Normalized {
+            range.start *= length;
+            range.end *= length;
+        }
+        range.start = range.start.max(0.0);
+        range.end = range.end.max(range.start);
+        range.start = range.start.min(length);
+        range.end = range.end.min(length);
 
-    /// Return the curve inside a given range of relative distance. See [`PathMeasure::split`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `range` is not in [0.0, 1] or the path is empty.
-    pub fn split_by_distance(&mut self, range: Range<f32>) -> Path {
-        self.require_not_empty();
         if range.is_empty() {
-            return Path::new();
+            return;
         }
-        if range.start < 0.0 || range.end > self.length() {
-            panic!("Illegal range: {:?}", range);
-        }
-        let mut path = Path::builder_with_attributes(self.num_attributes());
-        let result = self.measure_by_distance(range.start);
-        path.begin(result.position, result.attributes_store);
-        let (ptr1, seg1) = (self.ptr, self.edges[self.ptr].index);
-        self.move_ptr(range.end);
-        let (ptr2, seg2) = (self.ptr, self.edges[self.ptr].index);
+
+        let result = self.sample_impl(range.start, SampleType::Distance);
+        output.begin(result.position, result.attributes);
+        let (ptr1, seg1) = (self.cursor, self.edges[self.cursor].index);
+        self.move_cursor(range.end);
+        let (ptr2, seg2) = (self.cursor, self.edges[self.cursor].index);
 
         if seg1 == seg2 {
-            self.ptr = ptr1;
+            self.cursor = ptr1;
             let t_begin = self.t(range.start);
-            self.ptr = ptr2;
+            self.cursor = ptr2;
             let t_end = self.t(range.end);
             self.add_segment(
                 seg1,
                 Some(t_begin..t_end),
-                &mut path,
+                output,
             );
         } else {
-            self.ptr = ptr1;
-            self.add_segment(seg1, Some(self.t(range.start)..1.0), &mut path);
+            self.cursor = ptr1;
+            self.add_segment(seg1, Some(self.t(range.start)..1.0), output);
             for seg in (seg1 + 1)..seg2 {
-                self.add_segment(seg, None, &mut path);
+                self.add_segment(seg, None, output);
             }
-            self.ptr = ptr2;
-            self.add_segment(seg2, Some(0.0..self.t(range.end)), &mut path);
+            self.cursor = ptr2;
+            self.add_segment(seg2, Some(0.0..self.t(range.end)), output);
         }
-        path.end(false);
-        path.build()
-    }
-}
 
-impl<'l, PS: PositionStore> PathMeasure<'l, PS, EmptyAttribtueStore> {
-    pub fn new<Iter>(path: Iter, tolerance: f32, points: &'l PS) -> Self
-    where
-        Iter: IntoIterator<Item = IdEvent>,
-    {
-        Self::with_attributes(0, path, tolerance, points, &EmptyAttribtueStore)
-    }
-}
-
-impl<'l> PathMeasure<'l, Path, EmptyAttribtueStore> {
-    #[must_use]
-    pub fn from_path(path: &'l Path, tolerance: f32) -> Self {
-        Self::new(path.id_iter(), tolerance, path)
-    }
-}
-
-impl<'l> PathMeasure<'l, Path, Path> {
-    pub fn from_path_with_attributes(path: &'l Path, tolerance: f32) -> Self {
-        Self::with_attributes(path.num_attributes(), path.id_iter(), tolerance, path, path)
-    }
-}
-
-impl<'l> PathMeasure<'l, PathSlice<'l>, EmptyAttribtueStore> {
-    pub fn from_slice(path: &'l PathSlice, tolerance: f32) -> Self {
-        Self::new(path.id_iter(), tolerance, path)
-    }
-}
-
-impl<'l> PathMeasure<'l, PathSlice<'l>, PathSlice<'l>> {
-    pub fn from_slice_with_attributes(path: &'l PathSlice, tolerance: f32) -> Self {
-        Self::with_attributes(path.num_attributes(), path.id_iter(), tolerance, path, path)
+        output.end(false);
     }
 }
 
@@ -566,9 +652,10 @@ fn measure_line() {
     path.line_to(point(0.0, 0.0));
     path.end(false);
     let path = path.build();
-    let mut measure = PathMeasure::from_path(&path, 0.01);
+    let measure = PathMeasurements::from_path(&path, 0.01);
+    let mut sampler = measure.create_sampler(&path, SampleType::Normalized);
     for t in [0.0, 0.2, 0.3, 0.5, 1.0] {
-        let result = measure.measure(t);
+        let result = sampler.sample(t);
         assert!((result.position - point(1.0 - t, 1.0 - t)).length() < 1e-5);
         assert_eq!(result.tangent, vector(-1.0, -1.0).normalize());
     }
@@ -583,14 +670,15 @@ fn measure_square() {
     path.line_to(point(0.0, 1.0));
     path.close();
     let path = path.build();
-    let mut measure = PathMeasure::from_path(&path, 0.01);
+    let measure = PathMeasurements::from_path(&path, 0.01);
+    let mut sampler = measure.create_sampler(&path, SampleType::Normalized);
     for (t, position, tangent) in [
         (0.125, point(0.5, 0.0), vector(1.0, 0.0)),
         (0.375, point(1.0, 0.5), vector(0.0, 1.0)),
         (0.625, point(0.5, 1.0), vector(-1.0, 0.0)),
         (0.875, point(0.0, 0.5), vector(0.0, -1.0)),
     ] {
-        let result = measure.measure(t);
+        let result = sampler.sample(t);
         assert!((result.position - position).length() < 1e-5);
         assert_eq!(result.tangent, tangent);
     }
@@ -604,16 +692,18 @@ fn measure_attributes() {
     path.line_to(point(1.0, 1.0), Attributes(&[0.0, 0.0]));
     path.end(false);
     let path = path.build();
-    let mut measure = PathMeasure::from_path_with_attributes(&path, 0.01);
+    let measure = PathMeasurements::from_path(&path, 0.01);
+    let mut sampler = measure.create_sampler_with_attributes(&path, &path, SampleType::Normalized);
+
     for (t, position, attrs) in [
         (0.25, point(0.5, 0.0), Attributes(&[1.5, 2.5])),
         (0.5, point(1.0, 0.0), Attributes(&[2.0, 3.0])),
         (0.75, point(1.0, 0.5), Attributes(&[1.0, 1.5])),
     ] {
-        let result = measure.measure(t);
+        let result = sampler.sample(t);
         assert!((result.position - position).length() < 1e-5);
         for i in 0..2 {
-            assert!((result.attributes_store[i] - attrs[i]).abs() < 1e-5);
+            assert!((result.attributes[i] - attrs[i]).abs() < 1e-5);
         }
     }
 }
@@ -626,9 +716,12 @@ fn measure_bezier_curve() {
     path.quadratic_bezier_to(point(1.5, -0.7), point(2.0, 0.0));
     path.end(false);
     let path = path.build();
-    let mut measure = PathMeasure::from_path(&path, 0.01);
+
+    let measure = PathMeasurements::from_path(&path, 0.01);
+    let mut sampler = measure.create_sampler(&path, SampleType::Normalized);
+
     for t in [0.25, 0.75] {
-        let result = measure.measure(t);
+        let result = sampler.sample(t);
         assert_eq!(result.tangent, vector(1.0, 0.0));
     }
     for (t, position) in [
@@ -636,7 +729,7 @@ fn measure_bezier_curve() {
         (0.5, point(1.0, 0.0)),
         (1.0, point(2.0, 0.0)),
     ] {
-        let result = measure.measure(t);
+        let result = sampler.sample(t);
         assert_eq!(result.position, position);
     }
 }
@@ -652,10 +745,13 @@ fn split_square() {
     path.line_to(point(0.0, 1.0));
     path.close();
     let path = path.build();
-    let mut measure = PathMeasure::from_path(&path, 0.01);
-    let result = measure.split(0.125..0.625);
+    let measure = PathMeasurements::from_path(&path, 0.01);
+    let mut sampler = measure.create_sampler(&path, SampleType::Normalized);
+    let mut path2 = Path::builder();
+    sampler.split(0.125..0.625, &mut path2);
+    let path2 = path2.build();
     assert_eq!(
-        result.iter().collect::<Vec<_>>(),
+        path2.iter().collect::<Vec<_>>(),
         vec![
             Event::Begin {
                 at: point(0.5, 0.0)
@@ -690,10 +786,15 @@ fn split_bezier_curve() {
     path.quadratic_bezier_to(point(1.0, 1.0), point(2.0, 0.0));
     path.end(false);
     let path = path.build();
-    let mut measure = PathMeasure::from_path(&path, 0.01);
-    let result = measure.split(0.5..1.0);
+    let measure = PathMeasurements::from_path(&path, 0.01);
+    let mut sampler = measure.create_sampler(&path, SampleType::Normalized);
+
+    let mut path2 = Path::builder(); 
+    sampler.split(0.5..1.0, &mut path2);
+    let path2 = path2.build();
+
     assert_eq!(
-        result.iter().collect::<Vec<_>>(),
+        path2.iter().collect::<Vec<_>>(),
         vec![
             Event::Begin {
                 at: point(1.0, 0.5)
@@ -722,17 +823,24 @@ fn split_attributes() {
     path.line_to(point(1.0, 1.0), Attributes(&[0.0, 0.0]));
     path.end(false);
     let path = path.build();
-    let mut measure = PathMeasure::from_path_with_attributes(&path, 0.01);
+    let measure = PathMeasurements::from_path(&path, 0.01);
+    let mut sampler = measure.create_sampler_with_attributes(&path, &path, SampleType::Normalized);
+
+    let mut path2 = Path::builder_with_attributes(2);
+    sampler.split(0.0..1.0, &mut path2);
+    let path2 = path2.build();
+
     assert_eq!(
-        measure
-            .split(0.0..1.0)
-            .iter_with_attributes()
-            .collect::<Vec<_>>(),
+        path2.iter_with_attributes().collect::<Vec<_>>(),
         path.iter_with_attributes().collect::<Vec<_>>()
     );
-    let result = measure.split(0.25..0.75);
+
+    let mut path3 = Path::builder_with_attributes(2);
+    sampler.split(0.25..0.75, &mut path3);
+    let path3 = path3.build();
+
     assert_eq!(
-        result.iter_with_attributes().collect::<Vec<_>>(),
+        path3.iter_with_attributes().collect::<Vec<_>>(),
         vec![
             Event::Begin {
                 at: (point(0.5, 0.0), Attributes(&[1.5, 2.5]))

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -86,7 +86,6 @@ use crate::path::Verb;
 use crate::polygon::Polygon;
 use crate::{Attributes, EndpointId, Winding};
 
-use std::iter::IntoIterator;
 use std::marker::Sized;
 
 /// The radius of each corner of a rounded rectangle.
@@ -227,15 +226,6 @@ impl<B: PathBuilder> NoAttributes<B> {
     #[inline]
     pub fn path_event(&mut self, event: PathEvent) {
         self.inner.path_event(event, Attributes::NONE);
-    }
-
-    /// Adds events from an iterator.
-    #[inline]
-    pub fn extend<Evts>(&mut self, events: Evts)
-    where
-        Evts: IntoIterator<Item = PathEvent>,
-    {
-        self.inner.extend(events, Attributes::NONE);
     }
 
     /// Adds a sub-path from a polygon.
@@ -555,16 +545,6 @@ pub trait PathBuilder {
             Event::End { close, .. } => {
                 self.end(close);
             }
-        }
-    }
-
-    /// Adds events from an iterator.
-    fn extend<Evts>(&mut self, events: Evts, attributes: Attributes)
-    where
-        Evts: IntoIterator<Item = PathEvent>,
-    {
-        for evt in events.into_iter() {
-            self.path_event(evt, attributes)
         }
     }
 


### PR DESCRIPTION
On the surface this commit is a fairly big revamp of the PathMeasure API introduced by @Mivik, but it does not actually change much of the internal logic:
 - Most of the cached state is moved into a `PathMeasurements` struct which can be used immutably.
 - The temporary and mutable state goes into a `PathSampler` type which has a lifetime. It holds references to the measurements as well as the position and attribute stores, and keeps the cursor and attribute buffer.
 - All queries are performed by the path sampler (see `sample` and `split`). A parameter at the creation of the sampler controls whether real or normalized distances are used.
 - Some of the terminology has changed ("sample" rather than "measure" for example).
 - Splitting the path now takes a `&mut dyn PathBuilder` instead of returning a `Path` to allow building any kind of path data structure.

## Motivations
 - More easily cache the path measurements. The lifetime parameter in PathMeasure was making it hard to store it beyond the current stack frame. This is at the expense of having to pass the path both when creating the measurements and when creating the sampler.
 - Immutability. Once the measurements are made, they can be used completely immutably which makes it easy to, for example, make queries concurrently from multiple threads with a sampler per thread.

## Example

Sampling along the path now looks like:

```rust
let measurements = PathMeasurements::from_path(&path, tolerance);
let mut sampler = measurements.create_sampler(&path, SampleType::Normalized);

let mid_point  = sampler.sample(0.5).position();

let mut second_half = Path::builder();
sampler.split(0.5..1.0, &mut second_half);
let second_half = second_half.build();
```