### PR TITLE
Remove wrapper types for attributes and attribute indices

### DIFF
--- a/bench/path/src/main.rs
+++ b/bench/path/src/main.rs
@@ -7,7 +7,7 @@ use lyon::math::point;
 use lyon::path::commands;
 use lyon::path::traits::*;
 use lyon::path::PathBuffer;
-use lyon::path::{Attributes, ControlPointId, EndpointId, Event, IdEvent, Path, PathEvent};
+use lyon::path::{NO_ATTRIBUTES, ControlPointId, EndpointId, Event, IdEvent, Path, PathEvent};
 
 use bencher::Bencher;
 
@@ -196,16 +196,16 @@ fn no_attrib_iter(bench: &mut Bencher) {
         let mut path = Path::builder_with_attributes(0);
         for _ in 0..N {
             for _ in 0..10 {
-                path.begin(point(0.0, 0.0), Attributes::NONE);
+                path.begin(point(0.0, 0.0), NO_ATTRIBUTES);
                 for _ in 0..1_000 {
-                    path.line_to(point(1.0, 0.0), Attributes::NONE);
+                    path.line_to(point(1.0, 0.0), NO_ATTRIBUTES);
                     path.cubic_bezier_to(
                         point(2.0, 0.0),
                         point(2.0, 1.0),
                         point(2.0, 2.0),
-                        Attributes::NONE,
+                        NO_ATTRIBUTES,
                     );
-                    path.quadratic_bezier_to(point(2.0, 0.0), point(2.0, 1.0), Attributes::NONE);
+                    path.quadratic_bezier_to(point(2.0, 0.0), point(2.0, 1.0), NO_ATTRIBUTES);
                 }
                 path.end(true);
             }
@@ -233,19 +233,19 @@ fn f32x2_attrib_iter(bench: &mut Bencher) {
         let mut path = Path::builder_with_attributes(2);
         for _ in 0..N {
             for _ in 0..10 {
-                path.begin(point(0.0, 0.0), Attributes(&[0.0, 1.0]));
+                path.begin(point(0.0, 0.0), &[0.0, 1.0]);
                 for _ in 0..1_000 {
-                    path.line_to(point(1.0, 0.0), Attributes(&[0.0, 1.0]));
+                    path.line_to(point(1.0, 0.0), &[0.0, 1.0]);
                     path.cubic_bezier_to(
                         point(2.0, 0.0),
                         point(2.0, 1.0),
                         point(2.0, 2.0),
-                        Attributes(&[0.0, 1.0]),
+                        &[0.0, 1.0],
                     );
                     path.quadratic_bezier_to(
                         point(2.0, 0.0),
                         point(2.0, 1.0),
-                        Attributes(&[0.0, 1.0]),
+                        &[0.0, 1.0],
                     );
                 }
                 path.end(true);

--- a/bench/path/src/main.rs
+++ b/bench/path/src/main.rs
@@ -7,7 +7,7 @@ use lyon::math::point;
 use lyon::path::commands;
 use lyon::path::traits::*;
 use lyon::path::PathBuffer;
-use lyon::path::{NO_ATTRIBUTES, ControlPointId, EndpointId, Event, IdEvent, Path, PathEvent};
+use lyon::path::{ControlPointId, EndpointId, Event, IdEvent, Path, PathEvent, NO_ATTRIBUTES};
 
 use bencher::Bencher;
 
@@ -242,11 +242,7 @@ fn f32x2_attrib_iter(bench: &mut Bencher) {
                         point(2.0, 2.0),
                         &[0.0, 1.0],
                     );
-                    path.quadratic_bezier_to(
-                        point(2.0, 0.0),
-                        point(2.0, 1.0),
-                        &[0.0, 1.0],
-                    );
+                    path.quadratic_bezier_to(point(2.0, 0.0), point(2.0, 1.0), &[0.0, 1.0]);
                 }
                 path.end(true);
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -478,9 +478,8 @@ fn get_stroke(matches: &ArgMatches) -> Option<StrokeOptions> {
         }
         if let Some(var_stroke_str) = matches.value_of("VARIABLE_LINE_WIDTH") {
             options.variable_line_width = var_stroke_str
-                .parse::<u8>()
+                .parse::<usize>()
                 .ok()
-                .map(|idx| lyon::path::AttributeIndex(idx))
         }
 
         Some(options)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -477,9 +477,7 @@ fn get_stroke(matches: &ArgMatches) -> Option<StrokeOptions> {
             options.miter_limit = limit;
         }
         if let Some(var_stroke_str) = matches.value_of("VARIABLE_LINE_WIDTH") {
-            options.variable_line_width = var_stroke_str
-                .parse::<usize>()
-                .ok()
+            options.variable_line_width = var_stroke_str.parse::<usize>().ok()
         }
 
         Some(options)

--- a/crates/algorithms/src/hatching.rs
+++ b/crates/algorithms/src/hatching.rs
@@ -30,7 +30,7 @@ use crate::geom::LineSegment;
 use crate::math::{point, vector, Angle, Point, Rotation, Vector};
 use crate::path::builder::{Build, PathBuilder};
 use crate::path::private::DebugValidator;
-use crate::path::{self, Attributes, EndpointId, PathEvent};
+use crate::path::{self, Attributes, EndpointId, PathEvent, NO_ATTRIBUTES};
 use std::marker::PhantomData;
 
 use std::cmp::Ordering;
@@ -548,8 +548,8 @@ impl PathBuilder for EventsBuilder {
             self.current,
             ctrl,
             to,
-            Attributes::NONE,
-            Attributes::NONE,
+            NO_ATTRIBUTES,
+            NO_ATTRIBUTES,
             self,
             &mut [],
         )
@@ -568,8 +568,8 @@ impl PathBuilder for EventsBuilder {
             ctrl1,
             ctrl2,
             to,
-            Attributes::NONE,
-            Attributes::NONE,
+            NO_ATTRIBUTES,
+            NO_ATTRIBUTES,
             self,
             &mut [],
         )
@@ -586,7 +586,7 @@ impl HatchingEvents {
         builder.edges = mem::take(&mut self.edges);
 
         for evt in it {
-            builder.path_event(evt, Attributes::NONE);
+            builder.path_event(evt, NO_ATTRIBUTES);
         }
         mem::swap(self, &mut builder.build());
     }

--- a/crates/algorithms/src/lib.rs
+++ b/crates/algorithms/src/lib.rs
@@ -16,9 +16,9 @@ pub mod hit_test;
 pub mod length;
 pub mod measure;
 pub mod raycast;
+pub mod rect;
 pub mod walk;
 pub mod winding;
-pub mod rect;
 
 pub use crate::path::geom;
 pub use crate::path::math;

--- a/crates/algorithms/src/raycast.rs
+++ b/crates/algorithms/src/raycast.rs
@@ -55,9 +55,12 @@ where
                 );
             }
             PathEvent::Quadratic { from, ctrl, to } => {
-                QuadraticBezierSegment { from, ctrl, to }.for_each_flattened(tolerance, &mut |line| {
-                    test_segment(&mut state, line);
-                });
+                QuadraticBezierSegment { from, ctrl, to }.for_each_flattened(
+                    tolerance,
+                    &mut |line| {
+                        test_segment(&mut state, line);
+                    },
+                );
             }
             PathEvent::Cubic {
                 from,

--- a/crates/algorithms/src/rect.rs
+++ b/crates/algorithms/src/rect.rs
@@ -1,4 +1,4 @@
-use crate::math::{point, Box2D, Point, Vector, vector};
+use crate::math::{point, vector, Box2D, Point, Vector};
 use crate::path::PathEvent;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -36,7 +36,10 @@ impl ToRectangleOptions {
 }
 
 /// If the input path represents an axis-aligned rectangle, return it.
-pub fn to_axis_aligned_rectangle<P: IntoIterator<Item = PathEvent>>(path: P, options: &ToRectangleOptions) -> Option<Box2D> {
+pub fn to_axis_aligned_rectangle<P: IntoIterator<Item = PathEvent>>(
+    path: P,
+    options: &ToRectangleOptions,
+) -> Option<Box2D> {
     let tolerance = options.tolerance;
     let mut ctx = ToRectangle {
         min: point(0.0, 0.0),
@@ -95,8 +98,13 @@ pub fn to_axis_aligned_rectangle<P: IntoIterator<Item = PathEvent>>(path: P, opt
                 }
 
                 ctx.edge(from, to);
-            } 
-            PathEvent::Cubic { from, ctrl1, ctrl2, to } => {
+            }
+            PathEvent::Cubic {
+                from,
+                ctrl1,
+                ctrl2,
+                to,
+            } => {
                 let tol = vector(tolerance, tolerance);
                 let to_axis = (to - from).abs().greater_than(tol);
                 let mut ctrl1_axis = (ctrl1 - from).abs().greater_than(tol);
@@ -114,20 +122,27 @@ pub fn to_axis_aligned_rectangle<P: IntoIterator<Item = PathEvent>>(path: P, opt
                     return None;
                 }
 
-                if to_axis.x && !(is_between(ctrl1.x, from.x, to.x) && is_between(ctrl2.x, from.x, to.x)) {
+                if to_axis.x
+                    && !(is_between(ctrl1.x, from.x, to.x) && is_between(ctrl2.x, from.x, to.x))
+                {
                     return None;
                 }
 
-                if to_axis.y && !(is_between(ctrl1.y, from.y, to.y) && is_between(ctrl2.y, from.y, to.y)) {
+                if to_axis.y
+                    && !(is_between(ctrl1.y, from.y, to.y) && is_between(ctrl2.y, from.y, to.y))
+                {
                     return None;
                 }
 
                 ctx.edge(from, to);
-            } 
+            }
         }
     }
 
-    Some(Box2D { min: ctx.min, max: ctx.max })
+    Some(Box2D {
+        min: ctx.min,
+        max: ctx.max,
+    })
 }
 
 struct ToRectangle {
@@ -239,9 +254,17 @@ fn direction(v: Vector, tolerance: f32) -> Option<Dir> {
     }
 
     let dir = if x {
-        if v.x > 0.0 { Dir::Right } else { Dir::Left }
+        if v.x > 0.0 {
+            Dir::Right
+        } else {
+            Dir::Left
+        }
     } else {
-        if v.y > 0.0 { Dir::Down } else { Dir::Up }
+        if v.y > 0.0 {
+            Dir::Down
+        } else {
+            Dir::Up
+        }
     };
 
     Some(dir)
@@ -266,8 +289,13 @@ fn test_to_axis_aligned_rectangle() {
     let path = builder.build();
 
     let r = to_axis_aligned_rectangle(&path, &fill).unwrap();
-    assert!(approx_eq(r, Box2D { min: point(0.0, 0.0), max: point(10.0, 5.0) }));
-
+    assert!(approx_eq(
+        r,
+        Box2D {
+            min: point(0.0, 0.0),
+            max: point(10.0, 5.0)
+        }
+    ));
 
     let mut builder = crate::path::Path::builder();
     builder.begin(point(0.0, 0.0));
@@ -278,7 +306,13 @@ fn test_to_axis_aligned_rectangle() {
     let path = builder.build();
 
     let r = to_axis_aligned_rectangle(&path, &fill).unwrap();
-    assert!(approx_eq(r, Box2D { min: point(0.0, 0.0), max: point(10.0, 5.0) }));
+    assert!(approx_eq(
+        r,
+        Box2D {
+            min: point(0.0, 0.0),
+            max: point(10.0, 5.0)
+        }
+    ));
     assert!(to_axis_aligned_rectangle(&path, &stroke).is_none());
 
     let mut builder = crate::path::Path::builder();
@@ -294,8 +328,13 @@ fn test_to_axis_aligned_rectangle() {
     let path = builder.build();
 
     let r = to_axis_aligned_rectangle(&path, &fill).unwrap();
-    assert!(approx_eq(r, Box2D { min: point(0.0, 0.0), max: point(10.0, 5.0) }));
-
+    assert!(approx_eq(
+        r,
+        Box2D {
+            min: point(0.0, 0.0),
+            max: point(10.0, 5.0)
+        }
+    ));
 
     let mut builder = crate::path::Path::builder();
     builder.begin(point(0.0, 0.0));
@@ -305,7 +344,6 @@ fn test_to_axis_aligned_rectangle() {
     let path = builder.build();
 
     assert!(to_axis_aligned_rectangle(&path, &fill).is_none());
-
 
     let mut builder = crate::path::Path::builder();
     builder.begin(point(0.0, 0.0));
@@ -324,7 +362,6 @@ fn test_to_axis_aligned_rectangle() {
     let path = builder.build();
 
     assert!(to_axis_aligned_rectangle(&path, &fill).is_none());
-
 
     let mut builder = crate::path::Path::builder();
     builder.begin(point(0.0, 0.0));
@@ -347,7 +384,13 @@ fn test_to_axis_aligned_rectangle() {
     let path = builder.build();
 
     let r = to_axis_aligned_rectangle(&path, &fill).unwrap();
-    assert!(approx_eq(r, Box2D { min: point(0.0, 0.0), max: point(10.0, 5.0) }));
+    assert!(approx_eq(
+        r,
+        Box2D {
+            min: point(0.0, 0.0),
+            max: point(10.0, 5.0)
+        }
+    ));
 
     let mut builder = crate::path::Path::builder();
     builder.begin(point(0.0, 0.0));
@@ -358,7 +401,6 @@ fn test_to_axis_aligned_rectangle() {
     let path = builder.build();
 
     assert!(to_axis_aligned_rectangle(&path, &fill).is_none());
-
 
     let mut builder = crate::path::Path::builder();
     builder.begin(point(-1.0, 0.0));
@@ -382,10 +424,13 @@ fn test_to_axis_aligned_rectangle() {
     let path = builder.build();
 
     let r = to_axis_aligned_rectangle(&path, &fill).unwrap();
-    assert!(approx_eq(r, Box2D { min: point(0.0, 0.0), max: point(10.0, 5.0) }));
-
-
-
+    assert!(approx_eq(
+        r,
+        Box2D {
+            min: point(0.0, 0.0),
+            max: point(10.0, 5.0)
+        }
+    ));
 
     let mut builder = crate::path::Path::builder();
     builder.begin(point(0.0, 0.0));

--- a/crates/algorithms/src/walk.rs
+++ b/crates/algorithms/src/walk.rs
@@ -43,7 +43,7 @@
 use crate::geom::{CubicBezierSegment, QuadraticBezierSegment, LineSegment};
 use crate::math::*;
 use crate::path::builder::*;
-use crate::path::{Attributes, EndpointId, PathEvent};
+use crate::path::{EndpointId, PathEvent, Attributes};
 
 use std::f32;
 use std::ops::Range;
@@ -179,7 +179,7 @@ impl<'l> PathWalker<'l> {
                 position,
                 tangent,
                 distance: self.advancement,
-                attributes: Attributes(&self.attribute_buffer[..]),
+                attributes: &self.attribute_buffer[..],
             };
             if let Some(distance) = self.pattern.next(event) {
                 self.next_distance = distance;
@@ -208,8 +208,8 @@ impl<'l> PathWalker<'l> {
             self.done = true;
         }
 
-        self.prev_attributes.copy_from_slice(attributes.as_slice());
-        self.first_attributes.copy_from_slice(attributes.as_slice());
+        self.prev_attributes.copy_from_slice(attributes);
+        self.first_attributes.copy_from_slice(attributes);
 
         EndpointId::INVALID
     }
@@ -223,7 +223,7 @@ impl<'l> PathWalker<'l> {
             (LineSegment { from, to }.sample(x), tangent)
         );
 
-        self.prev_attributes.copy_from_slice(attributes.as_slice());
+        self.prev_attributes.copy_from_slice(attributes);
 
         EndpointId::INVALID
     }
@@ -234,7 +234,7 @@ impl<'l> PathWalker<'l> {
             let first = self.first;
             let from = self.prev;
             let tangent = (first - from).normalize();
-            self.edge(first, 0.0..1.0, Attributes(&attributes),
+            self.edge(first, 0.0..1.0, &attributes,
                 &|x| (LineSegment { from, to: first }.sample(x), tangent)
             );
             self.first_attributes = attributes;
@@ -262,7 +262,7 @@ impl<'l> PathWalker<'l> {
             }
         });
 
-        self.prev_attributes.copy_from_slice(attributes.as_slice());
+        self.prev_attributes.copy_from_slice(attributes);
 
         EndpointId::INVALID
     }
@@ -290,7 +290,7 @@ impl<'l> PathWalker<'l> {
             }
         });
 
-        self.prev_attributes.copy_from_slice(attributes.as_slice());
+        self.prev_attributes.copy_from_slice(attributes);
 
         EndpointId::INVALID
     }

--- a/crates/algorithms/src/walk.rs
+++ b/crates/algorithms/src/walk.rs
@@ -40,10 +40,10 @@
 //! ```
 //!
 
-use crate::geom::{CubicBezierSegment, QuadraticBezierSegment, LineSegment};
+use crate::geom::{CubicBezierSegment, LineSegment, QuadraticBezierSegment};
 use crate::math::*;
 use crate::path::builder::*;
-use crate::path::{EndpointId, PathEvent, Attributes};
+use crate::path::{Attributes, EndpointId, PathEvent};
 
 use std::f32;
 use std::ops::Range;
@@ -146,7 +146,13 @@ impl<'l> PathWalker<'l> {
         }
     }
 
-    fn edge(&mut self, to: Point, t: Range<f32>, attributes: Attributes, pos_cb: &dyn Fn(f32) -> (Point, Vector)) {
+    fn edge(
+        &mut self,
+        to: Point,
+        t: Range<f32>,
+        attributes: Attributes,
+        pos_cb: &dyn Fn(f32) -> (Point, Vector),
+    ) {
         debug_assert!(!self.need_moveto);
 
         let v = to - self.prev;
@@ -219,9 +225,9 @@ impl<'l> PathWalker<'l> {
 
         let from = self.prev;
         let tangent = (to - from).normalize();
-        self.edge(to, 0.0..1.0, attributes, &|x|
+        self.edge(to, 0.0..1.0, attributes, &|x| {
             (LineSegment { from, to }.sample(x), tangent)
-        );
+        });
 
         self.prev_attributes.copy_from_slice(attributes);
 
@@ -234,9 +240,9 @@ impl<'l> PathWalker<'l> {
             let first = self.first;
             let from = self.prev;
             let tangent = (first - from).normalize();
-            self.edge(first, 0.0..1.0, &attributes,
-                &|x| (LineSegment { from, to: first }.sample(x), tangent)
-            );
+            self.edge(first, 0.0..1.0, &attributes, &|x| {
+                (LineSegment { from, to: first }.sample(x), tangent)
+            });
             self.first_attributes = attributes;
             self.need_moveto = true;
         }

--- a/crates/extra/src/parser.rs
+++ b/crates/extra/src/parser.rs
@@ -2,7 +2,6 @@ use path::{
     geom::{ArcFlags, SvgArc},
     math::{point, vector, Angle, Point},
     traits::PathBuilder,
-    Attributes,
 };
 
 use std::fmt;
@@ -271,7 +270,7 @@ impl PathParser {
             match cmd {
                 'l' | 'L' => {
                     let to = self.parse_endpoint(is_relatve, src)?;
-                    output.line_to(to, Attributes(&self.attribute_buffer));
+                    output.line_to(to, &self.attribute_buffer);
                 }
                 'h' | 'H' => {
                     let mut x = self.parse_number(src)?;
@@ -281,7 +280,7 @@ impl PathParser {
                     let to = point(x, self.current_position.y);
                     self.current_position = to;
                     self.parse_attributes(src)?;
-                    output.line_to(to, Attributes(&self.attribute_buffer));
+                    output.line_to(to, &self.attribute_buffer);
                 }
                 'v' | 'V' => {
                     let mut y = self.parse_number(src)?;
@@ -291,33 +290,33 @@ impl PathParser {
                     let to = point(self.current_position.x, y);
                     self.current_position = to;
                     self.parse_attributes(src)?;
-                    output.line_to(to, Attributes(&self.attribute_buffer));
+                    output.line_to(to, &self.attribute_buffer);
                 }
                 'q' | 'Q' => {
                     let ctrl = self.parse_point(is_relatve, src)?;
                     let to = self.parse_endpoint(is_relatve, src)?;
                     prev_quadratic_ctrl = Some(ctrl);
-                    output.quadratic_bezier_to(ctrl, to, Attributes(&self.attribute_buffer));
+                    output.quadratic_bezier_to(ctrl, to, &self.attribute_buffer);
                 }
                 't' | 'T' => {
                     let ctrl = self.get_smooth_ctrl(prev_quadratic_ctrl);
                     let to = self.parse_endpoint(is_relatve, src)?;
                     prev_quadratic_ctrl = Some(ctrl);
-                    output.quadratic_bezier_to(ctrl, to, Attributes(&self.attribute_buffer));
+                    output.quadratic_bezier_to(ctrl, to, &self.attribute_buffer);
                 }
                 'c' | 'C' => {
                     let ctrl1 = self.parse_point(is_relatve, src)?;
                     let ctrl2 = self.parse_point(is_relatve, src)?;
                     let to = self.parse_endpoint(is_relatve, src)?;
                     prev_cubic_ctrl = Some(ctrl2);
-                    output.cubic_bezier_to(ctrl1, ctrl2, to, Attributes(&self.attribute_buffer));
+                    output.cubic_bezier_to(ctrl1, ctrl2, to, &self.attribute_buffer);
                 }
                 's' | 'S' => {
                     let ctrl1 = self.get_smooth_ctrl(prev_cubic_ctrl);
                     let ctrl2 = self.parse_point(is_relatve, src)?;
                     let to = self.parse_endpoint(is_relatve, src)?;
                     prev_cubic_ctrl = Some(ctrl2);
-                    output.cubic_bezier_to(ctrl1, ctrl2, to, Attributes(&self.attribute_buffer));
+                    output.cubic_bezier_to(ctrl1, ctrl2, to, &self.attribute_buffer);
                 }
                 'a' | 'A' => {
                     let prev_attributes = self.attribute_buffer.clone();
@@ -347,7 +346,7 @@ impl PathParser {
                         output.quadratic_bezier_to(
                             curve.ctrl,
                             curve.to,
-                            Attributes(&interpolated_attributes),
+                            &interpolated_attributes,
                         );
                     });
                 }
@@ -358,7 +357,7 @@ impl PathParser {
 
                     let to = self.parse_endpoint(is_relatve, src)?;
                     first_position = to;
-                    output.begin(to, Attributes(&self.attribute_buffer));
+                    output.begin(to, &self.attribute_buffer);
                     self.need_end = true;
                     need_start = false;
                 }

--- a/crates/extra/src/parser.rs
+++ b/crates/extra/src/parser.rs
@@ -343,11 +343,7 @@ impl PathParser {
                             interpolated_attributes[i] = prev_attributes[i] * (1.0 - range.end)
                                 + self.attribute_buffer[i] * range.end;
                         }
-                        output.quadratic_bezier_to(
-                            curve.ctrl,
-                            curve.to,
-                            &interpolated_attributes,
-                        );
+                        output.quadratic_bezier_to(curve.ctrl, curve.to, &interpolated_attributes);
                     });
                 }
                 'm' | 'M' => {

--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -5,8 +5,8 @@ use std::ops::Range;
 
 use crate::scalar::{cast, Float, Scalar};
 use crate::segment::{BoundingBox, Segment};
-use crate::{CubicBezierSegment, QuadraticBezierSegment, LineSegment, Line};
 use crate::{point, vector, Angle, Box2D, Point, Rotation, Transform, Vector};
+use crate::{CubicBezierSegment, Line, LineSegment, QuadraticBezierSegment};
 
 /// An elliptic arc curve segment.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -312,7 +312,10 @@ impl<S: Scalar> Arc<S> {
             from = to;
         }
 
-        callback(&LineSegment { from, to: self.to() });
+        callback(&LineSegment {
+            from,
+            to: self.to(),
+        });
     }
 
     /// Approximates the curve with sequence of line segments.
@@ -338,12 +341,18 @@ impl<S: Scalar> Arc<S> {
             iter = iter.after_split(step);
             let t1 = t0 + step * (S::ONE - t0);
             let to = iter.from();
-            callback(&LineSegment { from, to, }, t0 .. t1);
+            callback(&LineSegment { from, to }, t0..t1);
             from = to;
             t0 = t1;
         }
 
-        callback(&LineSegment { from, to: self.to() }, t0 .. S::ONE);
+        callback(
+            &LineSegment {
+                from,
+                to: self.to(),
+            },
+            t0..S::ONE,
+        );
     }
 
     /// Finds the interval of the beginning of the curve that can be approximated with a
@@ -577,7 +586,10 @@ impl<S: Scalar> SvgArc<S> {
     /// its approximation.
     pub fn for_each_flattened<F: FnMut(&LineSegment<S>)>(&self, tolerance: S, cb: &mut F) {
         if self.is_straight_line() {
-            cb(&LineSegment { from: self.from, to: self.to });
+            cb(&LineSegment {
+                from: self.from,
+                to: self.to,
+            });
             return;
         }
 
@@ -590,9 +602,19 @@ impl<S: Scalar> SvgArc<S> {
     /// its approximation.
     ///
     /// The end of the t parameter range at the final segment is guaranteed to be equal to `1.0`.
-    pub fn for_each_flattened_with_t<F: FnMut(&LineSegment<S>, Range<S>)>(&self, tolerance: S, cb: &mut F) {
+    pub fn for_each_flattened_with_t<F: FnMut(&LineSegment<S>, Range<S>)>(
+        &self,
+        tolerance: S,
+        cb: &mut F,
+    ) {
         if self.is_straight_line() {
-            cb(&LineSegment { from: self.from, to: self.to }, S::ZERO .. S::ONE);
+            cb(
+                &LineSegment {
+                    from: self.from,
+                    to: self.to,
+                },
+                S::ZERO..S::ONE,
+            );
             return;
         }
 
@@ -752,8 +774,12 @@ impl<S: Scalar> Segment for Arc<S> {
         self.approximate_length(tolerance)
     }
 
-    fn for_each_flattened_with_t(&self, tolerance: Self::Scalar, callback: &mut dyn FnMut(&LineSegment<S>, Range<S>)) {
-        self.for_each_flattened_with_t(tolerance, &mut|s, t| callback(s, t));
+    fn for_each_flattened_with_t(
+        &self,
+        tolerance: Self::Scalar,
+        callback: &mut dyn FnMut(&LineSegment<S>, Range<S>),
+    ) {
+        self.for_each_flattened_with_t(tolerance, &mut |s, t| callback(s, t));
     }
 }
 

--- a/crates/geom/src/cubic_bezier.rs
+++ b/crates/geom/src/cubic_bezier.rs
@@ -1,4 +1,3 @@
-
 use crate::cubic_bezier_intersections::cubic_bezier_intersections_t;
 use crate::scalar::Scalar;
 use crate::segment::{BoundingBox, Segment};
@@ -407,12 +406,12 @@ impl<S: Scalar> CubicBezierSegment<S> {
         let mut t0 = S::ZERO;
         for &t in &extrema {
             if t != t0 {
-                cb(t0 .. t);
+                cb(t0..t);
                 t0 = t;
             }
         }
 
-        cb(t0 .. S::ONE);
+        cb(t0..S::ONE);
     }
 
     /// Invokes a callback for each monotonic part of the segment.
@@ -443,11 +442,11 @@ impl<S: Scalar> CubicBezierSegment<S> {
     {
         let mut t0 = S::ZERO;
         self.for_each_local_y_extremum_t(&mut |t| {
-            cb(t0 .. t);
+            cb(t0..t);
             t0 = t;
         });
 
-        cb(t0 .. S::ONE);
+        cb(t0..S::ONE);
     }
 
     /// Invokes a callback for each y-monotonic part of the segment.
@@ -474,11 +473,11 @@ impl<S: Scalar> CubicBezierSegment<S> {
     {
         let mut t0 = S::ZERO;
         self.for_each_local_x_extremum_t(&mut |t| {
-            cb(t0 .. t);
+            cb(t0..t);
             t0 = t;
         });
 
-        cb(t0 .. S::ONE);
+        cb(t0..S::ONE);
     }
 
     /// Invokes a callback for each x-monotonic part of the segment.
@@ -555,7 +554,11 @@ impl<S: Scalar> CubicBezierSegment<S> {
     /// its approximation.
     ///
     /// The end of the t parameter range at the final segment is guaranteed to be equal to `1.0`.
-    pub fn for_each_flattened_with_t<F: FnMut(&LineSegment<S>, Range<S>)>(&self, tolerance: S, callback: &mut F) {
+    pub fn for_each_flattened_with_t<F: FnMut(&LineSegment<S>, Range<S>)>(
+        &self,
+        tolerance: S,
+        callback: &mut F,
+    ) {
         debug_assert!(tolerance >= S::EPSILON * S::EPSILON);
         let quadratics_tolerance = tolerance * S::value(0.4);
         let flattening_tolerance = tolerance * S::value(0.8);
@@ -581,7 +584,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
     pub fn approximate_length(&self, tolerance: S) -> S {
         let mut length = S::ZERO;
 
-        self.for_each_quadratic_bezier(tolerance, &mut|quad| {
+        self.for_each_quadratic_bezier(tolerance, &mut |quad| {
             length += quad.length();
         });
 
@@ -597,8 +600,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         // See www.faculty.idc.ac.il/arik/quality/appendixa.html for an explanation
         // of this approach.
         let pa = self.ctrl1 - self.from;
-        let pb =
-            self.ctrl2.to_vector() - (self.ctrl1.to_vector() * S::TWO) + self.from.to_vector();
+        let pb = self.ctrl2.to_vector() - (self.ctrl1.to_vector() * S::TWO) + self.from.to_vector();
         let pc = self.to.to_vector() - (self.ctrl2.to_vector() * S::THREE)
             + (self.ctrl1.to_vector() * S::THREE)
             - self.from.to_vector();
@@ -1236,7 +1238,11 @@ impl<S: Scalar> CubicBezierSegment<S> {
         // Move the most constrained control point by a subset of the uniform displacement
         // depending on the weight.
         let uniform_displacement = new_a - old_a;
-        let f = if t < S::HALF { S::TWO * weight } else { S::TWO * (S::ONE - weight) };
+        let f = if t < S::HALF {
+            S::TWO * weight
+        } else {
+            S::TWO * (S::ONE - weight)
+        };
         let mut new_ctrl1 = ctrl1 + uniform_displacement * f;
 
         // Now that the most constrained control point is placed there is only one position
@@ -1262,8 +1268,12 @@ impl<S: Scalar> CubicBezierSegment<S> {
 impl<S: Scalar> Segment for CubicBezierSegment<S> {
     impl_segment!(S);
 
-    fn for_each_flattened_with_t(&self, tolerance: Self::Scalar, callback: &mut dyn FnMut(&LineSegment<S>, Range<S>)) {
-        self.for_each_flattened_with_t(tolerance, &mut|s, t| callback(s, t));
+    fn for_each_flattened_with_t(
+        &self,
+        tolerance: Self::Scalar,
+        callback: &mut dyn FnMut(&LineSegment<S>, Range<S>),
+    ) {
+        self.for_each_flattened_with_t(tolerance, &mut |s, t| callback(s, t));
     }
 }
 
@@ -1990,7 +2000,6 @@ fn cubic_line_intersection_on_endpoint() {
     assert!(intersections.is_empty());
 }
 
-
 #[test]
 fn test_cubic_to_quadratics() {
     use euclid::approxeq::ApproxEq;
@@ -2003,13 +2012,15 @@ fn test_cubic_to_quadratics() {
 
     let mut count = 0;
     assert_eq!(quadratic.to_cubic().num_quadratics(0.0001), 1);
-    quadratic.to_cubic().for_each_quadratic_bezier(0.0001, &mut |c| {
-        assert!(count == 0);
-        assert!(c.from.approx_eq(&quadratic.from));
-        assert!(c.ctrl.approx_eq(&quadratic.ctrl));
-        assert!(c.to.approx_eq(&quadratic.to));
-        count += 1;
-    });
+    quadratic
+        .to_cubic()
+        .for_each_quadratic_bezier(0.0001, &mut |c| {
+            assert!(count == 0);
+            assert!(c.from.approx_eq(&quadratic.from));
+            assert!(c.ctrl.approx_eq(&quadratic.ctrl));
+            assert!(c.to.approx_eq(&quadratic.to));
+            count += 1;
+        });
 
     let cubic = CubicBezierSegment {
         from: point(1.0f32, 1.0),

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -513,8 +513,12 @@ impl<S: Scalar> Segment for LineSegment<S> {
         self.length()
     }
 
-    fn for_each_flattened_with_t(&self, _tolerance: Self::Scalar, callback: &mut dyn FnMut(&LineSegment<S>, Range<S>)) {
-        callback(self, S::ZERO .. S::ONE);
+    fn for_each_flattened_with_t(
+        &self,
+        _tolerance: Self::Scalar,
+        callback: &mut dyn FnMut(&LineSegment<S>, Range<S>),
+    ) {
+        callback(self, S::ZERO..S::ONE);
     }
 }
 

--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -264,7 +264,10 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
             return true;
         }
 
-        let d = self.baseline().to_line().square_distance_to_point(self.ctrl);
+        let d = self
+            .baseline()
+            .to_line()
+            .square_distance_to_point(self.ctrl);
 
         d <= (tolerance * tolerance * S::FOUR)
     }
@@ -359,17 +362,14 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
                 to: self.sample(t),
             };
 
-            callback(&s, t_from .. t);
+            callback(&s, t_from..t);
             from = s.to;
             t_from = t;
         }
 
-        let s = LineSegment {
-            from,
-            to: self.to,
-        };
+        let s = LineSegment { from, to: self.to };
 
-        callback(&s, t_from .. S::ONE);
+        callback(&s, t_from..S::ONE);
     }
 
     /// Returns the flattened representation of the curve as an iterator, starting *after* the
@@ -403,19 +403,19 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
         let mut start = S::ZERO;
 
         if let Some(t) = t0 {
-            cb(start .. t);
+            cb(start..t);
             start = t;
         }
 
         if let Some(t) = t1 {
             // In extreme cases the same point can be an x and y inflection point.
             if t != start {
-                cb(start .. t);
+                cb(start..t);
                 start = t
             }
         }
 
-        cb(start .. S::ONE);
+        cb(start..S::ONE);
     }
 
     /// Invokes a callback for each monotonic part of the segment.
@@ -444,11 +444,11 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
     {
         match self.local_y_extremum_t() {
             Some(t) => {
-                cb(S::ZERO .. t);
-                cb(t .. S::ONE);
+                cb(S::ZERO..t);
+                cb(t..S::ONE);
             }
             None => {
-                cb(S::ZERO .. S::ONE);
+                cb(S::ZERO..S::ONE);
             }
         }
     }
@@ -477,11 +477,11 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
     {
         match self.local_x_extremum_t() {
             Some(t) => {
-                cb(S::ZERO .. t);
-                cb(t .. S::ONE);
+                cb(S::ZERO..t);
+                cb(t..S::ONE);
             }
             None => {
-                cb(S::ZERO .. S::ONE);
+                cb(S::ZERO..S::ONE);
             }
         }
     }
@@ -789,7 +789,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
         QuadraticBezierSegment {
             from: self.from,
             ctrl: new_position + (new_position - c) * inv_r,
-            to: self.to
+            to: self.to,
         }
     }
 
@@ -812,12 +812,12 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
             let v0 = (self.from.to_vector() * S::value(-0.492943519233745)
                 + self.ctrl.to_vector() * S::value(0.430331482911935)
                 + self.to.to_vector() * S::value(0.0626120363218102))
-                .length();
+            .length();
             let v1 = ((self.to - self.from) * S::value(0.4444444444444444)).length();
             let v2 = (self.from.to_vector() * S::value(-0.0626120363218102)
                 + self.ctrl.to_vector() * S::value(-0.430331482911935)
                 + self.to.to_vector() * S::value(0.492943519233745))
-                .length();
+            .length();
             return v0 + v1 + v2;
         }
 
@@ -835,7 +835,8 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
             // The curve has a sharp turns.
             v0
         } else {
-            v0 + S::HALF * S::HALF
+            v0 + S::HALF
+                * S::HALF
                 * a32
                 * (S::FOUR * c * a - b * b)
                 * (((S::TWO * a + b) * a2 + S::TWO * sqr_abc) / ba_c2).ln()
@@ -1038,8 +1039,12 @@ impl<S: Scalar> Iterator for FlattenedT<S> {
 impl<S: Scalar> Segment for QuadraticBezierSegment<S> {
     impl_segment!(S);
 
-    fn for_each_flattened_with_t(&self, tolerance: Self::Scalar, callback: &mut dyn FnMut(&LineSegment<S>, Range<S>)) {
-        self.for_each_flattened_with_t(tolerance, &mut|s, t| callback(s, t));
+    fn for_each_flattened_with_t(
+        &self,
+        tolerance: Self::Scalar,
+        callback: &mut dyn FnMut(&LineSegment<S>, Range<S>),
+    ) {
+        self.for_each_flattened_with_t(tolerance, &mut |s, t| callback(s, t));
     }
 }
 
@@ -1220,7 +1225,8 @@ fn length_straight_line() {
         from: Point::new(0.0f64, 0.0),
         ctrl: Point::new(1.0, 0.0),
         to: Point::new(2.0, 0.0),
-    }.length();
+    }
+    .length();
     assert!((len - 2.0).abs() < 0.000001);
 
     let len = CubicBezierSegment {
@@ -1473,16 +1479,33 @@ fn drag() {
 
         use euclid::approxeq::ApproxEq;
         let p1 = dragged.sample(t);
-        assert!(p1.approx_eq_eps(&target, &point(0.001, 0.001)), "{:?} == {:?}", p1, target);
+        assert!(
+            p1.approx_eq_eps(&target, &point(0.001, 0.001)),
+            "{:?} == {:?}",
+            p1,
+            target
+        );
     }
 }
 
 #[test]
 fn arc_length() {
     let curves = [
-        QuadraticBezierSegment { from: point(0.0f64, 0.0), ctrl: point(100.0, 0.0), to: point(0.0, 100.0) },
-        QuadraticBezierSegment { from: point(0.0, 0.0), ctrl: point(100.0, 0.0), to: point(200.0, 0.0) },
-        QuadraticBezierSegment { from: point(100.0, 0.0), ctrl: point(0.0, 0.0), to: point(50.0, 1.0) },
+        QuadraticBezierSegment {
+            from: point(0.0f64, 0.0),
+            ctrl: point(100.0, 0.0),
+            to: point(0.0, 100.0),
+        },
+        QuadraticBezierSegment {
+            from: point(0.0, 0.0),
+            ctrl: point(100.0, 0.0),
+            to: point(200.0, 0.0),
+        },
+        QuadraticBezierSegment {
+            from: point(100.0, 0.0),
+            ctrl: point(0.0, 0.0),
+            to: point(50.0, 1.0),
+        },
     ];
 
     for (idx, curve) in curves.iter().enumerate() {
@@ -1492,6 +1515,12 @@ fn arc_length() {
             accum += line.length();
         });
 
-        assert!((length - accum).abs() < 0.00001, "curve {:?}, {:?} == {:?}", idx, length, accum);
+        assert!(
+            (length - accum).abs() < 0.00001,
+            "curve {:?}, {:?} == {:?}",
+            idx,
+            length,
+            accum
+        );
     }
 }

--- a/crates/geom/src/segment.rs
+++ b/crates/geom/src/segment.rs
@@ -1,5 +1,5 @@
 use crate::scalar::Scalar;
-use crate::{point, Box2D, Point, Vector, LineSegment};
+use crate::{point, Box2D, LineSegment, Point, Vector};
 
 use std::ops::Range;
 
@@ -68,7 +68,7 @@ pub trait Segment: Copy + Sized {
     fn for_each_flattened_with_t(
         &self,
         tolerance: Self::Scalar,
-        callback: &mut dyn FnMut(&LineSegment<Self::Scalar>, Range<Self::Scalar>)
+        callback: &mut dyn FnMut(&LineSegment<Self::Scalar>, Range<Self::Scalar>),
     );
 }
 

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -84,7 +84,7 @@ use crate::geom::{traits::Transformation, Arc, ArcFlags, LineSegment, SvgArc};
 use crate::math::*;
 use crate::path::Verb;
 use crate::polygon::Polygon;
-use crate::{Attributes, EndpointId, Winding};
+use crate::{Attributes, EndpointId, Winding, NO_ATTRIBUTES};
 
 use std::marker::Sized;
 
@@ -161,7 +161,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     /// `at` becomes the current position of the sub-path.
     #[inline]
     pub fn begin(&mut self, at: Point) -> EndpointId {
-        self.inner.begin(at, Attributes::NONE)
+        self.inner.begin(at, NO_ATTRIBUTES)
     }
 
     /// Ends the current sub path.
@@ -187,7 +187,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     /// A sub-path must be in progress when this method is called.
     #[inline]
     pub fn line_to(&mut self, to: Point) -> EndpointId {
-        self.inner.line_to(to, Attributes::NONE)
+        self.inner.line_to(to, NO_ATTRIBUTES)
     }
 
     /// Adds a quadratic bézier curve to the current sub-path.
@@ -195,7 +195,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     /// A sub-path must be in progress when this method is called.
     #[inline]
     pub fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point) -> EndpointId {
-        self.inner.quadratic_bezier_to(ctrl, to, Attributes::NONE)
+        self.inner.quadratic_bezier_to(ctrl, to, NO_ATTRIBUTES)
     }
 
     /// Adds a cubic bézier curve to the current sub-path.
@@ -204,7 +204,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     #[inline]
     pub fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point) -> EndpointId {
         self.inner
-            .cubic_bezier_to(ctrl1, ctrl2, to, Attributes::NONE)
+            .cubic_bezier_to(ctrl1, ctrl2, to, NO_ATTRIBUTES)
     }
 
     /// Hints at the builder that a certain number of endpoints and control
@@ -225,7 +225,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     /// The requirements for each method apply to the corresponding event.
     #[inline]
     pub fn path_event(&mut self, event: PathEvent) {
-        self.inner.path_event(event, Attributes::NONE);
+        self.inner.path_event(event, NO_ATTRIBUTES);
     }
 
     /// Adds a sub-path from a polygon.
@@ -234,7 +234,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     /// No sub-path is in progress after the method is called.
     #[inline]
     pub fn add_polygon(&mut self, polygon: Polygon<Point>) {
-        self.inner.add_polygon(polygon, Attributes::NONE);
+        self.inner.add_polygon(polygon, NO_ATTRIBUTES);
     }
 
     /// Adds a sub-path containing a single point.
@@ -243,7 +243,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     /// No sub-path is in progress after the method is called.
     #[inline]
     pub fn add_point(&mut self, at: Point) -> EndpointId {
-        self.inner.add_point(at, Attributes::NONE)
+        self.inner.add_point(at, NO_ATTRIBUTES)
     }
 
     /// Adds a sub-path containing a single line segment.
@@ -252,7 +252,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     /// No sub-path is in progress after the method is called.
     #[inline]
     pub fn add_line_segment(&mut self, line: &LineSegment<f32>) -> (EndpointId, EndpointId) {
-        self.inner.add_line_segment(line, Attributes::NONE)
+        self.inner.add_line_segment(line, NO_ATTRIBUTES)
     }
 
     /// Adds a sub-path containing an ellipse.
@@ -268,7 +268,7 @@ impl<B: PathBuilder> NoAttributes<B> {
         winding: Winding,
     ) {
         self.inner
-            .add_ellipse(center, radii, x_rotation, winding, Attributes::NONE);
+            .add_ellipse(center, radii, x_rotation, winding, NO_ATTRIBUTES);
     }
 
     /// Adds a sub-path containing a circle.
@@ -281,7 +281,7 @@ impl<B: PathBuilder> NoAttributes<B> {
         B: Sized,
     {
         self.inner
-            .add_circle(center, radius, winding, Attributes::NONE);
+            .add_circle(center, radius, winding, NO_ATTRIBUTES);
     }
 
     /// Adds a sub-path containing a rectangle.
@@ -290,7 +290,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     /// No sub-path is in progress after the method is called.
     #[inline]
     pub fn add_rectangle(&mut self, rect: &Box2D, winding: Winding) {
-        self.inner.add_rectangle(rect, winding, Attributes::NONE);
+        self.inner.add_rectangle(rect, winding, NO_ATTRIBUTES);
     }
 
     /// Adds a sub-path containing a rectangle.
@@ -303,7 +303,7 @@ impl<B: PathBuilder> NoAttributes<B> {
         B: Sized,
     {
         self.inner
-            .add_rounded_rectangle(rect, radii, winding, Attributes::NONE);
+            .add_rounded_rectangle(rect, radii, winding, NO_ATTRIBUTES);
     }
 
     /// Returns a builder that approximates all curves with sequences of line segments.
@@ -376,7 +376,7 @@ impl<B: PathBuilder> PathBuilder for NoAttributes<B> {
 
     #[inline]
     fn begin(&mut self, at: Point, _attributes: Attributes) -> EndpointId {
-        self.inner.begin(at, Attributes::NONE)
+        self.inner.begin(at, NO_ATTRIBUTES)
     }
 
     #[inline]
@@ -386,7 +386,7 @@ impl<B: PathBuilder> PathBuilder for NoAttributes<B> {
 
     #[inline]
     fn line_to(&mut self, to: Point, _attributes: Attributes) -> EndpointId {
-        self.inner.line_to(to, Attributes::NONE)
+        self.inner.line_to(to, NO_ATTRIBUTES)
     }
 
     #[inline]
@@ -396,7 +396,7 @@ impl<B: PathBuilder> PathBuilder for NoAttributes<B> {
         to: Point,
         _attributes: Attributes,
     ) -> EndpointId {
-        self.inner.quadratic_bezier_to(ctrl, to, Attributes::NONE)
+        self.inner.quadratic_bezier_to(ctrl, to, NO_ATTRIBUTES)
     }
 
     #[inline]
@@ -408,7 +408,7 @@ impl<B: PathBuilder> PathBuilder for NoAttributes<B> {
         _attributes: Attributes,
     ) -> EndpointId {
         self.inner
-            .cubic_bezier_to(ctrl1, ctrl2, to, Attributes::NONE)
+            .cubic_bezier_to(ctrl1, ctrl2, to, NO_ATTRIBUTES)
     }
 
     #[inline]
@@ -965,7 +965,7 @@ impl<Builder: PathBuilder> PathBuilder for Flattened<Builder> {
     fn line_to(&mut self, to: Point, attributes: Attributes) -> EndpointId {
         let id = self.builder.line_to(to, attributes);
         self.current_position = to;
-        self.prev_attributes.copy_from_slice(attributes.as_slice());
+        self.prev_attributes.copy_from_slice(attributes);
         id
     }
 
@@ -981,12 +981,12 @@ impl<Builder: PathBuilder> PathBuilder for Flattened<Builder> {
             ctrl,
             to,
             attributes,
-            Attributes(&self.prev_attributes),
+            &self.prev_attributes,
             &mut self.builder,
             &mut self.attribute_buffer,
         );
         self.current_position = to;
-        self.prev_attributes.copy_from_slice(attributes.as_slice());
+        self.prev_attributes.copy_from_slice(attributes);
 
         id
     }
@@ -1005,12 +1005,12 @@ impl<Builder: PathBuilder> PathBuilder for Flattened<Builder> {
             ctrl2,
             to,
             attributes,
-            Attributes(&self.prev_attributes),
+            &self.prev_attributes,
             &mut self.builder,
             &mut self.attribute_buffer,
         );
         self.current_position = to;
-        self.prev_attributes.copy_from_slice(attributes.as_slice());
+        self.prev_attributes.copy_from_slice(attributes);
 
         id
     }
@@ -1186,7 +1186,7 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
     pub fn move_to(&mut self, to: Point) -> EndpointId {
         self.end_if_needed();
 
-        let id = self.builder.begin(to, Attributes(&self.attribute_buffer));
+        let id = self.builder.begin(to, &self.attribute_buffer);
 
         self.is_empty = false;
         self.need_moveto = false;
@@ -1205,7 +1205,7 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
         self.current_position = to;
         self.last_cmd = Verb::LineTo;
 
-        self.builder.line_to(to, Attributes(&self.attribute_buffer))
+        self.builder.line_to(to, &self.attribute_buffer)
     }
 
     pub fn close(&mut self) {
@@ -1246,7 +1246,7 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
         self.last_ctrl = ctrl;
 
         self.builder
-            .quadratic_bezier_to(ctrl, to, Attributes(&self.attribute_buffer))
+            .quadratic_bezier_to(ctrl, to, &self.attribute_buffer)
     }
 
     pub fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point) -> EndpointId {
@@ -1259,7 +1259,7 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
         self.last_ctrl = ctrl2;
 
         self.builder
-            .cubic_bezier_to(ctrl1, ctrl2, to, Attributes(&self.attribute_buffer))
+            .cubic_bezier_to(ctrl1, ctrl2, to, &self.attribute_buffer)
     }
 
     pub fn arc(&mut self, center: Point, radii: Vector, sweep_angle: Angle, x_rotation: Angle) {
@@ -1295,14 +1295,14 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
             self.move_to(arc_start);
         } else if (arc_start - self.current_position).square_length() < 0.01 {
             self.builder
-                .line_to(arc_start, Attributes(&self.attribute_buffer));
+                .line_to(arc_start, &self.attribute_buffer);
         }
 
         arc.for_each_quadratic_bezier(&mut |curve| {
             self.builder.quadratic_bezier_to(
                 curve.ctrl,
                 curve.to,
-                Attributes(&self.attribute_buffer),
+                &self.attribute_buffer,
             );
             self.current_position = curve.to;
         });

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -203,8 +203,7 @@ impl<B: PathBuilder> NoAttributes<B> {
     /// A sub-path must be in progress when this method is called.
     #[inline]
     pub fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point) -> EndpointId {
-        self.inner
-            .cubic_bezier_to(ctrl1, ctrl2, to, NO_ATTRIBUTES)
+        self.inner.cubic_bezier_to(ctrl1, ctrl2, to, NO_ATTRIBUTES)
     }
 
     /// Hints at the builder that a certain number of endpoints and control
@@ -407,8 +406,7 @@ impl<B: PathBuilder> PathBuilder for NoAttributes<B> {
         to: Point,
         _attributes: Attributes,
     ) -> EndpointId {
-        self.inner
-            .cubic_bezier_to(ctrl1, ctrl2, to, NO_ATTRIBUTES)
+        self.inner.cubic_bezier_to(ctrl1, ctrl2, to, NO_ATTRIBUTES)
     }
 
     #[inline]
@@ -1294,16 +1292,12 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
         if self.need_moveto {
             self.move_to(arc_start);
         } else if (arc_start - self.current_position).square_length() < 0.01 {
-            self.builder
-                .line_to(arc_start, &self.attribute_buffer);
+            self.builder.line_to(arc_start, &self.attribute_buffer);
         }
 
         arc.for_each_quadratic_bezier(&mut |curve| {
-            self.builder.quadratic_bezier_to(
-                curve.ctrl,
-                curve.to,
-                &self.attribute_buffer,
-            );
+            self.builder
+                .quadratic_bezier_to(curve.ctrl, curve.to, &self.attribute_buffer);
             self.current_position = curve.to;
         });
     }

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -415,7 +415,7 @@ impl AttributeStore for () {
     }
 
     fn get(&self, _: EndpointId) -> Attributes {
-        Attributes(&[])
+        NO_ATTRIBUTES
     }
 }
 
@@ -438,7 +438,7 @@ impl<'l> AttributeStore for AttributeSlice<'l> {
     fn get(&self, id: EndpointId) -> Attributes {
         let start = id.to_usize() * self.stride;
         let end = start + self.stride;
-        Attributes(&self.data[start..end])
+        &self.data[start..end]
     }
 
     fn num_attributes(&self) -> usize {
@@ -450,58 +450,12 @@ impl<'l> AttributeStore for AttributeSlice<'l> {
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct AttributeIndex(pub u8);
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Attributes<'l>(pub &'l [f32]);
-
-impl<'l> Attributes<'l> {
-    pub const NONE: Attributes<'static> = Attributes(&[]);
-
+impl AttributeIndex {
     #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[inline]
-    pub fn as_slice(&self) -> &[f32] {
-        self.0
-    }
+    pub fn index(&self) -> usize { self.0 as usize }
 }
 
-impl<'l> Default for Attributes<'l> {
-    fn default() -> Self {
-        Attributes::NONE
-    }
-}
+pub type Attributes<'l> = &'l [f32];
 
-impl<'l> std::ops::Index<AttributeIndex> for Attributes<'l> {
-    type Output = f32;
-    #[inline]
-    fn index(&self, idx: AttributeIndex) -> &f32 {
-        &self.0[idx.0 as usize]
-    }
-}
+pub const NO_ATTRIBUTES: Attributes<'static> = &[];
 
-impl<'l> std::ops::Index<usize> for Attributes<'l> {
-    type Output = f32;
-    #[inline]
-    fn index(&self, idx: usize) -> &f32 {
-        &self.0[idx]
-    }
-}
-
-impl<'l> From<&'l [f32]> for Attributes<'l> {
-    fn from(slice: &'l [f32]) -> Attributes<'l> {
-        Attributes(slice)
-    }
-}
-
-impl<'l> From<Attributes<'l>> for &'l [f32] {
-    fn from(attr: Attributes<'l>) -> &'l [f32] {
-        attr.0
-    }
-}

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -446,16 +446,10 @@ impl<'l> AttributeStore for AttributeSlice<'l> {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
-pub struct AttributeIndex(pub u8);
-
-impl AttributeIndex {
-    #[inline]
-    pub fn index(&self) -> usize { self.0 as usize }
-}
-
+/// An alias for `usize`.
+pub type AttributeIndex = usize;
+/// An alias for a slice of `f32` values.
 pub type Attributes<'l> = &'l [f32];
-
+/// An empty attribute slice.
 pub const NO_ATTRIBUTES: Attributes<'static> = &[];
 

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -452,4 +452,3 @@ pub type AttributeIndex = usize;
 pub type Attributes<'l> = &'l [f32];
 /// An empty attribute slice.
 pub const NO_ATTRIBUTES: Attributes<'static> = &[];
-

--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -1039,10 +1039,7 @@ impl<'l> IterWithAttributes<'l> {
                                 line.from,
                                 &buffer[next_offset..(next_offset + num_attributes)],
                             ),
-                            to: (
-                                line.to,
-                                &buffer[offset..(offset + num_attributes)],
-                            ),
+                            to: (line.to, &buffer[offset..(offset + num_attributes)]),
                         });
 
                         offset = next_offset;
@@ -1076,10 +1073,7 @@ impl<'l> IterWithAttributes<'l> {
                                 line.from,
                                 &buffer[next_offset..(next_offset + num_attributes)],
                             ),
-                            to: (
-                                line.to,
-                                &buffer[offset..(offset + num_attributes)],
-                            ),
+                            to: (line.to, &buffer[offset..(offset + num_attributes)]),
                         });
 
                         offset = next_offset;
@@ -1446,7 +1440,9 @@ fn n_stored_points(verb: Verb, attrib_stride: usize) -> usize {
 }
 
 #[cfg(test)]
-fn slice(a: &[f32]) -> &[f32] { a }
+fn slice(a: &[f32]) -> &[f32] {
+    a
+}
 
 #[test]
 fn test_reverse_path_simple() {
@@ -1730,12 +1726,7 @@ fn test_path_builder_1() {
     p.line_to(point(2.0, 0.0), &[2.0]);
     p.line_to(point(3.0, 0.0), &[3.0]);
     p.quadratic_bezier_to(point(4.0, 0.0), point(4.0, 1.0), &[4.0]);
-    p.cubic_bezier_to(
-        point(5.0, 0.0),
-        point(5.0, 1.0),
-        point(5.0, 2.0),
-        &[5.0],
-    );
+    p.cubic_bezier_to(point(5.0, 0.0), point(5.0, 1.0), point(5.0, 2.0), &[5.0]);
     p.end(true);
 
     p.begin(point(10.0, 0.0), &[6.0]);
@@ -2075,12 +2066,7 @@ fn flattened_custom_attributes() {
     let mut path = Path::builder_with_attributes(1);
     path.begin(point(0.0, 0.0), &[0.0]);
     path.quadratic_bezier_to(point(1.0, 0.0), point(1.0, 1.0), &[1.0]);
-    path.cubic_bezier_to(
-        point(1.0, 2.0),
-        point(0.0, 2.0),
-        point(0.0, 1.0),
-        &[2.0],
-    );
+    path.cubic_bezier_to(point(1.0, 2.0), point(0.0, 2.0), point(0.0, 1.0), &[2.0]);
     path.end(false);
 
     let path = path.build();
@@ -2127,10 +2113,7 @@ fn first_last() {
         path.first_endpoint(),
         Some((point(0.0, 0.0), slice(&[1.0])))
     );
-    assert_eq!(
-        path.last_endpoint(),
-        Some((point(4.0, 4.0), slice(&[5.0])))
-    );
+    assert_eq!(path.last_endpoint(), Some((point(4.0, 4.0), slice(&[5.0]))));
 
     let mut path = Path::builder_with_attributes(1);
     path.begin(point(0.0, 0.0), &[1.0]);
@@ -2143,10 +2126,7 @@ fn first_last() {
         path.first_endpoint(),
         Some((point(0.0, 0.0), slice(&[1.0])))
     );
-    assert_eq!(
-        path.last_endpoint(),
-        Some((point(0.0, 0.0), slice(&[1.0])))
-    );
+    assert_eq!(path.last_endpoint(), Some((point(0.0, 0.0), slice(&[1.0]))));
 }
 
 #[test]

--- a/crates/path/src/path_buffer.rs
+++ b/crates/path/src/path_buffer.rs
@@ -3,7 +3,7 @@
 use crate::builder::*;
 use crate::math::*;
 use crate::path;
-use crate::{Attributes, EndpointId, PathSlice};
+use crate::{Attributes, EndpointId, PathSlice, NO_ATTRIBUTES};
 
 use std::fmt;
 use std::iter::{FromIterator, FusedIterator, IntoIterator};
@@ -115,7 +115,7 @@ impl<'l> FromIterator<PathSlice<'l>> for PathBuffer {
                 let builder = buffer.builder();
                 path.iter()
                     .fold(builder, |mut builder, event| {
-                        builder.path_event(event, Attributes::NONE);
+                        builder.path_event(event, NO_ATTRIBUTES);
                         builder
                     })
                     .build();

--- a/crates/path/src/private.rs
+++ b/crates/path/src/private.rs
@@ -85,7 +85,7 @@ pub fn flatten_quadratic_bezier(
             for i in 0..n {
                 buffer[i] = prev_attributes[i] * (1.0 - t.end) + attributes[i] * t.end;
             }
-            Attributes(&buffer[..])
+            &buffer[..]
         };
         id = builder.line_to(line.to, attr);
     });
@@ -119,7 +119,7 @@ pub fn flatten_cubic_bezier(
             for i in 0..n {
                 buffer[i] = prev_attributes[i] * (1.0 - t.end) + attributes[i] * t.end;
             }
-            Attributes(&buffer[..])
+            &buffer[..]
         };
         id = builder.line_to(line.to, attr);
     });

--- a/crates/tessellation/src/basic_shapes.rs
+++ b/crates/tessellation/src/basic_shapes.rs
@@ -205,7 +205,7 @@ fn fill_border_radius(
 
 #[test]
 fn basic_shapes() {
-    use crate::{GeometryBuilderError};
+    use crate::GeometryBuilderError;
 
     let mut tess = crate::FillTessellator::new();
 

--- a/crates/tessellation/src/event_queue.rs
+++ b/crates/tessellation/src/event_queue.rs
@@ -1,5 +1,5 @@
 use crate::fill::{compare_positions, is_after};
-use crate::geom::{CubicBezierSegment, QuadraticBezierSegment, LineSegment};
+use crate::geom::{CubicBezierSegment, LineSegment, QuadraticBezierSegment};
 use crate::math::{point, Point};
 use crate::path::private::DebugValidator;
 use crate::path::{EndpointId, IdEvent, PathEvent, PositionStore};
@@ -747,7 +747,14 @@ impl EventQueueBuilder {
             self.second = to;
         }
 
-        self.add_edge(&LineSegment { from, to }, 1, self.prev_endpoint_id, to_id, t0, t1);
+        self.add_edge(
+            &LineSegment { from, to },
+            1,
+            self.prev_endpoint_id,
+            to_id,
+            t0,
+            t1,
+        );
 
         self.prev = self.current;
         self.prev_endpoint_id = to_id;

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -2215,8 +2215,7 @@ impl<'l> FillVertex<'l> {
                 let a = store.get(id);
                 assert!(a.len() == num_attributes);
                 assert!(self.attrib_buffer.len() == num_attributes);
-                self.attrib_buffer[..num_attributes]
-                    .clone_from_slice(&a[..num_attributes]);
+                self.attrib_buffer[..num_attributes].clone_from_slice(&a[..num_attributes]);
             }
             VertexSource::Edge { from, to, t } => {
                 let a = store.get(from);
@@ -2711,20 +2710,11 @@ fn fill_vertex_source_01() {
             }
 
             if eq(pos, point(0.0, 0.0)) {
-                assert_eq!(
-                    vertex.interpolated_attributes(),
-                    &[1.0, 0.0, 0.0]
-                )
+                assert_eq!(vertex.interpolated_attributes(), &[1.0, 0.0, 0.0])
             } else if eq(pos, point(1.0, 1.0)) {
-                assert_eq!(
-                    vertex.interpolated_attributes(),
-                    &[0.0, 1.0, 0.0]
-                )
+                assert_eq!(vertex.interpolated_attributes(), &[0.0, 1.0, 0.0])
             } else if eq(pos, point(0.0, 2.0)) {
-                assert_eq!(
-                    vertex.interpolated_attributes(),
-                    &[0.0, 0.0, 1.0]
-                )
+                assert_eq!(vertex.interpolated_attributes(), &[0.0, 0.0, 1.0])
             }
 
             let id = self.next_vertex;

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -712,7 +712,7 @@ impl path::AttributeStore for SimpleAttributeStore {
     fn get(&self, id: EndpointId) -> Attributes {
         let start = id.0 as usize * self.num_attributes;
         let end = start + self.num_attributes;
-        Attributes(&self.data[start..end])
+        &self.data[start..end]
     }
 
     fn num_attributes(&self) -> usize {
@@ -737,7 +737,7 @@ impl SimpleAttributeStore {
 
     pub fn add(&mut self, attributes: Attributes) -> EndpointId {
         debug_assert_eq!(attributes.len(), self.num_attributes);
-        self.data.extend_from_slice(attributes.as_slice());
+        self.data.extend_from_slice(attributes);
         let id = self.next_id;
         self.next_id.0 += 1;
         id

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -395,7 +395,7 @@ impl<'l> StrokeBuilder<'l> {
 
     fn get_width(&self, attributes: Attributes) -> f32 {
         if let Some(idx) = self.builder.options.variable_line_width {
-            self.builder.options.line_width * attributes[idx]
+            self.builder.options.line_width * attributes[idx.index()]
         } else {
             self.builder.options.line_width
         }
@@ -411,7 +411,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         self.validator.begin();
         let id = self.attrib_store.add(attributes);
         if let Some(attrib_index) = self.builder.options.variable_line_width {
-            let width = self.builder.options.line_width * attributes[attrib_index];
+            let width = self.builder.options.line_width * attributes[attrib_index.index()];
             self.builder.begin(to, id, width, self.attrib_store);
             self.prev = (to, id, width);
         } else {
@@ -431,7 +431,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         let id = self.attrib_store.add(attributes);
         self.validator.edge();
         if let Some(attrib_index) = self.builder.options.variable_line_width {
-            let width = self.builder.options.line_width * attributes[attrib_index];
+            let width = self.builder.options.line_width * attributes[attrib_index.index()];
             self.builder.line_to(to, id, width, self.attrib_store);
             self.prev = (to, id, width);
         } else {
@@ -455,7 +455,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         let curve = QuadraticBezierSegment { from, ctrl, to };
 
         if let Some(attrib_index) = self.builder.options.variable_line_width {
-            let end_width = self.builder.options.line_width * attributes[attrib_index];
+            let end_width = self.builder.options.line_width * attributes[attrib_index.index()];
             self.builder.quadratic_bezier_to(
                 &curve,
                 from_id,
@@ -495,7 +495,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         };
 
         if let Some(attrib_index) = self.builder.options.variable_line_width {
-            let end_width = self.builder.options.line_width * attributes[attrib_index];
+            let end_width = self.builder.options.line_width * attributes[attrib_index.index()];
             self.builder.cubic_bezier_to(
                 &curve,
                 from_id,
@@ -653,7 +653,7 @@ impl<'l> StrokeBuilderImpl<'l> {
         attributes: &dyn AttributeStore,
     ) -> TessellationResult {
         let base_width = self.options.line_width;
-        let attrib_index = self.options.variable_line_width.unwrap();
+        let attrib_index = self.options.variable_line_width.unwrap().index();
 
         let mut validator = DebugValidator::new();
 
@@ -2637,7 +2637,7 @@ impl<'a, 'b> StrokeVertex<'a, 'b> {
     #[inline]
     pub fn interpolated_attributes(&mut self) -> Attributes {
         if self.0.buffer_is_valid {
-            return Attributes(&self.0.buffer[..]);
+            return &self.0.buffer[..];
         }
 
         match self.0.src {
@@ -2650,7 +2650,7 @@ impl<'a, 'b> StrokeVertex<'a, 'b> {
                 }
                 self.0.buffer_is_valid = true;
 
-                Attributes(&self.0.buffer[..])
+                &self.0.buffer[..]
             }
         }
     }
@@ -2762,16 +2762,16 @@ fn test_path(path: PathSlice, options: &StrokeOptions, expected_triangle_count: 
 fn test_square() {
     let mut builder = Path::builder_with_attributes(1);
 
-    builder.begin(point(-1.0, 1.0), Attributes(&[0.3]));
-    builder.line_to(point(1.0, 1.0), Attributes(&[0.3]));
-    builder.line_to(point(1.0, -1.0), Attributes(&[0.3]));
-    builder.line_to(point(-1.0, -1.0), Attributes(&[0.3]));
+    builder.begin(point(-1.0, 1.0), &[0.3]);
+    builder.line_to(point(1.0, 1.0), &[0.3]);
+    builder.line_to(point(1.0, -1.0), &[0.3]);
+    builder.line_to(point(-1.0, -1.0), &[0.3]);
     builder.end(false);
 
-    builder.begin(point(-1.0, -1.0), Attributes(&[0.3]));
-    builder.line_to(point(1.0, -1.0), Attributes(&[0.3]));
-    builder.line_to(point(1.0, 1.0), Attributes(&[0.3]));
-    builder.line_to(point(-1.0, 1.0), Attributes(&[0.3]));
+    builder.begin(point(-1.0, -1.0), &[0.3]);
+    builder.line_to(point(1.0, -1.0), &[0.3]);
+    builder.line_to(point(1.0, 1.0), &[0.3]);
+    builder.line_to(point(-1.0, 1.0), &[0.3]);
     builder.end(false);
 
     let path = builder.build();
@@ -2833,28 +2833,28 @@ fn test_empty_caps() {
     let mut builder = Path::builder_with_attributes(1);
 
     // moveto + close: empty cap.
-    builder.begin(point(1.0, 0.0), Attributes(&[1.0]));
+    builder.begin(point(1.0, 0.0), &[1.0]);
     builder.end(true);
 
     // Only moveto + lineto at same position: empty cap.
-    builder.begin(point(2.0, 0.0), Attributes(&[1.0]));
-    builder.line_to(point(2.0, 0.0), Attributes(&[1.0]));
+    builder.begin(point(2.0, 0.0), &[1.0]);
+    builder.line_to(point(2.0, 0.0), &[1.0]);
     builder.end(false);
 
     // Only moveto + lineto at same position: empty cap.
-    builder.begin(point(3.0, 0.0), Attributes(&[1.0]));
-    builder.line_to(point(3.0, 0.0), Attributes(&[1.0]));
+    builder.begin(point(3.0, 0.0), &[1.0]);
+    builder.line_to(point(3.0, 0.0), &[1.0]);
     builder.end(true);
 
     // Only moveto + multiple lineto at same position: empty cap.
-    builder.begin(point(3.0, 0.0), Attributes(&[1.0]));
-    builder.line_to(point(3.0, 0.0), Attributes(&[1.0]));
-    builder.line_to(point(3.0, 0.0), Attributes(&[1.0]));
-    builder.line_to(point(3.0, 0.0), Attributes(&[1.0]));
+    builder.begin(point(3.0, 0.0), &[1.0]);
+    builder.line_to(point(3.0, 0.0), &[1.0]);
+    builder.line_to(point(3.0, 0.0), &[1.0]);
+    builder.line_to(point(3.0, 0.0), &[1.0]);
     builder.end(true);
 
     // moveto then end (not closed): no empty cap.
-    builder.begin(point(4.0, 0.0), Attributes(&[1.0]));
+    builder.begin(point(4.0, 0.0), &[1.0]);
     builder.end(false);
 
     let path = builder.build();
@@ -2948,9 +2948,9 @@ fn test_too_many_vertices() {
 #[test]
 fn stroke_vertex_source_01() {
     let mut path = crate::path::Path::builder_with_attributes(1);
-    let a = path.begin(point(0.0, 0.0), Attributes(&[1.0]));
-    let b = path.line_to(point(10.0, 10.0), Attributes(&[2.0]));
-    let c = path.quadratic_bezier_to(point(10.0, 20.0), point(0.0, 20.0), Attributes(&[3.0]));
+    let a = path.begin(point(0.0, 0.0), &[1.0]);
+    let b = path.line_to(point(10.0, 10.0), &[2.0]);
+    let c = path.quadratic_bezier_to(point(10.0, 20.0), point(0.0, 20.0), &[3.0]);
     path.end(true);
 
     let path = path.build();
@@ -3013,11 +3013,11 @@ fn stroke_vertex_source_01() {
 
             let vertex = attr.interpolated_attributes();
             if eq(pos, point(0.0, 0.0)) {
-                assert_eq!(vertex, Attributes(&[1.0]))
+                assert_eq!(vertex, &[1.0])
             } else if eq(pos, point(10.0, 10.0)) {
-                assert_eq!(vertex, Attributes(&[2.0]))
+                assert_eq!(vertex, &[2.0])
             } else if eq(pos, point(0.0, 20.0)) {
-                assert_eq!(vertex, Attributes(&[3.0]))
+                assert_eq!(vertex, &[3.0])
             } else {
                 assert_eq!(vertex.len(), 1);
                 assert!(vertex[0] > 2.0);

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -998,29 +998,33 @@ impl<'l> StrokeBuilderImpl<'l> {
         end_width: f32,
         attributes: &dyn AttributeStore,
     ) {
-        flatten_quad(curve, self.options.tolerance, &mut|position, t, is_flattening_step| {
-            let src = if t == 1.0 {
-                VertexSource::Endpoint { id: to_id }
-            } else {
-                VertexSource::Edge {
-                    from: from_id,
-                    to: to_id,
-                    t,
-                }
-            };
+        flatten_quad(
+            curve,
+            self.options.tolerance,
+            &mut |position, t, is_flattening_step| {
+                let src = if t == 1.0 {
+                    VertexSource::Endpoint { id: to_id }
+                } else {
+                    VertexSource::Edge {
+                        from: from_id,
+                        to: to_id,
+                        t,
+                    }
+                };
 
-            self.step(
-                EndpointData {
-                    position,
-                    half_width: (start_width * (1.0 - t) + end_width * t) * 0.5,
-                    line_join: self.options.line_join,
-                    src,
-                    is_flattening_step,
-                    ..Default::default()
-                },
-                attributes,
-            );
-        });
+                self.step(
+                    EndpointData {
+                        position,
+                        half_width: (start_width * (1.0 - t) + end_width * t) * 0.5,
+                        line_join: self.options.line_join,
+                        src,
+                        is_flattening_step,
+                        ..Default::default()
+                    },
+                    attributes,
+                );
+            },
+        );
     }
 
     pub(crate) fn cubic_bezier_to(
@@ -1105,29 +1109,33 @@ impl<'l> StrokeBuilderImpl<'l> {
         attributes: &dyn AttributeStore,
     ) {
         let half_width = self.options.line_width * 0.5;
-        flatten_quad(curve, self.options.tolerance, &mut|position, t, is_flattening_step| {
-            let src = if t == 1.0 {
-                VertexSource::Endpoint { id: to_id }
-            } else {
-                VertexSource::Edge {
-                    from: from_id,
-                    to: to_id,
-                    t,
-                }
-            };
+        flatten_quad(
+            curve,
+            self.options.tolerance,
+            &mut |position, t, is_flattening_step| {
+                let src = if t == 1.0 {
+                    VertexSource::Endpoint { id: to_id }
+                } else {
+                    VertexSource::Edge {
+                        from: from_id,
+                        to: to_id,
+                        t,
+                    }
+                };
 
-            self.fixed_width_step(
-                EndpointData {
-                    position,
-                    half_width,
-                    line_join: self.options.line_join,
-                    src,
-                    is_flattening_step,
-                    ..Default::default()
-                },
-                attributes,
-            );
-        });
+                self.fixed_width_step(
+                    EndpointData {
+                        position,
+                        half_width,
+                        line_join: self.options.line_join,
+                        src,
+                        is_flattening_step,
+                        ..Default::default()
+                    },
+                    attributes,
+                );
+            },
+        );
     }
 
     pub(crate) fn cubic_bezier_to_fw(
@@ -1221,7 +1229,7 @@ impl<'l> StrokeBuilderImpl<'l> {
             }
 
             let (p0, p1) = self.point_buffer.last_two_mut();
-            // TODO: This is hacky: We re-create the first two vertices on the edge towards the second endpoint 
+            // TODO: This is hacky: We re-create the first two vertices on the edge towards the second endpoint
             // so that they use the advancement value of the start of the sub path instead of the end of the
             // sub path as computed in the step_impl above.
             self.vertex.src = p0.src;
@@ -1241,7 +1249,9 @@ impl<'l> StrokeBuilderImpl<'l> {
                     (p0.side_points[side].next - p0.position) / p0.half_width
                 };
 
-                let vertex = self.output.add_stroke_vertex(StrokeVertex(&mut self.vertex, attributes))?;
+                let vertex = self
+                    .output
+                    .add_stroke_vertex(StrokeVertex(&mut self.vertex, attributes))?;
                 p0.side_points[side].next_vertex = vertex;
             }
 
@@ -2049,8 +2059,10 @@ fn compute_join_side_positions(
     // For concave sides we'll simply connect at the intersection of the two side edges.
     let concave = inward && normal_same_side && !join.fold[side];
 
-    if concave || ((join.line_join == LineJoin::Miter || join.line_join == LineJoin::MiterClip)
-            && !miter_limit_is_exceeded(normal, miter_limit)) {
+    if concave
+        || ((join.line_join == LineJoin::Miter || join.line_join == LineJoin::MiterClip)
+            && !miter_limit_is_exceeded(normal, miter_limit))
+    {
         let p = join.position + normal * join.half_width;
         join.side_points[side].single_vertex = Some(p);
     } else if join.line_join == LineJoin::MiterClip {
@@ -2741,13 +2753,13 @@ fn test_path(path: PathSlice, options: &StrokeOptions, expected_triangle_count: 
 
     let mut tess = StrokeTessellator::new();
     tess.tessellate_path(
-            path,
-            &options,
-            &mut TestBuilder {
-                builder: simple_builder(&mut buffers),
-            },
-        )
-        .unwrap();
+        path,
+        &options,
+        &mut TestBuilder {
+            builder: simple_builder(&mut buffers),
+        },
+    )
+    .unwrap();
 
     if let Some(triangles) = expected_triangle_count {
         assert_eq!(
@@ -3095,7 +3107,9 @@ fn find_sharp_turn(curve: &QuadraticBezierSegment<f32>) -> Option<f32> {
 
     // If the projection of the control point on the baseline is between the endpoint, we
     // can only get a sharp turn with a control point that is very far away.
-    let long_axis = if (v_dot_b >= 0.0 && v_dot_b <= baseline.dot(baseline)) || v_dot_n.abs() * 2.0 >= v_dot_b.abs() {
+    let long_axis = if (v_dot_b >= 0.0 && v_dot_b <= baseline.dot(baseline))
+        || v_dot_n.abs() * 2.0 >= v_dot_b.abs()
+    {
         // The control point is far enough from the endpoints It can cause a sharp turn.
         if baseline.square_length() * 30.0 > v.square_length() {
             return None;
@@ -3153,5 +3167,12 @@ fn test_triangle_winding() {
     let mut tess = StrokeTessellator::new();
     let options = StrokeOptions::tolerance(0.05);
 
-    tess.tessellate(&path, &options, &mut Builder { vertices: Vec::new() }).unwrap();
+    tess.tessellate(
+        &path,
+        &options,
+        &mut Builder {
+            vertices: Vec::new(),
+        },
+    )
+    .unwrap();
 }

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -395,7 +395,7 @@ impl<'l> StrokeBuilder<'l> {
 
     fn get_width(&self, attributes: Attributes) -> f32 {
         if let Some(idx) = self.builder.options.variable_line_width {
-            self.builder.options.line_width * attributes[idx.index()]
+            self.builder.options.line_width * attributes[idx]
         } else {
             self.builder.options.line_width
         }
@@ -411,7 +411,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         self.validator.begin();
         let id = self.attrib_store.add(attributes);
         if let Some(attrib_index) = self.builder.options.variable_line_width {
-            let width = self.builder.options.line_width * attributes[attrib_index.index()];
+            let width = self.builder.options.line_width * attributes[attrib_index];
             self.builder.begin(to, id, width, self.attrib_store);
             self.prev = (to, id, width);
         } else {
@@ -431,7 +431,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         let id = self.attrib_store.add(attributes);
         self.validator.edge();
         if let Some(attrib_index) = self.builder.options.variable_line_width {
-            let width = self.builder.options.line_width * attributes[attrib_index.index()];
+            let width = self.builder.options.line_width * attributes[attrib_index];
             self.builder.line_to(to, id, width, self.attrib_store);
             self.prev = (to, id, width);
         } else {
@@ -455,7 +455,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         let curve = QuadraticBezierSegment { from, ctrl, to };
 
         if let Some(attrib_index) = self.builder.options.variable_line_width {
-            let end_width = self.builder.options.line_width * attributes[attrib_index.index()];
+            let end_width = self.builder.options.line_width * attributes[attrib_index];
             self.builder.quadratic_bezier_to(
                 &curve,
                 from_id,
@@ -495,7 +495,7 @@ impl<'l> PathBuilder for StrokeBuilder<'l> {
         };
 
         if let Some(attrib_index) = self.builder.options.variable_line_width {
-            let end_width = self.builder.options.line_width * attributes[attrib_index.index()];
+            let end_width = self.builder.options.line_width * attributes[attrib_index];
             self.builder.cubic_bezier_to(
                 &curve,
                 from_id,
@@ -653,7 +653,7 @@ impl<'l> StrokeBuilderImpl<'l> {
         attributes: &dyn AttributeStore,
     ) -> TessellationResult {
         let base_width = self.options.line_width;
-        let attrib_index = self.options.variable_line_width.unwrap().index();
+        let attrib_index = self.options.variable_line_width.unwrap();
 
         let mut validator = DebugValidator::new();
 
@@ -2691,7 +2691,7 @@ where
 #[cfg(test)]
 use crate::geometry_builder::*;
 #[cfg(test)]
-use crate::path::{AttributeIndex, Path};
+use crate::path::Path;
 
 #[cfg(test)]
 fn test_path(path: PathSlice, options: &StrokeOptions, expected_triangle_count: Option<u32>) {
@@ -2778,7 +2778,7 @@ fn test_square() {
 
     // Test both with and without the fixed width fast path.
     let options = [
-        StrokeOptions::default().with_variable_line_width(AttributeIndex(0)),
+        StrokeOptions::default().with_variable_line_width(0),
         StrokeOptions::default(),
     ];
 
@@ -2860,7 +2860,7 @@ fn test_empty_caps() {
     let path = builder.build();
 
     let options = [
-        StrokeOptions::default().with_variable_line_width(AttributeIndex(0)),
+        StrokeOptions::default().with_variable_line_width(0),
         StrokeOptions::default(),
     ];
 
@@ -2960,7 +2960,7 @@ fn stroke_vertex_source_01() {
         &mut path.id_iter(),
         &path,
         Some(&path),
-        &StrokeOptions::default().with_variable_line_width(AttributeIndex(0)),
+        &StrokeOptions::default().with_variable_line_width(0),
         &mut CheckVertexSources {
             next_vertex: 0,
             a,


### PR DESCRIPTION
In retrospect they have been more cumbersome than useful, so it's hard to justify that big a change from `0.17`.
