### PR TITLE
add `Path::with_attributes` constructor

### DIFF
--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -113,6 +113,15 @@ impl Path {
         }
     }
 
+    #[inline]
+    pub fn with_attributes(num_attributes: usize) -> Path {
+        Path {
+            points: Box::new([]),
+            verbs: Box::new([]),
+            num_attributes,
+        }
+    }
+
     /// Returns a view on this `Path`.
     #[inline]
     pub fn as_slice(&self) -> PathSlice {


### PR DESCRIPTION
It's important to be able to construct an empty `Path` with a certain number of attributes.
I need this in my program.