### PR TITLE
use drain to clear vector and avoid copy

### DIFF
--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -1526,7 +1526,7 @@ impl FillTessellator {
         let from_id = self.current_vertex;
         self.active.edges.splice(
             above,
-            self.edges_below.iter().map(|edge| ActiveEdge {
+            self.edges_below.drain(0..).map(|edge| ActiveEdge {
                 from,
                 to: edge.to,
                 winding: edge.winding,
@@ -1536,8 +1536,6 @@ impl FillTessellator {
                 range_end: edge.range_end,
             }),
         );
-
-        self.edges_below.clear();
     }
 
     fn split_event(&mut self, left_enclosing_edge_idx: ActiveEdgeIdx, left_span_idx: SpanIdx) {

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -1526,7 +1526,7 @@ impl FillTessellator {
         let from_id = self.current_vertex;
         self.active.edges.splice(
             above,
-            self.edges_below.drain(0..).map(|edge| ActiveEdge {
+            self.edges_below.drain(..).map(|edge| ActiveEdge {
                 from,
                 to: edge.to,
                 winding: edge.winding,


### PR DESCRIPTION
In the original version, the contents in `edges_below` are iterated by references, some informations are copied implicitly to create active edge and `edges_below` is cleared soon.

IMO, we can use `edges_below::drain(0..)` iterator to empty this vector and iterate over  the original content with ownership. The result is same and correct. No `clear` is needed and no more copies are performed.