### PR TITLE
Add forbid(unsafe_code) to crates without unsafe code

### DIFF
--- a/crates/algorithms/src/lib.rs
+++ b/crates/algorithms/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 #![deny(bare_trait_objects)]
 #![allow(clippy::float_cmp)]
+#![forbid(unsafe_code)]
 
 //! 2d Path transformation and manipulation algorithms.
 //!

--- a/crates/extra/src/lib.rs
+++ b/crates/extra/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(bare_trait_objects)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
+#![forbid(unsafe_code)]
 
 extern crate lyon_path as path;
 

--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(unconditional_recursion)]
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::let_and_return)]
+#![forbid(unsafe_code)]
 
 //! Simple 2D geometric primitives on top of euclid.
 //!

--- a/crates/lyon/src/lib.rs
+++ b/crates/lyon/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 #![deny(bare_trait_objects)]
+#![forbid(unsafe_code)]
 
 //! GPU-based 2D graphics rendering tools in Rust using path tessellation.
 //!


### PR DESCRIPTION
This makes me feel better when this crate appears in my `cargo geiger` graph.