### PR TITLE
Make several lyon crates no_std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+
+[[package]]
 name = "lock_api"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +913,7 @@ name = "lyon_algorithms"
 version = "1.0.1"
 dependencies = [
  "lyon_path",
+ "num-traits",
  "serde",
 ]
 
@@ -949,6 +956,7 @@ name = "lyon_path"
 version = "1.0.1"
 dependencies = [
  "lyon_geom",
+ "num-traits",
  "serde",
 ]
 
@@ -1170,11 +1178,12 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.0.1",
+ "libm",
 ]
 
 [[package]]

--- a/crates/algorithms/Cargo.toml
+++ b/crates/algorithms/Cargo.toml
@@ -16,8 +16,11 @@ name = "lyon_algorithms"
 path = "src/lib.rs"
 
 [features]
+default = ["std"]
+std = ["lyon_path/std", "num-traits/std"]
 serialization = ["serde", "lyon_path/serialization"]
 
 [dependencies]
-lyon_path = { version = "1.0.0", path = "../path" }
-serde = { version = "1.0", optional = true, features = ["serde_derive"] }
+lyon_path = { version = "1.0.0", path = "../path", default-features = false }
+num-traits = { version = "0.2.15", default-features = false, features = ["libm"] }
+serde = { version = "1.0", optional = true, features = ["serde_derive"], default-features = false }

--- a/crates/algorithms/src/aabb.rs
+++ b/crates/algorithms/src/aabb.rs
@@ -3,7 +3,7 @@
 use crate::geom::{CubicBezierSegment, QuadraticBezierSegment};
 use crate::math::{point, Box2D, Point};
 use crate::path::PathEvent;
-use std::f32;
+use core::f32;
 
 /// Computes a conservative axis-aligned rectangle that contains the path.
 ///

--- a/crates/algorithms/src/fit.rs
+++ b/crates/algorithms/src/fit.rs
@@ -68,7 +68,7 @@ fn simple_fit() {
         use crate::geom::euclid::approxeq::ApproxEq;
         let result = a.min.approx_eq(&b.min) && a.max.approx_eq(&b.max);
         if !result {
-            println!("{:?} == {:?}", a, b);
+            std::println!("{:?} == {:?}", a, b);
         }
         result
     }

--- a/crates/algorithms/src/hatching.rs
+++ b/crates/algorithms/src/hatching.rs
@@ -31,11 +31,13 @@ use crate::math::{point, vector, Angle, Point, Rotation, Vector};
 use crate::path::builder::{Build, PathBuilder};
 use crate::path::private::DebugValidator;
 use crate::path::{self, Attributes, EndpointId, PathEvent, NO_ATTRIBUTES};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
-use std::cmp::Ordering;
-use std::f32;
-use std::mem;
+use core::cmp::Ordering;
+use core::f32;
+use core::mem;
+
+use alloc::vec::Vec;
 
 /// Parameters for the hatcher.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/crates/algorithms/src/hit_test.rs
+++ b/crates/algorithms/src/hit_test.rs
@@ -3,7 +3,7 @@
 use crate::geom::{CubicBezierSegment, LineSegment, QuadraticBezierSegment};
 use crate::math::Point;
 use crate::path::{FillRule, PathEvent};
-use std::f32;
+use core::f32;
 
 /// Returns whether the point is inside the path.
 pub fn hit_test_path<Iter>(point: &Point, path: Iter, fill_rule: FillRule, tolerance: f32) -> bool
@@ -192,7 +192,7 @@ fn test_hit_test() {
         FillRule::EvenOdd,
         0.1
     ));
-    println!(
+    std::println!(
         "winding {:?}",
         path_winding_number_at_position(&point(2.0, 0.0), path.iter(), 0.1)
     );

--- a/crates/algorithms/src/length.rs
+++ b/crates/algorithms/src/length.rs
@@ -3,7 +3,7 @@
 use crate::geom::{CubicBezierSegment, LineSegment, QuadraticBezierSegment};
 use crate::path::PathEvent;
 
-use std::iter::IntoIterator;
+use core::iter::IntoIterator;
 
 pub fn approximate_length<Iter>(path: Iter, tolerance: f32) -> f32
 where

--- a/crates/algorithms/src/lib.rs
+++ b/crates/algorithms/src/lib.rs
@@ -1,10 +1,16 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 #![deny(bare_trait_objects)]
 #![allow(clippy::float_cmp)]
+#![no_std]
 
 //! 2d Path transformation and manipulation algorithms.
 //!
 //! This crate is reexported in [lyon](https://docs.rs/lyon/).
+
+extern crate alloc;
+
+#[cfg(any(test, feature = "std"))]
+extern crate std;
 
 pub extern crate lyon_path as path;
 

--- a/crates/algorithms/src/measure.rs
+++ b/crates/algorithms/src/measure.rs
@@ -6,7 +6,9 @@ use crate::path::{
     builder::PathBuilder, AttributeStore, Attributes, EndpointId, IdEvent, Path, PathSlice,
     PositionStore,
 };
-use std::ops::Range;
+use core::ops::Range;
+
+use alloc::vec::Vec;
 
 /// Whether to measure real or normalized (between 0 and 1) distances.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -175,10 +177,10 @@ impl PathMeasurements {
         PS: PositionStore,
     {
         let tolerance = tolerance.max(1e-4);
-        let mut events = std::mem::take(&mut self.events);
+        let mut events = core::mem::take(&mut self.events);
         events.clear();
         events.extend(path.into_iter());
-        let mut edges = std::mem::take(&mut self.edges);
+        let mut edges = core::mem::take(&mut self.edges);
         edges.clear();
 
         let mut distance = 0.0;
@@ -346,7 +348,7 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathSampler<'l, PS, AS> {
             edges: &measurements.edges,
             positions,
             attributes,
-            attribute_buffer: vec![0.0; attributes.num_attributes()],
+            attribute_buffer: alloc::vec![0.0; attributes.num_attributes()],
             cursor: 0,
             sample_type,
         }
@@ -361,8 +363,8 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathSampler<'l, PS, AS> {
         if self.edges.is_empty() {
             let attr: &'static [f32] = &[];
             return PathSample {
-                position: point(std::f32::NAN, std::f32::NAN),
-                tangent: vector(std::f32::NAN, std::f32::NAN),
+                position: point(core::f32::NAN, core::f32::NAN),
+                tangent: vector(core::f32::NAN, core::f32::NAN),
                 attributes: attr,
             };
         }
@@ -508,7 +510,7 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathSampler<'l, PS, AS> {
         }
 
         fn floor_log2(num: usize) -> u32 {
-            std::mem::size_of::<usize>() as u32 * 8 - num.leading_zeros() - 1
+            core::mem::size_of::<usize>() as u32 * 8 - num.leading_zeros() - 1
         }
 
         // Here we use a heuristic method combining method 1 & 2
@@ -761,7 +763,7 @@ fn split_square() {
     let path2 = path2.build();
     assert_eq!(
         path2.iter().collect::<Vec<_>>(),
-        vec![
+        alloc::vec![
             Event::Begin {
                 at: point(0.5, 0.0)
             },
@@ -804,7 +806,7 @@ fn split_bezier_curve() {
 
     assert_eq!(
         path2.iter().collect::<Vec<_>>(),
-        vec![
+        alloc::vec![
             Event::Begin {
                 at: point(1.0, 0.5)
             },
@@ -850,7 +852,7 @@ fn split_attributes() {
 
     assert_eq!(
         path3.iter_with_attributes().collect::<Vec<_>>(),
-        vec![
+        alloc::vec![
             Event::Begin {
                 at: (point(0.5, 0.0), slice(&[1.5, 2.5]))
             },

--- a/crates/algorithms/src/raycast.rs
+++ b/crates/algorithms/src/raycast.rs
@@ -3,7 +3,7 @@
 use crate::geom::{CubicBezierSegment, Line, LineSegment, QuadraticBezierSegment};
 use crate::math::{point, vector, Point, Vector};
 use crate::path::PathEvent;
-use std::f32;
+use core::f32;
 
 pub struct Ray {
     pub origin: Point,

--- a/crates/algorithms/src/rect.rs
+++ b/crates/algorithms/src/rect.rs
@@ -3,6 +3,8 @@
 use crate::math::{point, vector, Box2D, Point, Vector};
 use crate::path::PathEvent;
 
+use num_traits::Float;
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ToRectangleOptions {
     pub tolerance: f32,

--- a/crates/algorithms/src/walk.rs
+++ b/crates/algorithms/src/walk.rs
@@ -45,8 +45,10 @@ use crate::math::*;
 use crate::path::builder::*;
 use crate::path::{Attributes, EndpointId, PathEvent};
 
-use std::f32;
-use std::ops::Range;
+use core::f32;
+use core::ops::Range;
+
+use alloc::vec::Vec;
 
 /// Walks along the path staring at offset `start` and applies a `Pattern`.
 pub fn walk_along_path<Iter>(path: Iter, start: f32, tolerance: f32, pattern: &mut dyn Pattern)
@@ -139,9 +141,9 @@ impl<'l> PathWalker<'l> {
             need_moveto: true,
             done: false,
             pattern,
-            prev_attributes: vec![0.0; num_attributes],
-            attribute_buffer: vec![0.0; num_attributes],
-            first_attributes: vec![0.0; num_attributes],
+            prev_attributes: alloc::vec![0.0; num_attributes],
+            attribute_buffer: alloc::vec![0.0; num_attributes],
+            first_attributes: alloc::vec![0.0; num_attributes],
             num_attributes,
         }
     }
@@ -236,7 +238,7 @@ impl<'l> PathWalker<'l> {
 
     pub fn end(&mut self, close: bool) {
         if close {
-            let attributes = std::mem::take(&mut self.first_attributes);
+            let attributes = core::mem::take(&mut self.first_attributes);
             let first = self.first;
             let from = self.prev;
             let tangent = (first - from).normalize();

--- a/crates/geom/Cargo.toml
+++ b/crates/geom/Cargo.toml
@@ -14,10 +14,12 @@ edition = "2018"
 name = "lyon_geom"
 
 [features]
+default = ["std"]
 serialization = ["serde", "euclid/serde"]
+std = ["arrayvec/std", "euclid/std", "num-traits/std"]
 
 [dependencies]
-euclid = "0.22.4"
-arrayvec = "0.7"
-num-traits = "0.2"
-serde = { version = "1.0", optional = true, features = ["serde_derive"] }
+euclid = { version = "0.22.4", default-features = false }
+arrayvec = { version = "0.7", default-features = false }
+num-traits = { version = "0.2", features = ["libm"], default-features = false }
+serde = { version = "1.0", optional = true, features = ["serde_derive"], default-features = false }

--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -1,7 +1,7 @@
 //! Elliptic arc related maths and tools.
 
-use std::mem::swap;
-use std::ops::Range;
+use core::mem::swap;
+use core::ops::Range;
 
 use crate::scalar::{cast, Float, Scalar};
 use crate::segment::{BoundingBox, Segment};
@@ -1032,7 +1032,7 @@ fn test_bounding_box() {
             || !r1.min.y.approx_eq(&r2.min.y)
             || !r1.max.y.approx_eq(&r2.max.y)
         {
-            println!("\n   left: {:?}\n   right: {:?}", r1, r2);
+            std::println!("\n   left: {:?}\n   right: {:?}", r1, r2);
             return false;
         }
 
@@ -1105,7 +1105,7 @@ fn test_bounding_box() {
 
     let mut angle = Angle::zero();
     for _ in 0..10 {
-        println!("angle: {:?}", angle);
+        std::println!("angle: {:?}", angle);
         let r = Arc {
             center: point(0.0, 0.0),
             radii: vector(4.0, 4.0),
@@ -1126,7 +1126,7 @@ fn test_bounding_box() {
 
     let mut angle = Angle::zero();
     for _ in 0..10 {
-        println!("angle: {:?}", angle);
+        std::println!("angle: {:?}", angle);
         let r = Arc {
             center: point(0.0, 0.0),
             radii: vector(4.0, 4.0),
@@ -1172,7 +1172,7 @@ fn negative_flattening_step() {
         x_rotation: Angle::zero(),
     };
 
-    let flattened: Vec<_> = arc.flattened(0.1).collect();
+    let flattened: std::vec::Vec<_> = arc.flattened(0.1).collect();
 
     assert!(flattened.len() > 1);
 }

--- a/crates/geom/src/cubic_bezier.rs
+++ b/crates/geom/src/cubic_bezier.rs
@@ -7,8 +7,11 @@ use crate::{point, Box2D, Point, Vector};
 use crate::{Line, LineEquation, LineSegment, QuadraticBezierSegment};
 use arrayvec::ArrayVec;
 
-use std::cmp::Ordering::{Equal, Greater, Less};
-use std::ops::Range;
+use core::cmp::Ordering::{Equal, Greater, Less};
+use core::ops::Range;
+
+#[cfg(test)]
+use std::vec::Vec;
 
 /// A 2d curve segment defined by four points: the beginning of the segment, two control
 /// points and the end of the segment.
@@ -661,7 +664,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         let mut second_inflection = c / q;
 
         if first_inflection > second_inflection {
-            std::mem::swap(&mut first_inflection, &mut second_inflection);
+            core::mem::swap(&mut first_inflection, &mut second_inflection);
         }
 
         if in_range(first_inflection) {
@@ -742,7 +745,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         let mut first_extremum = (-b - discriminant_sqrt) / (S::TWO * a);
         let mut second_extremum = (-b + discriminant_sqrt) / (S::TWO * a);
         if first_extremum > second_extremum {
-            std::mem::swap(&mut first_extremum, &mut second_extremum);
+            core::mem::swap(&mut first_extremum, &mut second_extremum);
         }
 
         if in_range(first_extremum) {
@@ -1232,7 +1235,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         let mut ctrl1 = self.ctrl1;
         let mut ctrl2 = self.ctrl2;
         if t < S::HALF {
-            std::mem::swap(&mut ctrl1, &mut ctrl2);
+            core::mem::swap(&mut ctrl1, &mut ctrl2);
         }
 
         // Move the most constrained control point by a subset of the uniform displacement
@@ -1253,7 +1256,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         let mut new_ctrl2 = new_ctrl1 + (new_a - new_ctrl1) * (d12_pre / d1_pre);
 
         if t < S::HALF {
-            std::mem::swap(&mut new_ctrl1, &mut new_ctrl2);
+            core::mem::swap(&mut new_ctrl1, &mut new_ctrl2);
         }
 
         CubicBezierSegment {
@@ -1366,8 +1369,8 @@ impl<S: Scalar> Iterator for Flattened<S> {
 
 #[cfg(test)]
 fn print_arrays(a: &[Point<f32>], b: &[Point<f32>]) {
-    println!("left:  {:?}", a);
-    println!("right: {:?}", b);
+    std::println!("left:  {:?}", a);
+    std::println!("right: {:?}", b);
 }
 
 #[cfg(test)]
@@ -1382,7 +1385,7 @@ fn assert_approx_eq(a: &[Point<f32>], b: &[Point<f32>]) {
         let dy = f32::abs(a[i].y - b[i].y);
         if dx > threshold || dy > threshold {
             print_arrays(a, b);
-            println!("diff = {:?} {:?}", dx, dy);
+            std::println!("diff = {:?} {:?}", dx, dy);
             panic!("The arrays are not equal");
         }
     }
@@ -1824,7 +1827,7 @@ fn test_line_segment_intersections() {
     fn assert_approx_eq(a: ArrayVec<(f32, f32), 3>, b: &[(f32, f32)], epsilon: f32) {
         for i in 0..a.len() {
             if f32::abs(a[i].0 - b[i].0) > epsilon || f32::abs(a[i].1 - b[i].1) > epsilon {
-                println!("{:?} != {:?}", a, b);
+                std::println!("{:?} != {:?}", a, b);
             }
             assert!((a[i].0 - b[i].0).abs() <= epsilon && (a[i].1 - b[i].1).abs() <= epsilon);
         }
@@ -1874,7 +1877,7 @@ fn test_parameters_for_value() {
     fn assert_approx_eq(a: ArrayVec<f32, 3>, b: &[f32], epsilon: f32) {
         for i in 0..a.len() {
             if f32::abs(a[i] - b[i]) > epsilon {
-                println!("{:?} != {:?}", a, b);
+                std::println!("{:?} != {:?}", a, b);
             }
             assert!((a[i] - b[i]).abs() <= epsilon);
         }

--- a/crates/geom/src/cubic_bezier_intersections.rs
+++ b/crates/geom/src/cubic_bezier_intersections.rs
@@ -10,7 +10,8 @@ use crate::CubicBezierSegment;
 ///! for motivation and details of how the process works.
 use crate::{point, Box2D, Point};
 use arrayvec::ArrayVec;
-use std::ops::Range;
+use core::mem;
+use core::ops::Range;
 
 // Computes the intersections (if any) between two cubic bézier curves in the form of the `t`
 // parameters of each intersection point along the curves.
@@ -676,7 +677,7 @@ fn convex_hull_of_distance_curve<S: Scalar>(
 
     // Flip the hull if needed:
     if dist1 < S::ZERO || (dist1 == S::ZERO && dist2 < S::ZERO) {
-        std::mem::swap(top, bottom);
+        mem::swap(top, bottom);
     }
 }
 

--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(unconditional_recursion)]
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::let_and_return)]
+#![no_std]
 
 //! Simple 2D geometric primitives on top of euclid.
 //!
@@ -77,6 +78,9 @@
 
 //#![allow(needless_return)] // clippy
 
+#[cfg(any(test, feature = "std"))]
+extern crate std;
+
 // Reexport dependencies.
 pub use arrayvec;
 pub use euclid;
@@ -115,8 +119,8 @@ mod scalar {
     pub(crate) use num_traits::cast::cast;
     pub(crate) use num_traits::{Float, FloatConst, NumCast};
 
-    use std::fmt::{Debug, Display};
-    use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
+    use core::fmt::{Debug, Display};
+    use core::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 
     pub trait Scalar:
         Float
@@ -174,8 +178,8 @@ mod scalar {
         const NINE: Self = 9.0;
         const TEN: Self = 10.0;
 
-        const MIN: Self = std::f32::MIN;
-        const MAX: Self = std::f32::MAX;
+        const MIN: Self = core::f32::MIN;
+        const MAX: Self = core::f32::MAX;
 
         const EPSILON: Self = 1e-4;
 
@@ -218,8 +222,8 @@ mod scalar {
         const NINE: Self = 9.0;
         const TEN: Self = 10.0;
 
-        const MIN: Self = std::f64::MIN;
-        const MAX: Self = std::f64::MAX;
+        const MIN: Self = core::f64::MIN;
+        const MAX: Self = core::f64::MAX;
 
         const EPSILON: Self = 1e-8;
 

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -3,9 +3,9 @@ use crate::segment::{BoundingBox, Segment};
 use crate::traits::Transformation;
 use crate::utils::min_max;
 use crate::{point, vector, Box2D, Point, Vector};
-use std::mem::swap;
+use core::mem::swap;
 
-use std::ops::Range;
+use core::ops::Range;
 
 /// A linear segment.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -308,7 +308,7 @@ impl<S: Scalar> LineSegment<S> {
         // TODO: is it really useful to swap?
         let swap = a > b;
         if swap {
-            std::mem::swap(&mut a, &mut b);
+            core::mem::swap(&mut a, &mut b);
         }
 
         let d = b - a;
@@ -759,7 +759,7 @@ fn fuzzy_eq_point(a: Point<f32>, b: Point<f32>, epsilon: f32) -> bool {
 
 #[test]
 fn intersection_rotated() {
-    use std::f32::consts::PI;
+    use core::f32::consts::PI;
     let epsilon = 0.0001;
     let count: u32 = 100;
 
@@ -869,7 +869,7 @@ fn bounding_box() {
         max: point(3.0, 5.0),
     };
 
-    let cases = vec![(l1, r1), (l2, r2), (l3, r3)];
+    let cases = std::vec![(l1, r1), (l2, r2), (l3, r3)];
     for &(ls, r) in &cases {
         assert_eq!(ls.bounding_box(), r);
     }
@@ -948,7 +948,7 @@ fn solve_y_for_x() {
     let eqn = line.equation();
 
     if let Some(y) = eqn.solve_y_for_x(line.point.x) {
-        println!("{:?} != {:?}", y, line.point.y);
+        std::println!("{:?} != {:?}", y, line.point.y);
         assert!(f64::abs(y - line.point.y) < 0.000001)
     }
 
@@ -966,7 +966,7 @@ fn solve_y_for_x() {
         let eqn = line.equation();
 
         if let Some(y) = eqn.solve_y_for_x(line.point.x) {
-            println!("{:?} != {:?}", y, line.point.y);
+            std::println!("{:?} != {:?}", y, line.point.y);
             assert!(f64::abs(y - line.point.y) < 0.000001)
         }
 
@@ -1169,7 +1169,7 @@ fn clipped() {
     fn approx_eq(a: LineSegment<f32>, b: LineSegment<f32>) -> bool {
         let ok = a.from.approx_eq(&b.from) && a.to.approx_eq(&b.to);
         if !ok {
-            println!("{:?} != {:?}", a, b);
+            std::println!("{:?} != {:?}", a, b);
         }
 
         ok

--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -5,8 +5,8 @@ use crate::{point, Box2D, Point, Vector};
 use crate::{CubicBezierSegment, Line, LineEquation, LineSegment, Triangle};
 use arrayvec::ArrayVec;
 
-use std::mem;
-use std::ops::Range;
+use core::mem;
+use core::ops::Range;
 
 /// A 2d curve segment defined by three points: the beginning of the segment, a control
 /// point and the end of the segment.
@@ -628,7 +628,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
             let mut t2 = c / (a * t1);
 
             if t1 > t2 {
-                std::mem::swap(&mut t1, &mut t2);
+                mem::swap(&mut t1, &mut t2);
             }
 
             if t1 >= S::ZERO && t1 <= S::ONE {
@@ -1412,7 +1412,7 @@ fn issue_678() {
     };
 
     let intersections = quadratic.line_intersections(&line);
-    println!("{:?}", intersections);
+    std::println!("{:?}", intersections);
 
     assert_eq!(intersections.len(), 1);
 }

--- a/crates/geom/src/segment.rs
+++ b/crates/geom/src/segment.rs
@@ -1,7 +1,7 @@
 use crate::scalar::Scalar;
 use crate::{point, Box2D, LineSegment, Point, Vector};
 
-use std::ops::Range;
+use core::ops::Range;
 
 /// Common APIs to segment types.
 pub trait Segment: Copy + Sized {

--- a/crates/geom/src/triangle.rs
+++ b/crates/geom/src/triangle.rs
@@ -307,7 +307,7 @@ fn test_bounding_box() {
         max: point(2.0, 5.0),
     };
 
-    let cases = vec![(t1, r1), (t2, r2), (t3, r3)];
+    let cases = std::vec![(t1, r1), (t2, r2), (t3, r3)];
     for &(tri, r) in &cases {
         assert_eq!(tri.bounding_box(), r);
     }

--- a/crates/geom/src/utils.rs
+++ b/crates/geom/src/utils.rs
@@ -131,7 +131,7 @@ fn cubic_polynomial() {
     fn assert_approx_eq(a: ArrayVec<f32, 3>, b: &[f32], epsilon: f32) {
         for i in 0..a.len() {
             if f32::abs(a[i] - b[i]) > epsilon {
-                println!("{:?} != {:?}", a, b);
+                std::println!("{:?} != {:?}", a, b);
             }
             assert!((a[i] - b[i]).abs() <= epsilon);
         }

--- a/crates/path/Cargo.toml
+++ b/crates/path/Cargo.toml
@@ -13,8 +13,11 @@ edition = "2018"
 name = "lyon_path"
 
 [features]
+default = ["std"]
+std = ["lyon_geom/std", "num-traits/std"]
 serialization = ["serde", "lyon_geom/serialization"]
 
 [dependencies]
-lyon_geom = { version = "1.0.0", path = "../geom" }
-serde = { version = "1.0", optional = true, features = ["serde_derive"] }
+lyon_geom = { version = "1.0.0", path = "../geom", default-features = false }
+num-traits = { version = "0.2.15", default-features = false, features = ["libm"] }
+serde = { version = "1.0", optional = true, features = ["serde_derive"], default-features = false }

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -86,7 +86,12 @@ use crate::path::Verb;
 use crate::polygon::Polygon;
 use crate::{Attributes, EndpointId, Winding, NO_ATTRIBUTES};
 
-use std::marker::Sized;
+use core::marker::Sized;
+
+use alloc::vec::Vec;
+use alloc::vec;
+
+use num_traits::Float;
 
 /// The radius of each corner of a rounded rectangle.
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
@@ -109,8 +114,8 @@ impl BorderRadii {
     }
 }
 
-impl std::fmt::Display for BorderRadii {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for BorderRadii {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // In the order of a well known convention (CSS) clockwise from top left
         write!(
             f,
@@ -609,7 +614,7 @@ pub trait PathBuilder {
             Winding::Negative => -1.0,
         };
 
-        use std::f32::consts::PI;
+        use core::f32::consts::PI;
         let arc = Arc {
             center,
             radii,
@@ -1770,7 +1775,7 @@ fn svg_builder_arc_to_update_position() {
 
 #[test]
 fn issue_650() {
-    use std::f32::consts::PI;
+    use core::f32::consts::PI;
     let mut builder = crate::path::Path::builder().with_svg();
     builder.arc(
         point(0.0, 0.0),

--- a/crates/path/src/commands.rs
+++ b/crates/path/src/commands.rs
@@ -60,7 +60,10 @@ use crate::events::{Event, IdEvent, PathEvent};
 use crate::math::Point;
 use crate::{ControlPointId, EndpointId, EventId, Position, PositionStore};
 
-use std::fmt;
+use core::fmt;
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 // Note: Tried making the path generic over the integer type used to store
 // the commands to allow u16 and u32, but the performance difference is very
@@ -75,7 +78,7 @@ mod verb {
     pub const END: u32 = 5;
 }
 
-/// Sadly this is very close to std::slice::Iter but reimplementing
+/// Sadly this is very close to core::slice::Iter but reimplementing
 /// it manually to iterate over u32 makes a difference.
 /// It would seem that having next return u32 with a special value
 /// for the end of the iteration instead of Option<u32> should
@@ -85,7 +88,7 @@ mod verb {
 struct CmdIter<'l> {
     ptr: *const u32,
     end: *const u32,
-    _marker: std::marker::PhantomData<&'l u32>,
+    _marker: core::marker::PhantomData<&'l u32>,
 }
 
 impl<'l> CmdIter<'l> {
@@ -95,7 +98,7 @@ impl<'l> CmdIter<'l> {
         CmdIter {
             ptr,
             end,
-            _marker: std::marker::PhantomData,
+            _marker: core::marker::PhantomData,
         }
     }
 
@@ -369,7 +372,7 @@ impl<'l, Endpoint, ControlPoint> CommandsPathSlice<'l, Endpoint, ControlPoint> {
     }
 }
 
-impl<'l, Endpoint, ControlPoint> std::ops::Index<EndpointId>
+impl<'l, Endpoint, ControlPoint> core::ops::Index<EndpointId>
     for CommandsPathSlice<'l, Endpoint, ControlPoint>
 {
     type Output = Endpoint;
@@ -378,7 +381,7 @@ impl<'l, Endpoint, ControlPoint> std::ops::Index<EndpointId>
     }
 }
 
-impl<'l, Endpoint, ControlPoint> std::ops::Index<ControlPointId>
+impl<'l, Endpoint, ControlPoint> core::ops::Index<ControlPointId>
     for CommandsPathSlice<'l, Endpoint, ControlPoint>
 {
     type Output = ControlPoint;

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(bare_trait_objects)]
 #![deny(unconditional_recursion)]
 #![allow(clippy::match_like_matches_macro)]
+#![no_std]
 
 //! Data structures and traits to work with paths (vector graphics).
 //!
@@ -40,6 +41,11 @@
 //! ```
 //!
 
+extern crate alloc;
+
+#[cfg(any(test, feature = "std"))]
+extern crate std;
+
 pub use lyon_geom as geom;
 
 #[cfg(feature = "serialization")]
@@ -69,8 +75,8 @@ pub use crate::path_buffer::{PathBuffer, PathBufferSlice};
 pub use crate::polygon::{IdPolygon, Polygon};
 
 use math::Point;
-use std::fmt;
-use std::u32;
+use core::fmt;
+use core::u32;
 
 pub mod traits {
     //! `lyon_path` traits reexported here for convenience.
@@ -333,7 +339,7 @@ impl fmt::Debug for EndpointId {
 pub struct EventId(#[doc(hidden)] pub u32);
 
 impl EventId {
-    pub const INVALID: Self = EventId(std::u32::MAX);
+    pub const INVALID: Self = EventId(core::u32::MAX);
     pub fn to_usize(self) -> usize {
         self.0 as usize
     }

--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -12,9 +12,13 @@ use crate::{
     PositionStore, NO_ATTRIBUTES,
 };
 
-use std::fmt;
-use std::iter::{FromIterator, IntoIterator};
-use std::u32;
+use core::fmt;
+use core::iter::{FromIterator, IntoIterator};
+use core::u32;
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use alloc::vec;
 
 /// Enumeration corresponding to the [Event](https://docs.rs/lyon_core/*/lyon_core/events/enum.Event.html) enum
 /// without the parameters.
@@ -224,14 +228,14 @@ impl FromIterator<PathEvent> for Path {
     }
 }
 
-impl std::ops::Index<EndpointId> for Path {
+impl core::ops::Index<EndpointId> for Path {
     type Output = Point;
     fn index(&self, id: EndpointId) -> &Point {
         &self.points[id.to_usize()]
     }
 }
 
-impl std::ops::Index<ControlPointId> for Path {
+impl core::ops::Index<ControlPointId> for Path {
     type Output = Point;
     fn index(&self, id: ControlPointId) -> &Point {
         &self.points[id.to_usize()]
@@ -409,14 +413,14 @@ impl<'l> fmt::Debug for PathSlice<'l> {
     }
 }
 
-impl<'l> std::ops::Index<EndpointId> for PathSlice<'l> {
+impl<'l> core::ops::Index<EndpointId> for PathSlice<'l> {
     type Output = Point;
     fn index(&self, id: EndpointId) -> &Point {
         &self.points[id.to_usize()]
     }
 }
 
-impl<'l> std::ops::Index<ControlPointId> for PathSlice<'l> {
+impl<'l> core::ops::Index<ControlPointId> for PathSlice<'l> {
     type Output = Point;
     fn index(&self, id: ControlPointId) -> &Point {
         &self.points[id.to_usize()]
@@ -813,7 +817,7 @@ fn nan_check(p: Point) {
 #[derive(Clone)]
 pub struct Iter<'l> {
     points: PointIter<'l>,
-    verbs: ::std::slice::Iter<'l, Verb>,
+    verbs: ::core::slice::Iter<'l, Verb>,
     current: Point,
     first: Point,
     // Number of slots in the points array occupied by the custom attributes.
@@ -914,7 +918,7 @@ impl<'l> Iterator for Iter<'l> {
 struct PointIter<'l> {
     ptr: *const Point,
     end: *const Point,
-    _marker: std::marker::PhantomData<&'l Point>,
+    _marker: core::marker::PhantomData<&'l Point>,
 }
 
 impl<'l> PointIter<'l> {
@@ -924,13 +928,13 @@ impl<'l> PointIter<'l> {
         PointIter {
             ptr,
             end,
-            _marker: std::marker::PhantomData,
+            _marker: core::marker::PhantomData,
         }
     }
 
     #[inline]
     fn remaining_len(&self) -> usize {
-        (self.end as usize - self.ptr as usize) / std::mem::size_of::<Point>()
+        (self.end as usize - self.ptr as usize) / core::mem::size_of::<Point>()
     }
 
     #[inline]
@@ -939,7 +943,7 @@ impl<'l> PointIter<'l> {
         // are always followed by advance_n which will
         // catch the issue and panic.
         if self.ptr >= self.end {
-            return point(std::f32::NAN, std::f32::NAN);
+            return point(core::f32::NAN, core::f32::NAN);
         }
 
         unsafe {
@@ -963,7 +967,7 @@ impl<'l> PointIter<'l> {
 #[derive(Clone)]
 pub struct IterWithAttributes<'l> {
     points: PointIter<'l>,
-    verbs: ::std::slice::Iter<'l, Verb>,
+    verbs: ::core::slice::Iter<'l, Verb>,
     current: (Point, Attributes<'l>),
     first: (Point, Attributes<'l>),
     num_attributes: usize,
@@ -1099,7 +1103,7 @@ impl<'l> IterWithAttributes<'l> {
         self.points.advance_n(self.attrib_stride);
         let attributes = unsafe {
             // SAFETY: advance_n would have panicked if the slice is out of bounds
-            std::slice::from_raw_parts(attributes_ptr, self.num_attributes)
+            core::slice::from_raw_parts(attributes_ptr, self.num_attributes)
         };
 
         (position, attributes)
@@ -1172,7 +1176,7 @@ impl<'l> Iterator for IterWithAttributes<'l> {
 /// An iterator of endpoint and control point ids for `Path` and `PathSlice`.
 #[derive(Clone, Debug)]
 pub struct IdIter<'l> {
-    verbs: ::std::slice::Iter<'l, Verb>,
+    verbs: ::core::slice::Iter<'l, Verb>,
     current: u32,
     first: u32,
     evt: u32,
@@ -1274,7 +1278,7 @@ fn interpolated_attributes(
 
     unsafe {
         let ptr = &points[idx].x as *const f32;
-        std::slice::from_raw_parts(ptr, num_attributes)
+        core::slice::from_raw_parts(ptr, num_attributes)
     }
 }
 
@@ -1304,7 +1308,7 @@ fn concatenate_paths(
 
 /// An iterator of over a `Path` traversing the path in reverse.
 pub struct Reversed<'l> {
-    verbs: std::iter::Rev<std::slice::Iter<'l, Verb>>,
+    verbs: core::iter::Rev<core::slice::Iter<'l, Verb>>,
     path: PathSlice<'l>,
     num_attributes: usize,
     attrib_stride: usize,
@@ -1473,8 +1477,8 @@ fn test_reverse_path_simple() {
         b: Option<Event<(Point, Attributes<'l>), Point>>,
     ) -> bool {
         if a != b {
-            println!("left: {:?}", a);
-            println!("right: {:?}", b);
+            std::println!("left: {:?}", a);
+            std::println!("right: {:?}", b);
         }
 
         a == b
@@ -1548,8 +1552,8 @@ fn test_reverse_path() {
         b: Option<Event<(Point, Attributes<'l>), Point>>,
     ) -> bool {
         if a != b {
-            println!("left: {:?}", a);
-            println!("right: {:?}", b);
+            std::println!("left: {:?}", a);
+            std::println!("right: {:?}", b);
         }
 
         a == b

--- a/crates/path/src/path_buffer.rs
+++ b/crates/path/src/path_buffer.rs
@@ -5,9 +5,11 @@ use crate::math::*;
 use crate::path;
 use crate::{Attributes, EndpointId, PathSlice, NO_ATTRIBUTES};
 
-use std::fmt;
-use std::iter::{FromIterator, FusedIterator, IntoIterator};
-use std::ops::Range;
+use core::fmt;
+use core::iter::{FromIterator, FusedIterator, IntoIterator};
+use core::ops::Range;
+
+use alloc::vec::Vec;
 
 #[derive(Clone, Debug)]
 struct PathDescriptor {
@@ -198,8 +200,8 @@ impl<'l> Builder<'l> {
     #[inline]
     fn new(buffer: &'l mut PathBuffer) -> Self {
         let mut builder = path::Path::builder();
-        std::mem::swap(&mut buffer.points, &mut builder.inner_mut().points);
-        std::mem::swap(&mut buffer.verbs, &mut builder.inner_mut().verbs);
+        core::mem::swap(&mut buffer.points, &mut builder.inner_mut().points);
+        core::mem::swap(&mut buffer.verbs, &mut builder.inner_mut().verbs);
         let points_start = builder.inner().points.len() as u32;
         let verbs_start = builder.inner().verbs.len() as u32;
         Builder {
@@ -219,7 +221,7 @@ impl<'l> Builder<'l> {
             builder: path::BuilderWithAttributes {
                 builder: self.builder.into_inner(),
                 num_attributes,
-                first_attributes: vec![0.0; num_attributes],
+                first_attributes: alloc::vec![0.0; num_attributes],
             },
             points_start: self.points_start,
             verbs_start: self.verbs_start,
@@ -230,11 +232,11 @@ impl<'l> Builder<'l> {
     pub fn build(mut self) -> usize {
         let points_end = self.builder.inner().points.len() as u32;
         let verbs_end = self.builder.inner().verbs.len() as u32;
-        std::mem::swap(
+        core::mem::swap(
             &mut self.builder.inner_mut().points,
             &mut self.buffer.points,
         );
-        std::mem::swap(&mut self.builder.inner_mut().verbs, &mut self.buffer.verbs);
+        core::mem::swap(&mut self.builder.inner_mut().verbs, &mut self.buffer.verbs);
 
         let index = self.buffer.paths.len();
         self.buffer.paths.push(PathDescriptor {
@@ -355,8 +357,8 @@ impl<'l> BuilderWithAttributes<'l> {
     #[inline]
     pub fn new(buffer: &'l mut PathBuffer, num_attributes: usize) -> Self {
         let mut builder = path::Path::builder().into_inner();
-        std::mem::swap(&mut buffer.points, &mut builder.points);
-        std::mem::swap(&mut buffer.verbs, &mut builder.verbs);
+        core::mem::swap(&mut buffer.points, &mut builder.points);
+        core::mem::swap(&mut buffer.verbs, &mut builder.verbs);
         let points_start = builder.points.len() as u32;
         let verbs_start = builder.verbs.len() as u32;
         BuilderWithAttributes {
@@ -364,7 +366,7 @@ impl<'l> BuilderWithAttributes<'l> {
             builder: path::BuilderWithAttributes {
                 builder,
                 num_attributes,
-                first_attributes: vec![0.0; num_attributes],
+                first_attributes: alloc::vec![0.0; num_attributes],
             },
             points_start,
             verbs_start,
@@ -375,8 +377,8 @@ impl<'l> BuilderWithAttributes<'l> {
     pub fn build(mut self) -> usize {
         let points_end = self.builder.builder.points.len() as u32;
         let verbs_end = self.builder.builder.verbs.len() as u32;
-        std::mem::swap(&mut self.builder.builder.points, &mut self.buffer.points);
-        std::mem::swap(&mut self.builder.builder.verbs, &mut self.buffer.verbs);
+        core::mem::swap(&mut self.builder.builder.points, &mut self.buffer.points);
+        core::mem::swap(&mut self.builder.builder.verbs, &mut self.buffer.verbs);
 
         let index = self.buffer.paths.len();
         self.buffer.paths.push(PathDescriptor {
@@ -501,7 +503,7 @@ impl<'l> Build for BuilderWithAttributes<'l> {
 pub struct Iter<'l> {
     points: &'l [Point],
     verbs: &'l [path::Verb],
-    paths: ::std::slice::Iter<'l, PathDescriptor>,
+    paths: ::core::slice::Iter<'l, PathDescriptor>,
 }
 
 impl<'l> Iter<'l> {

--- a/crates/path/src/polygon.rs
+++ b/crates/path/src/polygon.rs
@@ -83,7 +83,7 @@ impl<'l, T> Polygon<'l, T> {
     }
 }
 
-impl<'l, T> std::ops::Index<EndpointId> for Polygon<'l, T> {
+impl<'l, T> core::ops::Index<EndpointId> for Polygon<'l, T> {
     type Output = T;
     fn index(&self, id: EndpointId) -> &T {
         &self.points[id.to_usize()]
@@ -132,7 +132,7 @@ impl<'l> IdPolygon<'l> {
 /// An iterator of `Event<EndpointId, ()>`.
 #[derive(Clone)]
 pub struct IdPolygonIter<'l> {
-    points: std::slice::Iter<'l, EndpointId>,
+    points: core::slice::Iter<'l, EndpointId>,
     idx: u32,
     prev: Option<EndpointId>,
     first: EndpointId,
@@ -170,7 +170,7 @@ impl<'l> Iterator for IdPolygonIter<'l> {
 /// An iterator of `Event<&Endpoint, ()>`.
 #[derive(Clone)]
 pub struct PolygonIter<'l, T> {
-    points: std::slice::Iter<'l, T>,
+    points: core::slice::Iter<'l, T>,
     prev: Option<&'l T>,
     first: Option<&'l T>,
     closed: bool,
@@ -205,7 +205,7 @@ impl<'l, T> Iterator for PolygonIter<'l, T> {
 /// An iterator of `PathEvent`.
 #[derive(Clone)]
 pub struct PathEvents<'l, T> {
-    points: std::slice::Iter<'l, T>,
+    points: core::slice::Iter<'l, T>,
     prev: Option<Point>,
     first: Option<Point>,
     closed: bool,
@@ -250,7 +250,7 @@ pub struct PolygonIdIter {
 
 impl PolygonIdIter {
     #[inline]
-    pub fn new(range: std::ops::Range<u32>, closed: bool) -> Self {
+    pub fn new(range: core::ops::Range<u32>, closed: bool) -> Self {
         PolygonIdIter {
             idx: range.start,
             start: range.start,


### PR DESCRIPTION
This PR makes several crates `no_std`. These crates did not depend on `libstd` for anything save for floating point functions, which are now used through the `num_traits` crate. The `num_traits` crate has its `libm` feature enabled. When the `std` feature is enabled on the affected crates, the `std` feature is in turn enabled on `num_traits`, avoiding the use of `libm` on targets with built-in floating point operations.

The crates I've converted are:

- `lyon_geom`
- `lyon_path` (still uses `alloc`)
- `lyon_algorithms` (still uses `alloc`)