### PR TITLE
Disable the folded join code path for miter joins that are not clipped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_tessellation"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "float_next_after",
  "lyon_extra",

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_tessellation"
-version = "1.0.5"
+version = "1.0.6"
 description = "A low level path tessellation library."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -1898,8 +1898,8 @@ fn tessellate_join(
     output: &mut dyn StrokeGeometryBuilder,
 ) -> Result<(), TessellationError> {
     let side_needs_join = [
-        join.side_points[SIDE_POSITIVE].single_vertex.is_none(),
-        join.side_points[SIDE_NEGATIVE].single_vertex.is_none(),
+        join.side_points[SIDE_POSITIVE].single_vertex.is_none() && !join.fold[SIDE_NEGATIVE],
+        join.side_points[SIDE_NEGATIVE].single_vertex.is_none() && !join.fold[SIDE_POSITIVE],
     ];
 
     if !join.fold[SIDE_POSITIVE] && !join.fold[SIDE_NEGATIVE] {


### PR DESCRIPTION
It isn't a very satisfying fix, but it will do for now.

Fixes #838