### PR TITLE
`add_rounded_polygon`

### DIFF
--- a/crates/algorithms/src/lib.rs
+++ b/crates/algorithms/src/lib.rs
@@ -25,6 +25,7 @@ pub mod raycast;
 pub mod rect;
 pub mod walk;
 pub mod winding;
+pub mod rounded_polygon;
 
 pub use crate::path::geom;
 pub use crate::path::math;

--- a/crates/algorithms/src/rounded_polygon.rs
+++ b/crates/algorithms/src/rounded_polygon.rs
@@ -1,0 +1,69 @@
+use lyon_path::{
+    builder::{NoAttributes, WithSvg},
+    geom::{euclid, Angle, Vector},
+    path::BuilderImpl,
+    traits::SvgPathBuilder,
+    ArcFlags, Polygon,
+};
+pub type Point = euclid::default::Point2D<f32>;
+
+pub fn add_rounded_polygon(
+    b: &mut NoAttributes<BuilderImpl>,
+    polygon: Polygon<Point>,
+    radius: f32,
+    clockwise: bool,
+) {
+    let builder = NoAttributes::<BuilderImpl>::new();
+    let mut svg_builder = WithSvg::new(builder);
+
+    let (_, p_last) = get_line_points(
+        polygon.points[polygon.points.len() - 1],
+        polygon.points[0],
+        radius,
+    );
+
+    svg_builder.move_to(p_last);
+    for index in 0..polygon.points.len() {
+        let (p1, p2) = get_line_points(
+            polygon.points[index],
+            polygon.points[(index + 1) % polygon.points.len()],
+            radius,
+        );
+
+        let is_right_turn = get_direction(
+            polygon.points[(polygon.points.len() + index - 1) % polygon.points.len()],
+            polygon.points[index],
+            polygon.points[(index + 1) % polygon.points.len()],
+        ) < 0.;
+
+        svg_builder.arc_to(
+            Vector::new(radius, radius),
+            Angle { radians: 0.0 },
+            ArcFlags {
+                large_arc: false,
+                sweep: is_right_turn == clockwise,
+            },
+            p1,
+        );
+        svg_builder.line_to(p2);
+    }
+
+    svg_builder.close();
+
+    let path = svg_builder.build();
+    b.extend_from_paths(&[path.as_slice()]);
+}
+
+fn get_line_points(p1: Point, p2: Point, radius: f32) -> (Point, Point) {
+    let dist = p1.distance_to(p2);
+    let ratio = radius / dist;
+
+    let r1 = p1.lerp(p2, ratio);
+    let r2 = p1.lerp(p2, 1. - ratio);
+
+    (Point::new(r1.x, r1.y), Point::new(r2.x, r2.y))
+}
+
+fn get_direction(p0: Point, p1: Point, p2: Point) -> f32 {
+    (p2 - p0).cross(p1 - p0)
+}

--- a/crates/algorithms/src/rounded_polygon.rs
+++ b/crates/algorithms/src/rounded_polygon.rs
@@ -6,6 +6,10 @@ use lyon_path::{
 
 pub type Point = euclid::default::Point2D<f32>;
 
+/// Adds a sub-path from a polygon but rounds the corners.
+///
+/// There must be no sub-path in progress when this method is called.
+/// No sub-path is in progress after the method is called.
 pub fn add_rounded_polygon<B: PathBuilder>(
     builder: &mut B,
     polygon: Polygon<Point>,

--- a/crates/algorithms/src/rounded_polygon.rs
+++ b/crates/algorithms/src/rounded_polygon.rs
@@ -31,7 +31,7 @@ pub fn add_rounded_polygon<B: PathBuilder>(
         let (q_current, q_next) = get_line_points(p_current, p_next, radius);
 
         let turn_winding = get_winding(p_previous, p_current, p_next);
-        arc_to(
+        arc(
             builder,
             Vector::new(radius, radius),
             Angle { radians: 0.0 },
@@ -71,7 +71,7 @@ fn get_winding(p0: Point, p1: Point, p2: Point) -> Winding {
     }
 }
 
-fn arc_to<B: PathBuilder>(
+fn arc<B: PathBuilder>(
     builder: &mut B,
     radii: Vector<f32>,
     x_rotation: Angle<f32>,
@@ -95,5 +95,98 @@ fn arc_to<B: PathBuilder>(
         geom_arc.for_each_quadratic_bezier(&mut |curve| {
             builder.quadratic_bezier_to(curve.ctrl, curve.to, attributes);
         });
+    }
+}
+
+#[test]
+fn rounded_polygon() {
+    use crate::geom::point;
+    use crate::rounded_polygon::*;
+    use alloc::vec::Vec;
+    use euclid::approxeq::ApproxEq;
+
+    type Point = euclid::Point2D<f32, euclid::UnknownUnit>;
+    type Event = path::Event<Point, Point>;
+    let arrow_points = [
+        point(-1.0, -0.3),
+        point(0.0, -0.3),
+        point(0.0, -1.0),
+        point(1.5, 0.0),
+        point(0.0, 1.0),
+        point(0.0, 0.3),
+        point(-1.0, 0.3),
+    ];
+
+    let arrow_polygon = Polygon {
+        points: &arrow_points,
+        closed: true,
+    };
+
+    let mut builder = lyon_path::Path::builder();
+    add_rounded_polygon(&mut builder, arrow_polygon, 2.0, lyon_path::NO_ATTRIBUTES);
+    let arrow_path = builder.build();
+
+    //check that we have the right ordering of event types
+    let actual_events: alloc::vec::Vec<_> = arrow_path.into_iter().collect();
+
+    let actual_event_types = actual_events
+        .iter()
+        .map(|x| match x {
+            Event::Begin { at: _ } => "b",
+            Event::Line { from: _, to: _ } => "l",
+            Event::Quadratic {
+                from: _,
+                ctrl: _,
+                to: _,
+            } => "q",
+            Event::Cubic {
+                from: _,
+                ctrl1: _,
+                ctrl2: _,
+                to: _,
+            } => "c",
+            Event::End {
+                last: _,
+                first: _,
+                close: _,
+            } => "e",
+        })
+        .collect::<alloc::vec::Vec<_>>()
+        .concat();
+
+    assert_eq!(actual_event_types, "bqqqlqqlqqlqqlqqlqqlqqle");
+
+    let expected_lines = std::vec![
+        (point(1.0, -0.3), point(-2.0, -0.3)),
+        (point(0.0, -2.3), point(0.0, 1.0)),
+        (point(1.66, 0.11), point(-0.16, -1.11)),
+        (point(-0.16, 1.11), point(1.66, -0.11)),
+        (point(-0.0, -1.0), point(0.0, 2.3)),
+        (point(-2.0, 0.3), point(1.0, 0.3)),
+        (point(-1.0, -1.7), point(-1.0, 1.7))
+    ];
+
+    //Check that the lines are approximately correct
+    let actual_lines: Vec<_> = arrow_path
+        .into_iter()
+        .filter_map(|event| match event {
+            Event::Line { from, to } => Some((from, to)),
+            _ => None,
+        })
+        .collect();
+
+    for (actual, expected) in actual_lines.into_iter().zip(expected_lines.into_iter()) {
+        for (actual_point, expected_point) in [(actual.0, expected.0), (actual.1, expected.1)] {
+            assert!(actual_point.approx_eq_eps(&expected_point, &Point::new(0.01, 0.01)))
+        }
+    }
+
+    //Check that each event goes from the end of the previous event
+
+    let mut previous = actual_events[0].to();
+
+    for e in actual_events {
+        e.from().approx_eq(&previous);
+        previous = e.to();
     }
 }

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -1,6 +1,6 @@
 use lyon::extra::rust_logo::build_logo_path;
 use lyon::math::*;
-use lyon::path::Path;
+use lyon::path::{Path, Polygon};
 use lyon::tessellation;
 use lyon::tessellation::geometry_builder::*;
 use lyon::tessellation::{FillOptions, FillTessellator};
@@ -141,16 +141,21 @@ fn main() {
     build_logo_path(&mut builder);
     let path = builder.build();
 
+    let arrow_polygon = Polygon {
+        points: &[
+            point(-1.0, -0.3),
+            point(0.0, -0.3),
+            point(0.0, -1.0),
+            point(1.5, 0.0),
+            point(0.0, 1.0),
+            point(0.0, 0.3),
+            point(-1.0, 0.3),
+        ],
+        closed: true,
+    };
     // Build a Path for the arrow.
     let mut builder = Path::builder();
-    builder.begin(point(-1.0, -0.3));
-    builder.line_to(point(0.0, -0.3));
-    builder.line_to(point(0.0, -1.0));
-    builder.line_to(point(1.5, 0.0));
-    builder.line_to(point(0.0, 1.0));
-    builder.line_to(point(0.0, 0.3));
-    builder.line_to(point(-1.0, 0.3));
-    builder.close();
+    builder.add_polygon(arrow_polygon);
     let arrow_path = builder.build();
 
     fill_tess

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -1,12 +1,12 @@
 use lyon::extra::rust_logo::build_logo_path;
 use lyon::math::*;
-use lyon::path::{Path, Polygon};
+use lyon::path::{Path, Polygon, NO_ATTRIBUTES};
 use lyon::tessellation;
 use lyon::tessellation::geometry_builder::*;
 use lyon::tessellation::{FillOptions, FillTessellator};
 use lyon::tessellation::{StrokeOptions, StrokeTessellator};
 
-use lyon::algorithms::walk;
+use lyon::algorithms::{walk, rounded_polygon};
 
 use winit::dpi::PhysicalSize;
 use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
@@ -155,7 +155,8 @@ fn main() {
     };
     // Build a Path for the arrow.
     let mut builder = Path::builder();
-    builder.add_polygon(arrow_polygon);
+    rounded_polygon::add_rounded_polygon(&mut builder, arrow_polygon, 0.2, true);
+    //builder.add_polygon(arrow_polygon);
     let arrow_path = builder.build();
 
     fill_tess

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -141,21 +141,24 @@ fn main() {
     build_logo_path(&mut builder);
     let path = builder.build();
 
+
+    let arrow_points = [
+        point(-1.0, -0.3),
+        point(0.0, -0.3),
+        point(0.0, -1.0),
+        point(1.5, 0.0),
+        point(0.0, 1.0),
+        point(0.0, 0.3),
+        point(-1.0, 0.3),
+    ];
+
     let arrow_polygon = Polygon {
-        points: &[
-            point(-1.0, -0.3),
-            point(0.0, -0.3),
-            point(0.0, -1.0),
-            point(1.5, 0.0),
-            point(0.0, 1.0),
-            point(0.0, 0.3),
-            point(-1.0, 0.3),
-        ],
+        points: &arrow_points,
         closed: true,
     };
     // Build a Path for the arrow.
     let mut builder = Path::builder();
-    rounded_polygon::add_rounded_polygon(&mut builder, arrow_polygon, 0.2, true, NO_ATTRIBUTES);
+    rounded_polygon::add_rounded_polygon(&mut builder, arrow_polygon, 0.2, NO_ATTRIBUTES);
     //builder.add_polygon(arrow_polygon);
     let arrow_path = builder.build();
 

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -155,7 +155,7 @@ fn main() {
     };
     // Build a Path for the arrow.
     let mut builder = Path::builder();
-    rounded_polygon::add_rounded_polygon(&mut builder, arrow_polygon, 0.2, true);
+    rounded_polygon::add_rounded_polygon(&mut builder, arrow_polygon, 0.2, true, NO_ATTRIBUTES);
     //builder.add_polygon(arrow_polygon);
     let arrow_path = builder.build();
 


### PR DESCRIPTION
Added `rounded_polygon::add_rounded_polygon()` to lyon_algorithms.  

Closes https://github.com/nical/lyon/issues/846

I also made the arrows in the wgpu example rounded to show them off but am happy to revert that.