### PR TITLE
SVG Builder Documentation

### DIFF
--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -802,6 +802,8 @@ pub trait SvgPathBuilder {
 
     /// Equivalent to `cubic_bezier_to` in relative coordinates.
     ///
+    /// Corresponding SVG command: `c`.
+    ///
     /// The provided coordinates are offsets relative to the current position of
     /// the builder.
     fn relative_cubic_bezier_to(&mut self, ctrl1: Vector, ctrl2: Vector, to: Vector);

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -845,7 +845,7 @@ pub trait SvgPathBuilder {
 
     /// Adds an horizontal line segment.
     ///
-    /// Corresponding SVG command: `L`.
+    /// Corresponding SVG command: `H`.
     ///
     /// Equivalent to `line_to`, using the y coordinate of the current position.
     fn horizontal_line_to(&mut self, x: f32);


### PR DESCRIPTION
Horizontal Line To corresponds to the `H` op not `L`

Add relative cubic bezier `c`