### PR TITLE
Expose path::path::* as path::* for brevity

### DIFF
--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -56,7 +56,10 @@ pub mod builder;
 pub mod commands;
 mod events;
 pub mod iterator;
+// TODO: remove "pub" on mod path to avoid redundant  "use lyon::path::path::Path" in user code
+//       breaking change would require 1.1 bump?
 pub mod path;
+pub use path::*;
 pub mod path_buffer;
 pub mod polygon;
 


### PR DESCRIPTION
It used to be that public elements of `lyon::path::*` were exposed, but since 1.0, they were moved to `lyon::path::path::*`.

This PR makes them exposed as `lyon::path::*` again. Eventually you may want to make the path::path private, but that requires a major or at least a minor version bump.

P.S. this makes migrating from pre-1.0 easier too.