### PR TITLE
Make clippy happy without significant changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,18 @@ jobs:
           command: test
           args: --all --verbose --all-features
 
+      - name: Format
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Lint
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all --all-targets --all-features -- -D warnings
+
   wasm:
     env:
         RUST_BACKTRACE: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,18 +33,6 @@ jobs:
           command: test
           args: --all --verbose --all-features
 
-      - name: Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Lint
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all --all-targets --all-features -- -D warnings
-
   wasm:
     env:
         RUST_BACKTRACE: 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ of prior knowledge about the project. Most of these issues are labelled
 on their estimated difficulty.
 
 If you are interested in working on the tessellators, the wiki has some information
-about the algortithms that may be useful to you
+about the algorithms that may be useful to you
 
  - [fill tessellator](https://github.com/nical/lyon/wiki/Tessellator)
  - [stroke tessellator](https://github.com/nical/lyon/wiki/Stroke-tessellation)
@@ -45,7 +45,7 @@ about the algortithms that may be useful to you
 - Commits should be as small as possible, while ensuring that each commit is
   correct independently (i.e., each commit should compile and pass tests).
 
-- If your patch is not getting reviewed or you need a specific person to review
+- If your patch is not getting reviewed, or you need a specific person to review
   it, you can @-reply a reviewer asking for a review in the pull request or a
   comment.
 
@@ -55,7 +55,7 @@ For specific git instructions, see [GitHub workflow 101](https://github.com/serv
 
 ## Testing
 
-To run all tests from all of the lyon crates, run `cargo test --all` from the root of the repository.
+To run all tests from all lyon crates, run `cargo test --all` from the root of the repository.
 
 ## Conduct
 
@@ -64,7 +64,7 @@ For escalation or moderation issues, please contact Nical (nical@fastmail.com) i
 
 ## Communication
 
-[Gitter](https://gitter.im/lyon-rs/Lobby) and the [github issues](https://github.com/nical/lyon/issues) are good places to ask questions and more generally talk about about lyon. Some of the lyon contributors also frequent the `#rust` and `#rust-gamedev` channels on [`irc.mozilla.org`](https://wiki.mozilla.org/IRC).
+[Gitter](https://gitter.im/lyon-rs/Lobby) and the [GitHub issues](https://github.com/nical/lyon/issues) are good places to ask questions and more generally talk about lyon. Some of the lyon contributors also frequent the `#rust` and `#rust-gamedev` channels on [`irc.mozilla.org`](https://wiki.mozilla.org/IRC).
 
 ## License
 
@@ -75,5 +75,5 @@ If such a change occurs, it will not affect versions of the project prior to the
 
 ### In other words...
 
-At this time we are not entirely certain which of MPL2 or dual MIT/Apache2 is the best licensing scheme for this project. Both approaches are very permissive and we want to keep the door open to changing to MPL2 in the future.
+At this time we are not entirely certain which of MPL2 or dual MIT/Apache2 is the best licensing scheme for this project. Both approaches are very permissive, and we want to keep the door open to changing to MPL2 in the future.
 This project will remain usable under the MIT/Apache2 license for the foreseeable future. However, by contributing to this project you accept that your contributions may be re-licensed under the Mozilla Public License 2.0 without the MIT and Apache2 options.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ fn main() {
     let path = builder.build();
     // Let's use our own custom vertex type instead of the default one.
     #[derive(Copy, Clone, Debug)]
-    struct MyVertex { position: [f32; 2] };
+    struct MyVertex { position: [f32; 2] }
     // Will contain the result of the tessellation.
     let mut geometry: VertexBuffers<MyVertex, u16> = VertexBuffers::new();
     let mut tessellator = FillTessellator::new();

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Although the format of the output of the tessellators is customizable, the algor
 
 ### Is anti-aliasing supported?
 
-There is currently no built-in support for anti-aliasing in the tessellators. Anti-aliasing can still be achieved by users of this crate using techniques commonly employed in video games (msaa, taa, fxaa, etc.).
+There is currently no built-in support for antialiasing in the tessellators. Antialiasing can still be achieved by users of this crate using techniques commonly employed in video games (msaa, taa, fxaa, etc.).
 
 ### I need help!
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -114,7 +114,7 @@ $> lyon show -i assets/logo.path --fill --stroke --tolerance 0.05 --line-join Ro
 
 ## ```fuzz```
 
-This command runs the built-in fuzzer. The fuzzer will generate random paths and tessellate them until it finds a path that trigers an error. Once an error is found, the fuzzer tries to reduce the test case and prints the reduced test case to stdout.
+This command runs the built-in fuzzer. The fuzzer will generate random paths and tessellate them until it finds a path that triggers an error. Once an error is found, the fuzzer tries to reduce the test case and prints the reduced test case to stdout.
 
 Run ```$> lyon fuzz --help``` for more details.
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -124,7 +124,7 @@ fn main() {
                 .arg(
                     Arg::with_name("IGNORE_ERRORS")
                         .long("ignore-errors")
-                        .help("Try to continue when encoutering errors unless it is a panic."),
+                        .help("Try to continue when encountering errors unless it is a panic."),
                 ),
         )
         .subcommand(
@@ -401,7 +401,7 @@ fn get_render_params(matches: &ArgMatches) -> RenderCmd {
     RenderCmd {
         aa: if let Some(aa) = matches.value_of("ANTIALIASING") {
             match aa {
-                // wgpu currently only supports msaa 4 for protability reasons.
+                // wgpu currently only supports msaa 4 for portability reasons.
                 "msaa" => AntiAliasing::Msaa(4),
                 _ => AntiAliasing::None,
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -161,8 +161,8 @@ fn main() {
         .get_matches();
 
     if let Some(command) = matches.subcommand_matches("tessellate") {
-        let output = get_output(&command);
-        let cmd = get_tess_command(&command, true);
+        let output = get_output(command);
+        let cmd = get_tess_command(command, true);
         let cmd_copy = cmd.clone();
         let float_precision = cmd.float_precision;
 
@@ -198,9 +198,9 @@ fn main() {
 
     if let Some(command) = matches.subcommand_matches("path") {
         let cmd = PathCmd {
-            path: get_path(&command).expect("Need a path to transform"),
+            path: get_path(command).expect("Need a path to transform"),
             output: get_output(command),
-            tolerance: get_tolerance(&command),
+            tolerance: get_tolerance(command),
             count: command.is_present("COUNT"),
             flatten: command.is_present("FLATTEN"),
         };
@@ -233,7 +233,7 @@ fn main() {
     }
 }
 
-fn declare_input_path<'a>(app: App<'a>) -> App<'a> {
+fn declare_input_path(app: App) -> App {
     app.arg(
         Arg::with_name("PATH")
             .value_name("PATH")
@@ -252,7 +252,7 @@ fn declare_input_path<'a>(app: App<'a>) -> App<'a> {
     )
 }
 
-fn declare_tess_params<'a>(app: App<'a>, need_path: bool) -> App<'a> {
+fn declare_tess_params(app: App, need_path: bool) -> App {
     if need_path {
         declare_input_path(app)
     } else {
@@ -389,12 +389,9 @@ fn get_path(matches: &ArgMatches) -> Option<Path> {
 
     let mut builder = Path::builder_with_attributes(options.num_attributes);
 
-    match parser.parse(&options, &mut Source::new(path_str.chars()), &mut builder) {
-        Err(e) => {
-            println!("Error while parsing path: {}", path_str);
-            println!("{:?}", e);
-        }
-        _ => {}
+    if let Err(e) = parser.parse(&options, &mut Source::new(path_str.chars()), &mut builder) {
+        println!("Error while parsing path: {}", path_str);
+        println!("{:?}", e);
     }
 
     Some(builder.build())
@@ -431,7 +428,7 @@ fn get_tess_command(command: &ArgMatches, need_path: bool) -> TessellateCmd {
     let fill =
         if command.is_present("FILL") || (stroke.is_none() && hatch.is_none() && dots.is_none()) {
             Some(
-                FillOptions::tolerance(get_tolerance(&command))
+                FillOptions::tolerance(get_tolerance(command))
                     .with_fill_rule(fill_rule)
                     .with_sweep_orientation(orientation),
             )

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,7 @@ use lyon::geom::euclid::Angle;
 use lyon::path::Path;
 use lyon::tessellation::{FillOptions, FillRule, LineCap, LineJoin, Orientation, StrokeOptions};
 use std::fs::File;
-use std::io::{stderr, stdout, Read, Write};
+use std::io::{stdout, Read, Write};
 
 fn main() {
     env_logger::init();
@@ -371,7 +371,7 @@ fn get_path(matches: &ArgMatches) -> Option<Path> {
         if let Ok(mut file) = File::open(input_file) {
             file.read_to_string(&mut path_str).unwrap();
         } else {
-            write!(&mut stderr(), "Cannot open file {}", input_file).unwrap();
+            eprintln!("Cannot open file {input_file}");
             return None;
         }
     }
@@ -656,12 +656,11 @@ fn get_hatching_angle(matches: &ArgMatches) -> Angle<f32> {
 }
 
 fn get_output(matches: &ArgMatches) -> Box<dyn Write> {
-    let mut output: Box<dyn Write> = Box::new(stdout());
     if let Some(output_file) = matches.value_of("OUTPUT") {
         if let Ok(file) = File::create(output_file) {
-            output = Box::new(file);
+            return Box::new(file);
         }
     }
 
-    output
+    Box::new(stdout())
 }

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -420,7 +420,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         label: None,
         layout: Some(&pipeline_layout),
         vertex: wgpu::VertexState {
-            module: &vs_module,
+            module: vs_module,
             entry_point: "main",
             buffers: &[wgpu::VertexBufferLayout {
                 array_stride: std::mem::size_of::<GpuVertex>() as u64,
@@ -445,7 +445,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
             }],
         },
         fragment: Some(wgpu::FragmentState {
-            module: &fs_module,
+            module: fs_module,
             entry_point: "main",
             targets: &[Some(wgpu::ColorTargetState {
                 format: wgpu::TextureFormat::Bgra8Unorm,
@@ -487,7 +487,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         label: None,
         layout: Some(&pipeline_layout),
         vertex: wgpu::VertexState {
-            module: &bg_vs_module,
+            module: bg_vs_module,
             entry_point: "main",
             buffers: &[wgpu::VertexBufferLayout {
                 array_stride: std::mem::size_of::<Point>() as u64,
@@ -500,7 +500,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
             }],
         },
         fragment: Some(wgpu::FragmentState {
-            module: &bg_fs_module,
+            module: bg_fs_module,
             entry_point: "main",
             targets: &[Some(wgpu::ColorTargetState {
                 format: wgpu::TextureFormat::Bgra8Unorm,
@@ -517,7 +517,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
             unclipped_depth: false,
             conservative: false,
         },
-        depth_stencil: depth_stencil_state.clone(),
+        depth_stencil: depth_stencil_state,
         multisample: wgpu::MultisampleState {
             count: sample_count,
             mask: !0,
@@ -600,8 +600,8 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
             label: Some("Encoder"),
         });
 
-        cpu_primitives[stroke_prim_id as usize].width = scene.stroke_width;
-        cpu_primitives[stroke_prim_id as usize].color = [
+        cpu_primitives[stroke_prim_id].width = scene.stroke_width;
+        cpu_primitives[stroke_prim_id].color = [
             (frame_count * 0.008 - 1.6).sin() * 0.1 + 0.1,
             (frame_count * 0.005 - 1.6).sin() * 0.1 + 0.1,
             (frame_count * 0.01 - 1.6).sin() * 0.1 + 0.1,
@@ -672,16 +672,16 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
                 }),
             });
 
-            let index_range;
-            if scene.show_wireframe {
+            let index_range = if scene.show_wireframe {
                 pass.set_pipeline(&wireframe_render_pipeline);
                 pass.set_index_buffer(wireframe_ibo.slice(..), wgpu::IndexFormat::Uint32);
-                index_range = 0..(wireframe_indices.len() as u32);
+                0..(wireframe_indices.len() as u32)
             } else {
                 pass.set_pipeline(&render_pipeline);
                 pass.set_index_buffer(ibo.slice(..), wgpu::IndexFormat::Uint32);
-                index_range = 0..(geometry.indices.len() as u32);
-            }
+                0..(geometry.indices.len() as u32)
+            };
+
             pass.set_bind_group(0, &bind_group, &[]);
             pass.set_vertex_buffer(0, vbo.slice(..));
 

--- a/cli/src/tessellate/format.rs
+++ b/cli/src/tessellate/format.rs
@@ -3,7 +3,7 @@ use lyon::math::Point;
 use lyon::tessellation::geometry_builder::VertexBuffers;
 use regex::Regex;
 
-const DEFAULT_FMT: &str = "vertices: [@vertices{sep=, }{fmt=({position.x}, {position.y})}@]\\nindices: [@indices{sep=, }{fmt={index}}@]";
+const DEFAULT_FMT: &str = r"vertices: [@vertices{sep=, }{fmt=({position.x}, {position.y})}@]\nindices: [@indices{sep=, }{fmt={index}}@]";
 
 pub fn format_output(
     fmt_string: Option<&str>,
@@ -16,11 +16,11 @@ pub fn format_output(
     let mut output = String::with_capacity(buffers.vertices.len() + buffers.indices.len());
     for section in fmt {
         if let Some(capture) = extract.captures(section) {
-            let itername = capture.get(1).map(|m| m.as_str()).unwrap();
+            let iter_name = capture.get(1).map(|m| m.as_str()).unwrap();
             let sep = capture.get(2).map(|m| m.as_str()).unwrap();
             let pattern = capture.get(3).map(|m| m.as_str()).unwrap();
 
-            match itername {
+            match iter_name {
                 "vertices" => {
                     output.push_str(&format_iter(buffers.vertices.iter(), sep, pattern, |x| {
                         format_float(x, precision)

--- a/crates/algorithms/src/aabb.rs
+++ b/crates/algorithms/src/aabb.rs
@@ -3,7 +3,6 @@
 use crate::geom::{CubicBezierSegment, QuadraticBezierSegment};
 use crate::math::{point, Box2D, Point};
 use crate::path::PathEvent;
-use core::f32;
 
 /// Computes a conservative axis-aligned rectangle that contains the path.
 ///

--- a/crates/algorithms/src/area.rs
+++ b/crates/algorithms/src/area.rs
@@ -32,7 +32,7 @@ where
     } else {
         return None;
     };
-    let mut doube_area = 0.0;
+    let mut double_area = 0.0;
     let mut v0 = vector(0.0, 0.0);
 
     for evt in path.flattened(tolerance) {
@@ -42,13 +42,13 @@ where
             }
             PathEvent::End { last, first, .. } => {
                 let v1 = last - first;
-                doube_area += v0.cross(v1);
+                double_area += v0.cross(v1);
 
-                return Some(doube_area * 0.5);
+                return Some(double_area * 0.5);
             }
             PathEvent::Line { to, .. } => {
                 let v1 = to - first;
-                doube_area += v0.cross(v1);
+                double_area += v0.cross(v1);
                 v0 = v1;
             }
             PathEvent::Quadratic { .. } | PathEvent::Cubic { .. } => {

--- a/crates/algorithms/src/hatching.rs
+++ b/crates/algorithms/src/hatching.rs
@@ -34,7 +34,6 @@ use crate::path::{self, Attributes, EndpointId, PathEvent, NO_ATTRIBUTES};
 use core::marker::PhantomData;
 
 use core::cmp::Ordering;
-use core::f32;
 use core::mem;
 
 use alloc::vec::Vec;

--- a/crates/algorithms/src/hit_test.rs
+++ b/crates/algorithms/src/hit_test.rs
@@ -3,7 +3,6 @@
 use crate::geom::{CubicBezierSegment, LineSegment, QuadraticBezierSegment};
 use crate::math::Point;
 use crate::path::{FillRule, PathEvent};
-use core::f32;
 
 /// Returns whether the point is inside the path.
 pub fn hit_test_path<Iter>(point: &Point, path: Iter, fill_rule: FillRule, tolerance: f32) -> bool

--- a/crates/algorithms/src/lib.rs
+++ b/crates/algorithms/src/lib.rs
@@ -23,9 +23,9 @@ pub mod length;
 pub mod measure;
 pub mod raycast;
 pub mod rect;
+pub mod rounded_polygon;
 pub mod walk;
 pub mod winding;
-pub mod rounded_polygon;
 
 pub use crate::path::geom;
 pub use crate::path::math;

--- a/crates/algorithms/src/measure.rs
+++ b/crates/algorithms/src/measure.rs
@@ -105,25 +105,23 @@ impl<'l> PathSample<'l> {
 ///     measure::{PathMeasurements, SampleType},
 /// };
 ///
-/// fn main() {
-///     let mut path = Path::builder();
-///     path.begin(point(0.0, 0.0));
-///     path.quadratic_bezier_to(point(1.0, 1.0), point(2.0, 0.0));
-///     path.end(false);
-///     let path = path.build();
+/// let mut path = Path::builder();
+/// path.begin(point(0.0, 0.0));
+/// path.quadratic_bezier_to(point(1.0, 1.0), point(2.0, 0.0));
+/// path.end(false);
+/// let path = path.build();
 ///
-///     // Build the acceleration structure.
-///     let measurements = PathMeasurements::from_path(&path, 1e-3);
-///     let mut sampler = measurements.create_sampler(&path, SampleType::Normalized);
+/// // Build the acceleration structure.
+/// let measurements = PathMeasurements::from_path(&path, 1e-3);
+/// let mut sampler = measurements.create_sampler(&path, SampleType::Normalized);
 ///
-///     let sample  = sampler.sample(0.5);
-///     println!("Mid-point position: {:?}, tangent: {:?}", sample.position(), sample.tangent());
+/// let sample  = sampler.sample(0.5);
+/// println!("Mid-point position: {:?}, tangent: {:?}", sample.position(), sample.tangent());
 ///
-///     let mut second_half = Path::builder();
-///     sampler.split_range(0.5..1.0, &mut second_half);
-///     let second_half = second_half.build();
-///     assert!((sampler.length() / 2.0 - approximate_length(&second_half, 1e-3)).abs() < 1e-3);
-/// }
+/// let mut second_half = Path::builder();
+/// sampler.split_range(0.5..1.0, &mut second_half);
+/// let second_half = second_half.build();
+/// assert!((sampler.length() / 2.0 - approximate_length(&second_half, 1e-3)).abs() < 1e-3);
 /// ```
 ///
 pub struct PathMeasurements {
@@ -608,17 +606,17 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathSampler<'l, PS, AS> {
                 position: self.positions.get_endpoint(*at),
                 tangent: vector(0.0, 0.0),
                 attributes: self.attributes.get(*at),
-            }
+            };
         }
 
         use std::f32::NAN;
         for value in &mut self.attribute_buffer {
             *value = NAN;
         }
-        return PathSample {
+        PathSample {
             position: point(NAN, NAN),
             tangent: vector(NAN, NAN),
-            attributes: &self.attribute_buffer
+            attributes: &self.attribute_buffer,
         }
     }
 
@@ -905,7 +903,11 @@ fn zero_length() {
     let path = path.build();
     let measure = PathMeasurements::from_path(&path, 0.01);
     let mut sampler = measure.create_sampler_with_attributes(&path, &path, SampleType::Normalized);
-    let expected = PathSample { position: point(1.0, 2.0), tangent: vector(0.0, 0.0), attributes: &[3.0, 4.0] };
+    let expected = PathSample {
+        position: point(1.0, 2.0),
+        tangent: vector(0.0, 0.0),
+        attributes: &[3.0, 4.0],
+    };
     assert_eq!(sampler.sample(0.0), expected);
     assert_eq!(sampler.sample(0.5), expected);
     assert_eq!(sampler.sample(1.0), expected);
@@ -916,7 +918,11 @@ fn zero_length() {
     let path = path.build();
     let measure = PathMeasurements::from_path(&path, 0.01);
     let mut sampler = measure.create_sampler_with_attributes(&path, &path, SampleType::Distance);
-    let expected = PathSample { position: point(1.0, 2.0), tangent: vector(0.0, 0.0), attributes: &[3.0, 4.0] };
+    let expected = PathSample {
+        position: point(1.0, 2.0),
+        tangent: vector(0.0, 0.0),
+        attributes: &[3.0, 4.0],
+    };
     assert_eq!(sampler.sample(0.0), expected);
     assert_eq!(sampler.sample(0.5), expected);
     assert_eq!(sampler.sample(1.0), expected);

--- a/crates/algorithms/src/measure.rs
+++ b/crates/algorithms/src/measure.rs
@@ -79,7 +79,7 @@ impl<'l> PathSample<'l> {
 /// measured path, so it is usually a good idea to cache and reuse it whenever possible.
 ///
 /// Queries on path measurements are made via a sampler object (see `PathSampler`) which can be configured
-/// to measure real distance or normalzied ones (values between 0 and 1 with zero indicating the start
+/// to measure real distance or normalized ones (values between 0 and 1 with zero indicating the start
 /// of the path and 1 indicating the end).
 ///
 /// ## Differences with the `PathWalker`

--- a/crates/algorithms/src/measure.rs
+++ b/crates/algorithms/src/measure.rs
@@ -609,13 +609,13 @@ impl<'l, PS: PositionStore, AS: AttributeStore> PathSampler<'l, PS, AS> {
             };
         }
 
-        use std::f32::NAN;
         for value in &mut self.attribute_buffer {
-            *value = NAN;
+            *value = f32::NAN;
         }
+
         PathSample {
-            position: point(NAN, NAN),
-            tangent: vector(NAN, NAN),
+            position: point(f32::NAN, f32::NAN),
+            tangent: vector(f32::NAN, f32::NAN),
             attributes: &self.attribute_buffer,
         }
     }

--- a/crates/algorithms/src/raycast.rs
+++ b/crates/algorithms/src/raycast.rs
@@ -3,7 +3,6 @@
 use crate::geom::{CubicBezierSegment, Line, LineSegment, QuadraticBezierSegment};
 use crate::math::{point, vector, Point, Vector};
 use crate::path::PathEvent;
-use core::f32;
 
 pub struct Ray {
     pub origin: Point,

--- a/crates/algorithms/src/rect.rs
+++ b/crates/algorithms/src/rect.rs
@@ -264,12 +264,10 @@ fn direction(v: Vector, tolerance: f32) -> Option<Dir> {
         } else {
             Dir::Left
         }
+    } else if v.y > 0.0 {
+        Dir::Down
     } else {
-        if v.y > 0.0 {
-            Dir::Down
-        } else {
-            Dir::Up
-        }
+        Dir::Up
     };
 
     Some(dir)

--- a/crates/algorithms/src/rounded_polygon.rs
+++ b/crates/algorithms/src/rounded_polygon.rs
@@ -68,8 +68,8 @@ pub fn add_rounded_polygon<B: PathBuilder>(
 
 fn clamp_radius(radius: f32, p_previous: Point, p_current: Point, p_next: Point) -> f32 {
     let shorter_edge = ((p_current - p_next).length()).min((p_previous - p_current).length());
-    let clamped_radius = radius.min(shorter_edge * 0.5);
-    clamped_radius
+
+    radius.min(shorter_edge * 0.5)
 }
 
 fn get_point_between(p1: Point, p2: Point, radius: f32) -> Point {

--- a/crates/algorithms/src/walk.rs
+++ b/crates/algorithms/src/walk.rs
@@ -169,13 +169,22 @@ impl<'l> PathWalker<'l> {
         let mut distance = self.leftover + d;
         let mut x = 0.0;
         while distance >= self.next_distance {
+            // TODO: the only reason for this if statement right now is if distance is 0 in case num_attributes is 0.
+            //       if distance can never be 0, then this if statement check can be removed
             if self.num_attributes > 0 {
                 let t2 = t.end * self.next_distance / distance;
 
                 // TODO: are these asserts needed?  For now, this simply matches prior code in functionality
+                // TODO: I accidentally forgot to use `take(...)`, but all tests still passed. Is it needed?
                 assert!(self.prev_attributes.len() >= self.num_attributes);
                 assert!(attributes.len() >= self.num_attributes);
-                for (i, (prev, attr)) in self.prev_attributes.iter().zip(attributes).enumerate() {
+                for (i, (prev, attr)) in self
+                    .prev_attributes
+                    .iter()
+                    .take(self.num_attributes)
+                    .zip(attributes)
+                    .enumerate()
+                {
                     self.attribute_buffer[i] = prev * (1.0 - t2) + attr * t2;
                 }
             }

--- a/crates/algorithms/src/walk.rs
+++ b/crates/algorithms/src/walk.rs
@@ -171,9 +171,12 @@ impl<'l> PathWalker<'l> {
         while distance >= self.next_distance {
             if self.num_attributes > 0 {
                 let t2 = t.end * self.next_distance / distance;
-                for i in 0..self.num_attributes {
-                    self.attribute_buffer[i] =
-                        self.prev_attributes[i] * (1.0 - t2) + attributes[i] * t2;
+
+                // TODO: are these asserts needed?  For now, this simply matches prior code in functionality
+                assert!(self.prev_attributes.len() >= self.num_attributes);
+                assert!(attributes.len() >= self.num_attributes);
+                for (i, (prev, attr)) in self.prev_attributes.iter().zip(attributes).enumerate() {
+                    self.attribute_buffer[i] = prev * (1.0 - t2) + attr * t2;
                 }
             }
             x += (self.next_distance - self.leftover) * inv_d;

--- a/crates/algorithms/src/walk.rs
+++ b/crates/algorithms/src/walk.rs
@@ -45,7 +45,6 @@ use crate::math::*;
 use crate::path::builder::*;
 use crate::path::{Attributes, EndpointId, PathEvent};
 
-use core::f32;
 use core::ops::Range;
 
 use alloc::vec::Vec;

--- a/crates/algorithms/src/walk.rs
+++ b/crates/algorithms/src/walk.rs
@@ -168,23 +168,11 @@ impl<'l> PathWalker<'l> {
         let mut distance = self.leftover + d;
         let mut x = 0.0;
         while distance >= self.next_distance {
-            // TODO: the only reason for this if statement right now is if distance is 0 in case num_attributes is 0.
-            //       if distance can never be 0, then this if statement check can be removed
             if self.num_attributes > 0 {
                 let t2 = t.end * self.next_distance / distance;
-
-                // TODO: are these asserts needed?  For now, this simply matches prior code in functionality
-                // TODO: I accidentally forgot to use `take(...)`, but all tests still passed. Is it needed?
-                assert!(self.prev_attributes.len() >= self.num_attributes);
-                assert!(attributes.len() >= self.num_attributes);
-                for (i, (prev, attr)) in self
-                    .prev_attributes
-                    .iter()
-                    .take(self.num_attributes)
-                    .zip(attributes)
-                    .enumerate()
-                {
-                    self.attribute_buffer[i] = prev * (1.0 - t2) + attr * t2;
+                for i in 0..self.num_attributes {
+                    self.attribute_buffer[i] =
+                        self.prev_attributes[i] * (1.0 - t2) + attributes[i] * t2;
                 }
             }
             x += (self.next_distance - self.leftover) * inv_d;

--- a/crates/extra/src/debugging.rs
+++ b/crates/extra/src/debugging.rs
@@ -92,9 +92,9 @@ pub fn find_reduced_test_case<F: Fn(Path) -> bool + panic::UnwindSafe + panic::R
     for poly in &polygons {
         let mut poly_iter = poly.iter();
         let pos = *poly_iter.next().unwrap();
-        println!("    builder.begin(point({:.}, {:.}));", pos.x, pos.y);
+        println!("    builder.begin(point({}, {}));", pos.x, pos.y);
         for pos in poly_iter {
-            println!("    builder.line_to(point({:.}, {:.}));", pos.x, pos.y);
+            println!("    builder.line_to(point({}, {}));", pos.x, pos.y);
         }
         println!("    builder.close();\n");
     }

--- a/crates/extra/src/parser.rs
+++ b/crates/extra/src/parser.rs
@@ -134,6 +134,7 @@ impl<Iter: Iterator<Item = char>> Source<Iter> {
 /// - line to endpoint [3, 3] custom attribute 30.
 ///
 /// Note that only endpoints have custom attributes, control points do not.
+#[derive(Debug, Default)]
 pub struct PathParser {
     attribute_buffer: Vec<f32>,
     float_buffer: String,
@@ -145,14 +146,7 @@ pub struct PathParser {
 
 impl PathParser {
     pub fn new() -> Self {
-        PathParser {
-            attribute_buffer: Vec::new(),
-            float_buffer: String::new(),
-            num_attributes: 0,
-            stop_at: None,
-            current_position: point(0.0, 0.0),
-            need_end: false,
-        }
+        Self::default()
     }
 
     pub fn parse<Iter, Builder>(

--- a/crates/extra/src/parser.rs
+++ b/crates/extra/src/parser.rs
@@ -214,16 +214,16 @@ impl PathParser {
 
             //println!("{:?} at line {:?} column {:?}", cmd, cmd_line, cmd_col);
 
-            let is_relatve = cmd.is_lowercase();
+            let is_relative = cmd.is_lowercase();
 
             match cmd {
                 'l' | 'L' => {
-                    let to = self.parse_endpoint(is_relatve, src)?;
+                    let to = self.parse_endpoint(is_relative, src)?;
                     output.line_to(to, &self.attribute_buffer);
                 }
                 'h' | 'H' => {
                     let mut x = self.parse_number(src)?;
-                    if is_relatve {
+                    if is_relative {
                         x += self.current_position.x;
                     }
                     let to = point(x, self.current_position.y);
@@ -233,7 +233,7 @@ impl PathParser {
                 }
                 'v' | 'V' => {
                     let mut y = self.parse_number(src)?;
-                    if is_relatve {
+                    if is_relative {
                         y += self.current_position.y;
                     }
                     let to = point(self.current_position.x, y);
@@ -242,28 +242,28 @@ impl PathParser {
                     output.line_to(to, &self.attribute_buffer);
                 }
                 'q' | 'Q' => {
-                    let ctrl = self.parse_point(is_relatve, src)?;
-                    let to = self.parse_endpoint(is_relatve, src)?;
+                    let ctrl = self.parse_point(is_relative, src)?;
+                    let to = self.parse_endpoint(is_relative, src)?;
                     prev_quadratic_ctrl = Some(ctrl);
                     output.quadratic_bezier_to(ctrl, to, &self.attribute_buffer);
                 }
                 't' | 'T' => {
                     let ctrl = self.get_smooth_ctrl(prev_quadratic_ctrl);
-                    let to = self.parse_endpoint(is_relatve, src)?;
+                    let to = self.parse_endpoint(is_relative, src)?;
                     prev_quadratic_ctrl = Some(ctrl);
                     output.quadratic_bezier_to(ctrl, to, &self.attribute_buffer);
                 }
                 'c' | 'C' => {
-                    let ctrl1 = self.parse_point(is_relatve, src)?;
-                    let ctrl2 = self.parse_point(is_relatve, src)?;
-                    let to = self.parse_endpoint(is_relatve, src)?;
+                    let ctrl1 = self.parse_point(is_relative, src)?;
+                    let ctrl2 = self.parse_point(is_relative, src)?;
+                    let to = self.parse_endpoint(is_relative, src)?;
                     prev_cubic_ctrl = Some(ctrl2);
                     output.cubic_bezier_to(ctrl1, ctrl2, to, &self.attribute_buffer);
                 }
                 's' | 'S' => {
                     let ctrl1 = self.get_smooth_ctrl(prev_cubic_ctrl);
-                    let ctrl2 = self.parse_point(is_relatve, src)?;
-                    let to = self.parse_endpoint(is_relatve, src)?;
+                    let ctrl2 = self.parse_point(is_relative, src)?;
+                    let to = self.parse_endpoint(is_relative, src)?;
                     prev_cubic_ctrl = Some(ctrl2);
                     output.cubic_bezier_to(ctrl1, ctrl2, to, &self.attribute_buffer);
                 }
@@ -277,7 +277,7 @@ impl PathParser {
                     let x_rotation = self.parse_number(src)?;
                     let large_arc = self.parse_flag(src)?;
                     let sweep = self.parse_flag(src)?;
-                    let to = self.parse_endpoint(is_relatve, src)?;
+                    let to = self.parse_endpoint(is_relative, src)?;
                     let svg_arc = SvgArc {
                         from,
                         to,
@@ -309,7 +309,7 @@ impl PathParser {
                         output.end(false);
                     }
 
-                    let to = self.parse_endpoint(is_relatve, src)?;
+                    let to = self.parse_endpoint(is_relative, src)?;
                     first_position = to;
                     output.begin(to, &self.attribute_buffer);
                     self.need_end = true;
@@ -367,10 +367,10 @@ impl PathParser {
 
     fn parse_endpoint(
         &mut self,
-        is_relatve: bool,
+        is_relative: bool,
         src: &mut Source<impl Iterator<Item = char>>,
     ) -> Result<Point, ParseError> {
-        let position = self.parse_point(is_relatve, src)?;
+        let position = self.parse_point(is_relative, src)?;
         self.current_position = position;
 
         self.parse_attributes(src)?;
@@ -393,13 +393,13 @@ impl PathParser {
 
     fn parse_point(
         &mut self,
-        is_relatve: bool,
+        is_relative: bool,
         src: &mut Source<impl Iterator<Item = char>>,
     ) -> Result<Point, ParseError> {
         let mut x = self.parse_number(src)?;
         let mut y = self.parse_number(src)?;
 
-        if is_relatve {
+        if is_relative {
             x += self.current_position.x;
             y += self.current_position.y;
         }

--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -150,7 +150,7 @@ impl<S: Scalar> Arc<S> {
         }
     }
 
-    /// Approximate the arc with a sequence of quadratic Bézier curves.
+    /// Approximate the arc with a sequence of quadratic bézier curves.
     #[inline]
     pub fn for_each_quadratic_bezier<F>(&self, cb: &mut F)
     where
@@ -159,7 +159,7 @@ impl<S: Scalar> Arc<S> {
         arc_to_quadratic_beziers_with_t(self, &mut |curve, _| cb(curve));
     }
 
-    /// Approximate the arc with a sequence of quadratic Bézier curves.
+    /// Approximate the arc with a sequence of quadratic bézier curves.
     #[inline]
     pub fn for_each_quadratic_bezier_with_t<F>(&self, cb: &mut F)
     where
@@ -168,7 +168,7 @@ impl<S: Scalar> Arc<S> {
         arc_to_quadratic_beziers_with_t(self, cb);
     }
 
-    /// Approximate the arc with a sequence of cubic Bézier curves.
+    /// Approximate the arc with a sequence of cubic bézier curves.
     #[inline]
     pub fn for_each_cubic_bezier<F>(&self, cb: &mut F)
     where
@@ -525,7 +525,7 @@ impl<S: Scalar> SvgArc<S> {
             || self.from == self.to
     }
 
-    /// Approximates the arc with a sequence of quadratic Bézier segments.
+    /// Approximates the arc with a sequence of quadratic bézier segments.
     pub fn for_each_quadratic_bezier<F>(&self, cb: &mut F)
     where
         F: FnMut(&QuadraticBezierSegment<S>),
@@ -542,7 +542,7 @@ impl<S: Scalar> SvgArc<S> {
         Arc::from_svg_arc(self).for_each_quadratic_bezier(cb);
     }
 
-    /// Approximates the arc with a sequence of quadratic Bézier segments.
+    /// Approximates the arc with a sequence of quadratic bézier segments.
     pub fn for_each_quadratic_bezier_with_t<F>(&self, cb: &mut F)
     where
         F: FnMut(&QuadraticBezierSegment<S>, Range<S>),
@@ -562,7 +562,7 @@ impl<S: Scalar> SvgArc<S> {
         Arc::from_svg_arc(self).for_each_quadratic_bezier_with_t(cb);
     }
 
-    /// Approximates the arc with a sequence of cubic Bézier segments.
+    /// Approximates the arc with a sequence of cubic bézier segments.
     pub fn for_each_cubic_bezier<F>(&self, cb: &mut F)
     where
         F: FnMut(&CubicBezierSegment<S>),

--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -150,7 +150,7 @@ impl<S: Scalar> Arc<S> {
         }
     }
 
-    /// Approximate the arc with a sequence of quadratic bézier curves.
+    /// Approximate the arc with a sequence of quadratic Bézier curves.
     #[inline]
     pub fn for_each_quadratic_bezier<F>(&self, cb: &mut F)
     where
@@ -159,7 +159,7 @@ impl<S: Scalar> Arc<S> {
         arc_to_quadratic_beziers_with_t(self, &mut |curve, _| cb(curve));
     }
 
-    /// Approximate the arc with a sequence of quadratic bézier curves.
+    /// Approximate the arc with a sequence of quadratic Bézier curves.
     #[inline]
     pub fn for_each_quadratic_bezier_with_t<F>(&self, cb: &mut F)
     where
@@ -168,7 +168,7 @@ impl<S: Scalar> Arc<S> {
         arc_to_quadratic_beziers_with_t(self, cb);
     }
 
-    /// Approximate the arc with a sequence of cubic bézier curves.
+    /// Approximate the arc with a sequence of cubic Bézier curves.
     #[inline]
     pub fn for_each_cubic_bezier<F>(&self, cb: &mut F)
     where
@@ -525,7 +525,7 @@ impl<S: Scalar> SvgArc<S> {
             || self.from == self.to
     }
 
-    /// Approximates the arc with a sequence of quadratic bézier segments.
+    /// Approximates the arc with a sequence of quadratic Bézier segments.
     pub fn for_each_quadratic_bezier<F>(&self, cb: &mut F)
     where
         F: FnMut(&QuadraticBezierSegment<S>),
@@ -542,7 +542,7 @@ impl<S: Scalar> SvgArc<S> {
         Arc::from_svg_arc(self).for_each_quadratic_bezier(cb);
     }
 
-    /// Approximates the arc with a sequence of quadratic bézier segments.
+    /// Approximates the arc with a sequence of quadratic Bézier segments.
     pub fn for_each_quadratic_bezier_with_t<F>(&self, cb: &mut F)
     where
         F: FnMut(&QuadraticBezierSegment<S>, Range<S>),
@@ -562,7 +562,7 @@ impl<S: Scalar> SvgArc<S> {
         Arc::from_svg_arc(self).for_each_quadratic_bezier_with_t(cb);
     }
 
-    /// Approximates the arc with a sequence of cubic bézier segments.
+    /// Approximates the arc with a sequence of cubic Bézier segments.
     pub fn for_each_cubic_bezier<F>(&self, cb: &mut F)
     where
         F: FnMut(&CubicBezierSegment<S>),

--- a/crates/geom/src/cubic_bezier.rs
+++ b/crates/geom/src/cubic_bezier.rs
@@ -331,7 +331,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         }
     }
 
-    /// Approximate the curve with a single quadratic bézier segment.
+    /// Approximate the curve with a single quadratic Bézier segment.
     ///
     /// This is terrible as a general approximation but works if the cubic
     /// curve does not have inflection points and is "flat" enough. Typically
@@ -354,7 +354,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
             * ((self.to - self.ctrl2 * S::THREE) + (self.ctrl1 * S::THREE - self.from)).length()
     }
 
-    /// Returns true if the curve can be safely approximated with a single quadratic bézier
+    /// Returns true if the curve can be safely approximated with a single quadratic Bézier
     /// segment given the provided tolerance threshold.
     ///
     /// Equivalent to comparing `to_quadratic_error` with the tolerance threshold, avoiding
@@ -366,7 +366,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
             <= tolerance * tolerance
     }
 
-    /// Computes the number of quadratic bézier segments required to approximate this cubic curve
+    /// Computes the number of quadratic Bézier segments required to approximate this cubic curve
     /// given a tolerance threshold.
     ///
     /// Derived by Raph Levien from section 10.6 of Sedeberg's CAGD notes
@@ -500,7 +500,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         });
     }
 
-    /// Approximates the cubic bézier curve with sequence of quadratic ones,
+    /// Approximates the cubic Bézier curve with sequence of quadratic ones,
     /// invoking a callback at each step.
     pub fn for_each_quadratic_bezier<F>(&self, tolerance: S, cb: &mut F)
     where
@@ -509,7 +509,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         self.for_each_quadratic_bezier_with_t(tolerance, &mut |quad, _range| cb(quad));
     }
 
-    /// Approximates the cubic bézier curve with sequence of quadratic ones,
+    /// Approximates the cubic Bézier curve with sequence of quadratic ones,
     /// invoking a callback at each step.
     pub fn for_each_quadratic_bezier_with_t<F>(&self, tolerance: S, cb: &mut F)
     where
@@ -1007,7 +1007,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         result
     }
 
-    /// Computes the intersections (if any) between this segment a quadratic bézier segment.
+    /// Computes the intersections (if any) between this segment a quadratic Bézier segment.
     ///
     /// The result is provided in the form of the `t` parameters of each point along the curves. To
     /// get the intersection points, sample the curves at the corresponding values.
@@ -1023,7 +1023,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         self.cubic_intersections_t(&curve.to_cubic())
     }
 
-    /// Computes the intersection points (if any) between this segment and a quadratic bézier segment.
+    /// Computes the intersection points (if any) between this segment and a quadratic Bézier segment.
     pub fn quadratic_intersections(
         &self,
         curve: &QuadraticBezierSegment<S>,
@@ -1173,7 +1173,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         ((t3 + one_t3 - S::ONE) / (t3 + one_t3)).abs()
     }
 
-    // Returns a quadratic bézier curve built by dragging this curve's point at `t`
+    // Returns a quadratic Bézier curve built by dragging this curve's point at `t`
     // to a new position, without moving the endpoints.
     //
     // The relative effect on control points is chosen to give a similar "feel" to
@@ -1194,7 +1194,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         self.drag_with_weight(t, new_position, weight)
     }
 
-    // Returns a quadratic bézier curve built by dragging this curve's point at `t`
+    // Returns a quadratic Bézier curve built by dragging this curve's point at `t`
     // to a new position, without moving the endpoints.
     //
     // The provided weight specifies the relative effect on control points.

--- a/crates/geom/src/cubic_bezier.rs
+++ b/crates/geom/src/cubic_bezier.rs
@@ -1613,7 +1613,7 @@ fn fast_bounding_box_for_cubic_bezier_segment() {
 
     let actual_aabb = a.fast_bounding_box();
 
-    assert!(expected_aabb == actual_aabb)
+    assert_eq!(expected_aabb, actual_aabb)
 }
 
 #[test]
@@ -1653,7 +1653,7 @@ fn y_maximum_t_for_simple_cubic_segment() {
 
     let actual_y_maximum = a.y_maximum_t();
 
-    assert!(expected_y_maximum == actual_y_maximum)
+    assert_eq!(expected_y_maximum, actual_y_maximum)
 }
 
 #[test]
@@ -1669,7 +1669,7 @@ fn y_minimum_t_for_simple_cubic_segment() {
 
     let actual_y_minimum = a.y_minimum_t();
 
-    assert!(expected_y_minimum == actual_y_minimum)
+    assert_eq!(expected_y_minimum, actual_y_minimum)
 }
 
 #[test]
@@ -1718,7 +1718,7 @@ fn x_maximum_t_for_simple_cubic_segment() {
 
     let actual_x_maximum = a.x_maximum_t();
 
-    assert!(expected_x_maximum == actual_x_maximum)
+    assert_eq!(expected_x_maximum, actual_x_maximum)
 }
 
 #[test]
@@ -1734,7 +1734,7 @@ fn x_minimum_t_for_simple_cubic_segment() {
 
     let actual_x_minimum = a.x_minimum_t();
 
-    assert!(expected_x_minimum == actual_x_minimum)
+    assert_eq!(expected_x_minimum, actual_x_minimum)
 }
 
 #[test]
@@ -2036,7 +2036,7 @@ fn test_cubic_to_quadratics() {
     quadratic
         .to_cubic()
         .for_each_quadratic_bezier(0.0001, &mut |c| {
-            assert!(count == 0);
+            assert_eq!(count, 0);
             assert!(c.from.approx_eq(&quadratic.from));
             assert!(c.ctrl.approx_eq(&quadratic.ctrl));
             assert!(c.to.approx_eq(&quadratic.to));

--- a/crates/geom/src/cubic_bezier.rs
+++ b/crates/geom/src/cubic_bezier.rs
@@ -331,7 +331,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         }
     }
 
-    /// Approximate the curve with a single quadratic Bézier segment.
+    /// Approximate the curve with a single quadratic bézier segment.
     ///
     /// This is terrible as a general approximation but works if the cubic
     /// curve does not have inflection points and is "flat" enough. Typically
@@ -354,7 +354,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
             * ((self.to - self.ctrl2 * S::THREE) + (self.ctrl1 * S::THREE - self.from)).length()
     }
 
-    /// Returns true if the curve can be safely approximated with a single quadratic Bézier
+    /// Returns true if the curve can be safely approximated with a single quadratic bézier
     /// segment given the provided tolerance threshold.
     ///
     /// Equivalent to comparing `to_quadratic_error` with the tolerance threshold, avoiding
@@ -366,7 +366,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
             <= tolerance * tolerance
     }
 
-    /// Computes the number of quadratic Bézier segments required to approximate this cubic curve
+    /// Computes the number of quadratic bézier segments required to approximate this cubic curve
     /// given a tolerance threshold.
     ///
     /// Derived by Raph Levien from section 10.6 of Sedeberg's CAGD notes
@@ -500,7 +500,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         });
     }
 
-    /// Approximates the cubic Bézier curve with sequence of quadratic ones,
+    /// Approximates the cubic bézier curve with sequence of quadratic ones,
     /// invoking a callback at each step.
     pub fn for_each_quadratic_bezier<F>(&self, tolerance: S, cb: &mut F)
     where
@@ -509,7 +509,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         self.for_each_quadratic_bezier_with_t(tolerance, &mut |quad, _range| cb(quad));
     }
 
-    /// Approximates the cubic Bézier curve with sequence of quadratic ones,
+    /// Approximates the cubic bézier curve with sequence of quadratic ones,
     /// invoking a callback at each step.
     pub fn for_each_quadratic_bezier_with_t<F>(&self, tolerance: S, cb: &mut F)
     where
@@ -1007,7 +1007,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         result
     }
 
-    /// Computes the intersections (if any) between this segment a quadratic Bézier segment.
+    /// Computes the intersections (if any) between this segment a quadratic bézier segment.
     ///
     /// The result is provided in the form of the `t` parameters of each point along the curves. To
     /// get the intersection points, sample the curves at the corresponding values.
@@ -1023,7 +1023,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         self.cubic_intersections_t(&curve.to_cubic())
     }
 
-    /// Computes the intersection points (if any) between this segment and a quadratic Bézier segment.
+    /// Computes the intersection points (if any) between this segment and a quadratic bézier segment.
     pub fn quadratic_intersections(
         &self,
         curve: &QuadraticBezierSegment<S>,
@@ -1173,7 +1173,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         ((t3 + one_t3 - S::ONE) / (t3 + one_t3)).abs()
     }
 
-    // Returns a quadratic Bézier curve built by dragging this curve's point at `t`
+    // Returns a quadratic bézier curve built by dragging this curve's point at `t`
     // to a new position, without moving the endpoints.
     //
     // The relative effect on control points is chosen to give a similar "feel" to
@@ -1194,7 +1194,7 @@ impl<S: Scalar> CubicBezierSegment<S> {
         self.drag_with_weight(t, new_position, weight)
     }
 
-    // Returns a quadratic Bézier curve built by dragging this curve's point at `t`
+    // Returns a quadratic bézier curve built by dragging this curve's point at `t`
     // to a new position, without moving the endpoints.
     //
     // The provided weight specifies the relative effect on control points.

--- a/crates/geom/src/cubic_bezier_intersections.rs
+++ b/crates/geom/src/cubic_bezier_intersections.rs
@@ -775,7 +775,7 @@ fn do_test_once<S: Scalar>(
     curve2: &CubicBezierSegment<S>,
     intersection_count: i32,
 ) {
-    let intersections = cubic_bezier_intersections_t(&curve1, &curve2);
+    let intersections = cubic_bezier_intersections_t(curve1, curve2);
     for intersection in &intersections {
         let p1 = curve1.sample(intersection.0);
         let p2 = curve2.sample(intersection.1);

--- a/crates/geom/src/cubic_bezier_intersections.rs
+++ b/crates/geom/src/cubic_bezier_intersections.rs
@@ -1,6 +1,6 @@
 use crate::scalar::Scalar;
 use crate::CubicBezierSegment;
-///! Computes intersection parameters for two cubic bézier curves using bézier clipping, also known
+///! Computes intersection parameters for two cubic Bézier curves using Bézier clipping, also known
 ///! as fat line clipping.
 ///!
 ///! The implementation here was originally ported from that of paper.js:
@@ -13,7 +13,7 @@ use arrayvec::ArrayVec;
 use core::mem;
 use core::ops::Range;
 
-// Computes the intersections (if any) between two cubic bézier curves in the form of the `t`
+// Computes the intersections (if any) between two cubic Bézier curves in the form of the `t`
 // parameters of each intersection point along the curves.
 //
 // Returns endpoint intersections where an endpoint intersects the interior of the other curve,
@@ -250,12 +250,12 @@ fn line_line_intersections<S: Scalar>(
     result
 }
 
-// This function implements the main bézier clipping algorithm by recursively subdividing curve1 and
+// This function implements the main Bézier clipping algorithm by recursively subdividing curve1 and
 // curve2 in to smaller and smaller portions of the original curves with the property that one of
 // the curves intersects the fat line of the other curve at each stage.
 //
-// curve1 and curve2 at each stage are sub-bézier curves of the original curves; flip tells us
-// whether curve1 at a given stage is a subcurve of the original curve1 or the original curve2;
+// curve1 and curve2 at each stage are sub-Bézier curves of the original curves; flip tells us
+// whether curve1 at a given stage is a sub-curve of the original curve1 or the original curve2;
 // similarly for curve2.  domain1 and domain2 shrink (or stay the same) at each stage and describe
 // which subdomain of an original curve the current curve1 and curve2 correspond to. (The domains of
 // curve1 and curve2 are 0..1 at every stage.)

--- a/crates/geom/src/cubic_bezier_intersections.rs
+++ b/crates/geom/src/cubic_bezier_intersections.rs
@@ -1,11 +1,11 @@
 use crate::scalar::Scalar;
 use crate::CubicBezierSegment;
-///! Computes intersection parameters for two cubic Bézier curves using Bézier clipping, also known
+///! Computes intersection parameters for two cubic bézier curves using bézier clipping, also known
 ///! as fat line clipping.
 ///!
 ///! The implementation here was originally ported from that of paper.js:
 ///! https://github.com/paperjs/paper.js/blob/0deddebb2c83ea2a0c848f7c8ba5e22fa7562a4e/src/path/Curve.js#L2008
-///! See "Bézier Clipping method" in
+///! See "bézier Clipping method" in
 ///! https://scholarsarchive.byu.edu/facpub/1/
 ///! for motivation and details of how the process works.
 use crate::{point, Box2D, Point};
@@ -13,7 +13,7 @@ use arrayvec::ArrayVec;
 use core::mem;
 use core::ops::Range;
 
-// Computes the intersections (if any) between two cubic Bézier curves in the form of the `t`
+// Computes the intersections (if any) between two cubic bézier curves in the form of the `t`
 // parameters of each intersection point along the curves.
 //
 // Returns endpoint intersections where an endpoint intersects the interior of the other curve,
@@ -250,11 +250,11 @@ fn line_line_intersections<S: Scalar>(
     result
 }
 
-// This function implements the main Bézier clipping algorithm by recursively subdividing curve1 and
+// This function implements the main bézier clipping algorithm by recursively subdividing curve1 and
 // curve2 in to smaller and smaller portions of the original curves with the property that one of
 // the curves intersects the fat line of the other curve at each stage.
 //
-// curve1 and curve2 at each stage are sub-Bézier curves of the original curves; flip tells us
+// curve1 and curve2 at each stage are sub-bézier curves of the original curves; flip tells us
 // whether curve1 at a given stage is a sub-curve of the original curve1 or the original curve2;
 // similarly for curve2.  domain1 and domain2 shrink (or stay the same) at each stage and describe
 // which subdomain of an original curve the current curve1 and curve2 correspond to. (The domains of

--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -174,8 +174,8 @@ mod scalar {
         const NINE: Self = 9.0;
         const TEN: Self = 10.0;
 
-        const MIN: Self = core::f32::MIN;
-        const MAX: Self = core::f32::MAX;
+        const MIN: Self = f32::MIN;
+        const MAX: Self = f32::MAX;
 
         const EPSILON: Self = 1e-4;
 
@@ -218,8 +218,8 @@ mod scalar {
         const NINE: Self = 9.0;
         const TEN: Self = 10.0;
 
-        const MIN: Self = core::f64::MIN;
-        const MAX: Self = core::f64::MAX;
+        const MIN: Self = f64::MIN;
+        const MAX: Self = f64::MAX;
 
         const EPSILON: Self = 1e-8;
 

--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -15,7 +15,7 @@
 //! This crate implements some of the maths to work with:
 //!
 //! - lines and line segments,
-//! - quadratic and cubic bézier curves,
+//! - quadratic and cubic Bézier curves,
 //! - elliptic arcs,
 //! - triangles.
 //!

--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc(html_logo_url = "https://nical.github.io/lyon-doc/lyon-logo.svg")]
 #![deny(bare_trait_objects)]
 #![deny(unconditional_recursion)]
-#![allow(clippy::many_single_char_names)]
+#![allow(clippy::excessive_precision)]
 #![allow(clippy::let_and_return)]
+#![allow(clippy::many_single_char_names)]
 #![no_std]
 
 //! Simple 2D geometric primitives on top of euclid.

--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -15,7 +15,7 @@
 //! This crate implements some of the maths to work with:
 //!
 //! - lines and line segments,
-//! - quadratic and cubic Bézier curves,
+//! - quadratic and cubic bézier curves,
 //! - elliptic arcs,
 //! - triangles.
 //!

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -185,7 +185,7 @@ impl<S: Scalar> LineSegment<S> {
         self.to = self.from + v * (new_length / old_length);
     }
 
-    /// Computes thid mid-point of this segment.
+    /// Computes third mid-point of this segment.
     pub fn mid_point(&mut self) -> Point<S> {
         (self.from + self.to.to_vector()) / S::TWO
     }
@@ -851,7 +851,7 @@ fn intersection_touching() {
 #[test]
 fn intersection_overlap() {
     // It's hard to define the intersection points of two segments that overlap,
-    // (would be a region rather than a point) and more importanly, in practice
+    // (would be a region rather than a point) and more importantly, in practice
     // the algorithms in lyon don't need to consider this special case as an intersection,
     // so we choose to treat overlapping segments as not intersecting.
 

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -776,7 +776,7 @@ impl<S: Scalar> LineEquation<S> {
 
 #[cfg(test)]
 fn fuzzy_eq_f32(a: f32, b: f32, epsilon: f32) -> bool {
-    return f32::abs(a - b) <= epsilon;
+    f32::abs(a - b) <= epsilon
 }
 
 #[cfg(test)]

--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -1101,7 +1101,7 @@ fn bounding_box_for_monotonic_quadratic_bezier_segment() {
 
     let actual_aabb = a.bounding_box();
 
-    assert!(expected_aabb == actual_aabb)
+    assert_eq!(expected_aabb, actual_aabb)
 }
 
 #[test]
@@ -1119,7 +1119,7 @@ fn fast_bounding_box_for_quadratic_bezier_segment() {
 
     let actual_aabb = a.fast_bounding_box();
 
-    assert!(expected_aabb == actual_aabb)
+    assert_eq!(expected_aabb, actual_aabb)
 }
 
 #[test]
@@ -1137,7 +1137,7 @@ fn minimum_bounding_box_for_quadratic_bezier_segment() {
 
     let actual_aabb = a.bounding_box();
 
-    assert!(expected_aabb == actual_aabb)
+    assert_eq!(expected_aabb, actual_aabb)
 }
 
 #[test]
@@ -1152,7 +1152,7 @@ fn y_maximum_t_for_simple_segment() {
 
     let actual_y_maximum = a.y_maximum_t();
 
-    assert!(expected_y_maximum == actual_y_maximum)
+    assert_eq!(expected_y_maximum, actual_y_maximum)
 }
 
 #[test]
@@ -1166,7 +1166,7 @@ fn local_y_extremum_for_simple_segment() {
     let expected_y_inflection = 0.5;
 
     match a.local_y_extremum_t() {
-        Some(actual_y_inflection) => assert!(expected_y_inflection == actual_y_inflection),
+        Some(actual_y_inflection) => assert_eq!(expected_y_inflection, actual_y_inflection),
         None => panic!(),
     }
 }
@@ -1183,7 +1183,7 @@ fn y_minimum_t_for_simple_segment() {
 
     let actual_y_minimum = a.y_minimum_t();
 
-    assert!(expected_y_minimum == actual_y_minimum)
+    assert_eq!(expected_y_minimum, actual_y_minimum)
 }
 
 #[test]
@@ -1198,7 +1198,7 @@ fn x_maximum_t_for_simple_segment() {
 
     let actual_x_maximum = a.x_maximum_t();
 
-    assert!(expected_x_maximum == actual_x_maximum)
+    assert_eq!(expected_x_maximum, actual_x_maximum)
 }
 
 #[test]
@@ -1212,7 +1212,7 @@ fn local_x_extremum_for_simple_segment() {
     let expected_x_inflection = 0.5;
 
     match a.local_x_extremum_t() {
-        Some(actual_x_inflection) => assert!(expected_x_inflection == actual_x_inflection),
+        Some(actual_x_inflection) => assert_eq!(expected_x_inflection, actual_x_inflection),
         None => panic!(),
     }
 }
@@ -1229,7 +1229,7 @@ fn x_minimum_t_for_simple_segment() {
 
     let actual_x_minimum = a.x_minimum_t();
 
-    assert!(expected_x_minimum == actual_x_minimum)
+    assert_eq!(expected_x_minimum, actual_x_minimum)
 }
 
 #[test]

--- a/crates/geom/src/segment.rs
+++ b/crates/geom/src/segment.rs
@@ -65,6 +65,7 @@ pub trait Segment: Copy + Sized {
     /// its approximation.
     ///
     /// The parameter `t` at the final segment is guaranteed to be equal to `1.0`.
+    #[allow(clippy::type_complexity)] // <<< FIXME
     fn for_each_flattened_with_t(
         &self,
         tolerance: Self::Scalar,

--- a/crates/geom/src/segment.rs
+++ b/crates/geom/src/segment.rs
@@ -65,7 +65,7 @@ pub trait Segment: Copy + Sized {
     /// its approximation.
     ///
     /// The parameter `t` at the final segment is guaranteed to be equal to `1.0`.
-    #[allow(clippy::type_complexity)] // <<< FIXME
+    #[allow(clippy::type_complexity)]
     fn for_each_flattened_with_t(
         &self,
         tolerance: Self::Scalar,

--- a/crates/geom/src/triangle.rs
+++ b/crates/geom/src/triangle.rs
@@ -190,9 +190,9 @@ fn test_segments() {
         c: point(5.0, 6.0),
     };
 
-    assert!(t.ab() == t.ba().flip());
-    assert!(t.ac() == t.ca().flip());
-    assert!(t.bc() == t.cb().flip());
+    assert_eq!(t.ab(), t.ba().flip());
+    assert_eq!(t.ac(), t.ca().flip());
+    assert_eq!(t.bc(), t.cb().flip());
 }
 
 #[test]

--- a/crates/geom/src/utils.rs
+++ b/crates/geom/src/utils.rs
@@ -21,7 +21,7 @@ pub fn normalized_tangent<S: Scalar>(v: Vector<S>) -> Vector<S> {
     tangent(v).normalize()
 }
 
-/// Angle between vectors v1 and v2 (oriented clockwise assyming y points downwards).
+/// Angle between vectors v1 and v2 (oriented clockwise assuming y points downwards).
 /// The result is a number between `0` and `2 * PI`.
 ///
 /// ex: `directed_angle([0,1], [1,0]) = 3/2 Pi rad`

--- a/crates/lyon/src/lib.rs
+++ b/crates/lyon/src/lib.rs
@@ -23,7 +23,7 @@
 //!   **lyon_algorithms** - Various 2d path related algorithms.
 //! * [![crate](https://img.shields.io/crates/v/lyon_geom.svg)](https://crates.io/crates/lyon_geom)
 //!   [![doc](https://docs.rs/lyon_geom/badge.svg)](https://docs.rs/lyon_geom) -
-//!   **lyon_geom** - 2d utilities for cubic and quadratic bézier curves, arcs and more.
+//!   **lyon_geom** - 2d utilities for cubic and quadratic Bézier curves, arcs and more.
 //! * [![crate](https://img.shields.io/crates/v/lyon_extra.svg)](https://crates.io/crates/lyon_extra)
 //!   [![doc](https://docs.rs/lyon_extra/badge.svg)](https://docs.rs/lyon_extra) -
 //!   **lyon_extra** - Additional testing and debugging tools.

--- a/crates/lyon/src/lib.rs
+++ b/crates/lyon/src/lib.rs
@@ -23,7 +23,7 @@
 //!   **lyon_algorithms** - Various 2d path related algorithms.
 //! * [![crate](https://img.shields.io/crates/v/lyon_geom.svg)](https://crates.io/crates/lyon_geom)
 //!   [![doc](https://docs.rs/lyon_geom/badge.svg)](https://docs.rs/lyon_geom) -
-//!   **lyon_geom** - 2d utilities for cubic and quadratic Bézier curves, arcs and more.
+//!   **lyon_geom** - 2d utilities for cubic and quadratic bézier curves, arcs and more.
 //! * [![crate](https://img.shields.io/crates/v/lyon_extra.svg)](https://crates.io/crates/lyon_extra)
 //!   [![doc](https://docs.rs/lyon_extra/badge.svg)](https://docs.rs/lyon_extra) -
 //!   **lyon_extra** - Additional testing and debugging tools.

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -86,6 +86,7 @@ use crate::path::Verb;
 use crate::polygon::Polygon;
 use crate::{Attributes, EndpointId, Winding, NO_ATTRIBUTES};
 
+use core::f32::consts::PI;
 use core::marker::Sized;
 
 use alloc::vec;
@@ -141,7 +142,7 @@ pub struct NoAttributes<B: PathBuilder> {
 impl<B: PathBuilder> NoAttributes<B> {
     #[inline]
     pub fn wrap(inner: B) -> Self {
-        assert!(inner.num_attributes() == 0);
+        assert_eq!(inner.num_attributes(), 0);
         NoAttributes { inner }
     }
 
@@ -615,7 +616,6 @@ pub trait PathBuilder {
             Winding::Negative => -1.0,
         };
 
-        use core::f32::consts::PI;
         let arc = Arc {
             center,
             radii,
@@ -1776,7 +1776,6 @@ fn svg_builder_arc_to_update_position() {
 
 #[test]
 fn issue_650() {
-    use core::f32::consts::PI;
     let mut builder = crate::path::Path::builder().with_svg();
     builder.arc(
         point(0.0, 0.0),

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -197,7 +197,7 @@ impl<B: PathBuilder> NoAttributes<B> {
         self.inner.line_to(to, NO_ATTRIBUTES)
     }
 
-    /// Adds a quadratic Bézier curve to the current sub-path.
+    /// Adds a quadratic bézier curve to the current sub-path.
     ///
     /// A sub-path must be in progress when this method is called.
     #[inline]
@@ -205,7 +205,7 @@ impl<B: PathBuilder> NoAttributes<B> {
         self.inner.quadratic_bezier_to(ctrl, to, NO_ATTRIBUTES)
     }
 
-    /// Adds a cubic Bézier curve to the current sub-path.
+    /// Adds a cubic bézier curve to the current sub-path.
     ///
     /// A sub-path must be in progress when this method is called.
     #[inline]
@@ -475,7 +475,7 @@ pub trait PathBuilder {
     /// A sub-path must be in progress when this method is called.
     fn line_to(&mut self, to: Point, custom_attributes: Attributes) -> EndpointId;
 
-    /// Adds a quadratic Bézier curve to the current sub-path.
+    /// Adds a quadratic bézier curve to the current sub-path.
     ///
     /// A sub-path must be in progress when this method is called.
     fn quadratic_bezier_to(
@@ -485,7 +485,7 @@ pub trait PathBuilder {
         custom_attributes: Attributes,
     ) -> EndpointId;
 
-    /// Adds a cubic Bézier curve to the current sub-path.
+    /// Adds a cubic bézier curve to the current sub-path.
     ///
     /// A sub-path must be in progress when this method is called.
     fn cubic_bezier_to(
@@ -756,7 +756,7 @@ pub trait SvgPathBuilder {
     /// have a current position), the `line_to` command is replaced with a `move_to(to)`.
     fn line_to(&mut self, to: Point);
 
-    /// Adds a quadratic Bézier segment to the current sub-path.
+    /// Adds a quadratic bézier segment to the current sub-path.
     ///
     /// Corresponding SVG command: `Q`.
     ///
@@ -766,7 +766,7 @@ pub trait SvgPathBuilder {
     /// a `move_to(to)`.
     fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point);
 
-    /// Adds a cubic Bézier segment to the current sub-path.
+    /// Adds a cubic bézier segment to the current sub-path.
     ///
     /// Corresponding SVG command: `C`.
     ///
@@ -813,7 +813,7 @@ pub trait SvgPathBuilder {
     /// The first control point is assumed to be the reflection of the second
     /// control point on the previous command relative to the current point.
     /// If there is no previous command or if the previous command was not a
-    /// cubic Bézier segment, the first control point is coincident with
+    /// cubic bézier segment, the first control point is coincident with
     /// the current position.
     fn smooth_cubic_bezier_to(&mut self, ctrl2: Point, to: Point);
 
@@ -832,7 +832,7 @@ pub trait SvgPathBuilder {
     /// The control point is assumed to be the reflection of the control
     /// point on the previous command relative to the current point.
     /// If there is no previous command or if the previous command was not a
-    /// quadratic Bézier segment, a line segment is added instead.
+    /// quadratic bézier segment, a line segment is added instead.
     fn smooth_quadratic_bezier_to(&mut self, to: Point);
 
     /// Equivalent to `smooth_quadratic_bezier_to` in relative coordinates.
@@ -1217,7 +1217,7 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
             return;
         }
 
-        // Relative path ops tend to accumulate small floating point impressions
+        // Relative path ops tend to accumulate small floating point error,
         // which results in the last segment ending almost but not quite at the
         // start of the sub-path, causing a new edge to be inserted which often
         // intersects with the first or last edge. This can affect algorithms that

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -88,8 +88,8 @@ use crate::{Attributes, EndpointId, Winding, NO_ATTRIBUTES};
 
 use core::marker::Sized;
 
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
 use num_traits::Float;

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -197,7 +197,7 @@ impl<B: PathBuilder> NoAttributes<B> {
         self.inner.line_to(to, NO_ATTRIBUTES)
     }
 
-    /// Adds a quadratic bézier curve to the current sub-path.
+    /// Adds a quadratic Bézier curve to the current sub-path.
     ///
     /// A sub-path must be in progress when this method is called.
     #[inline]
@@ -205,7 +205,7 @@ impl<B: PathBuilder> NoAttributes<B> {
         self.inner.quadratic_bezier_to(ctrl, to, NO_ATTRIBUTES)
     }
 
-    /// Adds a cubic bézier curve to the current sub-path.
+    /// Adds a cubic Bézier curve to the current sub-path.
     ///
     /// A sub-path must be in progress when this method is called.
     #[inline]
@@ -475,7 +475,7 @@ pub trait PathBuilder {
     /// A sub-path must be in progress when this method is called.
     fn line_to(&mut self, to: Point, custom_attributes: Attributes) -> EndpointId;
 
-    /// Adds a quadratic bézier curve to the current sub-path.
+    /// Adds a quadratic Bézier curve to the current sub-path.
     ///
     /// A sub-path must be in progress when this method is called.
     fn quadratic_bezier_to(
@@ -485,7 +485,7 @@ pub trait PathBuilder {
         custom_attributes: Attributes,
     ) -> EndpointId;
 
-    /// Adds a cubic bézier curve to the current sub-path.
+    /// Adds a cubic Bézier curve to the current sub-path.
     ///
     /// A sub-path must be in progress when this method is called.
     fn cubic_bezier_to(
@@ -756,7 +756,7 @@ pub trait SvgPathBuilder {
     /// have a current position), the `line_to` command is replaced with a `move_to(to)`.
     fn line_to(&mut self, to: Point);
 
-    /// Adds a quadratic bézier segment to the current sub-path.
+    /// Adds a quadratic Bézier segment to the current sub-path.
     ///
     /// Corresponding SVG command: `Q`.
     ///
@@ -766,7 +766,7 @@ pub trait SvgPathBuilder {
     /// a `move_to(to)`.
     fn quadratic_bezier_to(&mut self, ctrl: Point, to: Point);
 
-    /// Adds a cubic bézier segment to the current sub-path.
+    /// Adds a cubic Bézier segment to the current sub-path.
     ///
     /// Corresponding SVG command: `C`.
     ///
@@ -813,7 +813,7 @@ pub trait SvgPathBuilder {
     /// The first control point is assumed to be the reflection of the second
     /// control point on the previous command relative to the current point.
     /// If there is no previous command or if the previous command was not a
-    /// cubic bézier segment, the first control point is coincident with
+    /// cubic Bézier segment, the first control point is coincident with
     /// the current position.
     fn smooth_cubic_bezier_to(&mut self, ctrl2: Point, to: Point);
 
@@ -832,7 +832,7 @@ pub trait SvgPathBuilder {
     /// The control point is assumed to be the reflection of the control
     /// point on the previous command relative to the current point.
     /// If there is no previous command or if the previous command was not a
-    /// quadratic bézier segment, a line segment is added instead.
+    /// quadratic Bézier segment, a line segment is added instead.
     fn smooth_quadratic_bezier_to(&mut self, to: Point);
 
     /// Equivalent to `smooth_quadratic_bezier_to` in relative coordinates.
@@ -1217,7 +1217,7 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
             return;
         }
 
-        // Relative path ops tend to accumulate small floating point imprecisions
+        // Relative path ops tend to accumulate small floating point impressions
         // which results in the last segment ending almost but not quite at the
         // start of the sub-path, causing a new edge to be inserted which often
         // intersects with the first or last edge. This can affect algorithms that

--- a/crates/path/src/iterator.rs
+++ b/crates/path/src/iterator.rs
@@ -83,7 +83,7 @@ use crate::geom::{cubic_bezier, quadratic_bezier, CubicBezierSegment, QuadraticB
 use crate::math::*;
 use crate::{Attributes, Event, PathEvent};
 
-// TODO: It would be great to add support for attributes in PathItertor.
+// TODO: It would be great to add support for attributes in PathIterator.
 
 /// An extension trait for `PathEvent` iterators.
 pub trait PathIterator: Iterator<Item = PathEvent> + Sized {
@@ -121,7 +121,7 @@ where
     }
 }
 
-/// An iterator that consumes `Event` iterator and yields flattend path events (with no curves).
+/// An iterator that consumes `Event` iterator and yields flattened path events (with no curves).
 pub struct Flattened<Iter> {
     it: Iter,
     current_position: Point,
@@ -207,7 +207,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        // At minimum, the inner iterator's size hint plus the flattening iterator's size hint can form the lower
+        // At minimum, the inner iterator size hint plus the flattening iterator size hint can form the lower
         // bracket.
         // We can't determine a maximum limit.
         let mut lo = self.it.size_hint().0;

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -74,9 +74,9 @@ pub use crate::path_buffer::{PathBuffer, PathBufferSlice};
 #[doc(inline)]
 pub use crate::polygon::{IdPolygon, Polygon};
 
-use math::Point;
 use core::fmt;
 use core::u32;
+use math::Point;
 
 pub mod traits {
     //! `lyon_path` traits reexported here for convenience.
@@ -375,7 +375,7 @@ impl Position for [f32; 2] {
     }
 }
 
-impl<'l, T> Position for (Point, T) {
+impl<T> Position for (Point, T) {
     fn position(&self) -> Point {
         self.0
     }

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -75,7 +75,6 @@ pub use crate::path_buffer::{PathBuffer, PathBufferSlice};
 pub use crate::polygon::{IdPolygon, Polygon};
 
 use core::fmt;
-use core::u32;
 use math::Point;
 
 pub mod traits {
@@ -339,7 +338,7 @@ impl fmt::Debug for EndpointId {
 pub struct EventId(#[doc(hidden)] pub u32);
 
 impl EventId {
-    pub const INVALID: Self = EventId(core::u32::MAX);
+    pub const INVALID: Self = EventId(u32::MAX);
     pub fn to_usize(self) -> usize {
         self.0 as usize
     }

--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -943,7 +943,7 @@ impl<'l> PointIter<'l> {
         // are always followed by advance_n which will
         // catch the issue and panic.
         if self.ptr >= self.end {
-            return point(core::f32::NAN, core::f32::NAN);
+            return point(f32::NAN, f32::NAN);
         }
 
         unsafe {

--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -17,8 +17,8 @@ use core::iter::{FromIterator, IntoIterator};
 use core::u32;
 
 use alloc::boxed::Box;
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
 
 /// Enumeration corresponding to the [Event](https://docs.rs/lyon_core/*/lyon_core/events/enum.Event.html) enum
 /// without the parameters.
@@ -1345,7 +1345,7 @@ impl<'l> Reversed<'l> {
 
 impl<'l> Iterator for Reversed<'l> {
     type Item = Event<(Point, Attributes<'l>), Point>;
-    fn next<'a>(&'a mut self) -> Option<Self::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         let endpoint_stride = self.attrib_stride + 1;
         let v = self.verbs.next()?;
         let event = match v {
@@ -1437,7 +1437,7 @@ impl<'l> Iterator for Reversed<'l> {
 
         self.p -= n_stored_points(*v, self.attrib_stride);
 
-        return Some(event);
+        Some(event)
     }
 }
 

--- a/crates/path/src/polygon.rs
+++ b/crates/path/src/polygon.rs
@@ -68,7 +68,7 @@ impl<'l, T> Polygon<'l, T> {
             Event::Begin {
                 at: &self.points[0],
             }
-        } else if idx as usize == self.points.len() - 1 {
+        } else if idx == self.points.len() - 1 {
             Event::End {
                 last: &self.points[self.points.len() - 1],
                 first: &self.points[0],
@@ -114,7 +114,7 @@ impl<'l> IdPolygon<'l> {
         let idx = id.0 as usize;
         if idx == 0 {
             IdEvent::Begin { at: self.points[0] }
-        } else if idx as usize == self.points.len() {
+        } else if idx == self.points.len() {
             IdEvent::End {
                 last: self.points[self.points.len() - 1],
                 first: self.points[0],

--- a/crates/path/src/private.rs
+++ b/crates/path/src/private.rs
@@ -56,6 +56,8 @@ impl DebugValidator {
         }
     }
 
+    /// TODO: this should use `self` to ensure it is dropped after this call
+    /// TODO: also, DebugValidator probably should not be exposed in the public API.
     #[inline(always)]
     pub fn build(&self) {
         #[cfg(debug_assertions)]

--- a/crates/path/src/private.rs
+++ b/crates/path/src/private.rs
@@ -9,32 +9,23 @@ pub use crate::math::Point;
 pub use crate::traits::PathBuilder;
 pub use crate::{Attributes, EndpointId};
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Default, Copy, Clone, Debug, PartialEq)]
 pub struct DebugValidator {
     #[cfg(debug_assertions)]
     in_subpath: bool,
 }
 
-impl Default for DebugValidator {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl DebugValidator {
     #[inline(always)]
     pub fn new() -> Self {
-        DebugValidator {
-            #[cfg(debug_assertions)]
-            in_subpath: false,
-        }
+        Self::default()
     }
 
     #[inline(always)]
     pub fn begin(&mut self) {
         #[cfg(debug_assertions)]
         {
-            assert!(!self.in_subpath);
+            assert!(!self.in_subpath, "multiple begin() calls without end()");
             self.in_subpath = true;
         }
     }
@@ -43,7 +34,7 @@ impl DebugValidator {
     pub fn end(&mut self) {
         #[cfg(debug_assertions)]
         {
-            assert!(self.in_subpath);
+            assert!(self.in_subpath, "end() called without begin()");
             self.in_subpath = false;
         }
     }
@@ -51,19 +42,15 @@ impl DebugValidator {
     #[inline(always)]
     pub fn edge(&self) {
         #[cfg(debug_assertions)]
-        {
-            assert!(self.in_subpath);
-        }
+        assert!(self.in_subpath, "edge operation is made before begin()");
     }
 
-    /// TODO: this should use `self` to ensure it is dropped after this call
+    /// TODO: this should consume `self` to ensure it is dropped after this call
     /// TODO: also, DebugValidator probably should not be exposed in the public API.
     #[inline(always)]
     pub fn build(&self) {
         #[cfg(debug_assertions)]
-        {
-            assert!(!self.in_subpath);
-        }
+        assert!(!self.in_subpath, "build() called before end()");
     }
 }
 

--- a/crates/path/src/private.rs
+++ b/crates/path/src/private.rs
@@ -85,6 +85,8 @@ pub fn flatten_quadratic_bezier(
             for i in 0..n {
                 buffer[i] = prev_attributes[i] * (1.0 - t.end) + attributes[i] * t.end;
             }
+            // BUG: https://github.com/rust-lang/rust-clippy/issues/10608
+            #[allow(clippy::redundant_slicing)]
             &buffer[..]
         };
         id = builder.line_to(line.to, attr);
@@ -119,6 +121,8 @@ pub fn flatten_cubic_bezier(
             for i in 0..n {
                 buffer[i] = prev_attributes[i] * (1.0 - t.end) + attributes[i] * t.end;
             }
+            // BUG: https://github.com/rust-lang/rust-clippy/issues/10608
+            #[allow(clippy::redundant_slicing)]
             &buffer[..]
         };
         id = builder.line_to(line.to, attr);

--- a/crates/tessellation/src/basic_shapes.rs
+++ b/crates/tessellation/src/basic_shapes.rs
@@ -135,7 +135,7 @@ fn bottom_right(rect: &Box2D) -> Point {
 // Returns the maximum length of individual line segments when approximating a
 // circle.
 //
-// From pythagora's theorem:
+// From Pythagorean theorem:
 // r² = (d/2)² + (r - t)²
 // r² = d²/4 + r² + t² - 2 * e * r
 // d² = 4 * (2 * t * r - t²)

--- a/crates/tessellation/src/earcut_tests.rs
+++ b/crates/tessellation/src/earcut_tests.rs
@@ -20184,7 +20184,7 @@ fn water_4() {
 fn earcut_test(path: &[&[[i32; 2]]]) {
     let mut builder = Path::builder();
     for &sub_path in path {
-        if sub_path.len() == 0 {
+        if sub_path.is_empty() {
             continue;
         }
         let start = sub_path[0];
@@ -20202,7 +20202,7 @@ fn earcut_test(path: &[&[[i32; 2]]]) {
 fn earcut_test_f32(path: &[&[[f32; 2]]]) {
     let mut builder = Path::builder();
     for &sub_path in path {
-        if sub_path.len() == 0 {
+        if sub_path.is_empty() {
             continue;
         }
         let start = sub_path[0];
@@ -20236,7 +20236,7 @@ fn tessellate(path: PathSlice, fill_rule: FillRule, log: bool) -> Result<usize, 
         tess.tessellate(&builder.build(), &options, &mut vertex_builder)
             .unwrap();
     }
-    return Ok(buffers.indices.len() / 3);
+    Ok(buffers.indices.len() / 3)
 }
 
 #[cfg(test)]

--- a/crates/tessellation/src/earcut_tests.rs
+++ b/crates/tessellation/src/earcut_tests.rs
@@ -1,6 +1,6 @@
 // This file contains tests that have been imported from Mapbox's Earcut tessellator
 // test suite available at: https://github.com/mapbox/earcut/tree/master/test/fixtures
-// Countrary to the rest of the code in the lyon repository, this file is placed under
+// Contrary to the rest of the code in the lyon repository, this file is placed under
 // the ISC license to match the original Mapbox code.
 //
 // -------------
@@ -19,10 +19,10 @@
 // THIS SOFTWARE.
 // -------------
 
-use crate::math::*;
 use crate::geometry_builder::{simple_builder, VertexBuffers};
+use crate::math::*;
 use crate::path::{Path, PathSlice};
-use crate::{FillTessellator, FillOptions, FillRule, TessellationError};
+use crate::{FillOptions, FillRule, FillTessellator, TessellationError};
 
 #[test]
 fn bad_diagonal() {
@@ -20221,8 +20221,7 @@ fn earcut_test_f32(path: &[&[[f32; 2]]]) {
 fn tessellate(path: PathSlice, fill_rule: FillRule, log: bool) -> Result<usize, TessellationError> {
     let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
     {
-        let options = FillOptions::tolerance(0.05)
-            .with_fill_rule(fill_rule);
+        let options = FillOptions::tolerance(0.05).with_fill_rule(fill_rule);
 
         use crate::path::iterator::*;
         let mut builder = Path::builder();

--- a/crates/tessellation/src/event_queue.rs
+++ b/crates/tessellation/src/event_queue.rs
@@ -793,7 +793,7 @@ impl EventQueueBuilder {
                 return;
             }
 
-            if first == None {
+            if first.is_none() {
                 first = Some(line.to)
             // We can't call vertex(prev, from, to) in the first iteration
             // because if we flipped the curve, we don't have a proper value for
@@ -803,7 +803,7 @@ impl EventQueueBuilder {
                 self.vertex_event_on_curve(line.from, t.start, self.prev_endpoint_id, to_id);
             }
 
-            self.add_edge(&line, winding, self.prev_endpoint_id, to_id, t.start, t.end);
+            self.add_edge(line, winding, self.prev_endpoint_id, to_id, t.start, t.end);
 
             prev = line.from;
         });
@@ -869,7 +869,7 @@ impl EventQueueBuilder {
                 return;
             }
 
-            if first == None {
+            if first.is_none() {
                 first = Some(line.to)
             // We can't call vertex(prev, from, to) in the first iteration
             // because if we flipped the curve, we don't have a proper value for
@@ -879,7 +879,7 @@ impl EventQueueBuilder {
                 self.vertex_event_on_curve(line.from, t.start, self.prev_endpoint_id, to_id);
             }
 
-            self.add_edge(&line, winding, self.prev_endpoint_id, to_id, t.start, t.end);
+            self.add_edge(line, winding, self.prev_endpoint_id, to_id, t.start, t.end);
 
             prev = line.from;
         });

--- a/crates/tessellation/src/event_queue.rs
+++ b/crates/tessellation/src/event_queue.rs
@@ -8,7 +8,6 @@ use crate::Orientation;
 use std::cmp::Ordering;
 use std::mem::swap;
 use std::ops::Range;
-use std::{f32, u32, usize};
 
 #[inline]
 fn reorient(p: Point) -> Point {
@@ -122,7 +121,7 @@ impl EventQueue {
             second: point(f32::NAN, f32::NAN),
             nth: 0,
             tolerance,
-            prev_endpoint_id: EndpointId(std::u32::MAX),
+            prev_endpoint_id: EndpointId(u32::MAX),
             validator: DebugValidator::new(),
         }
     }
@@ -495,7 +494,7 @@ impl EventQueueBuilder {
         self.reset();
 
         self.tolerance = tolerance;
-        let endpoint_id = EndpointId(std::u32::MAX);
+        let endpoint_id = EndpointId(u32::MAX);
         match sweep_orientation {
             Orientation::Vertical => {
                 for evt in path {

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -364,7 +364,7 @@ struct PendingEdge {
 ///   from the point of view of the tessellator.
 /// - The tessellator does not handle curves, and uses an approximation that introduces a
 ///   number of line segments and therefore endpoints between the original endpoints of any
-///   quadratic or cubic Bézier curve.
+///   quadratic or cubic bézier curve.
 ///
 /// This complicates the task of adding extra data to vertices without loosing the association
 /// during tessellation.

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use float_next_after::NextAfter;
 use std::cmp::Ordering;
-use std::f32;
+use std::f32::consts::FRAC_1_SQRT_2;
 use std::mem;
 use std::ops::Range;
 
@@ -60,7 +60,7 @@ fn fmax(a: f32, b: f32) -> f32 {
 }
 
 fn slope(v: Vector) -> f32 {
-    v.x / (v.y.max(std::f32::MIN))
+    v.x / (v.y.max(f32::MIN))
 }
 
 #[cfg(debug_assertions)]
@@ -826,7 +826,7 @@ impl FillTessellator {
     ) -> Result<(), TessellationError> {
         log_svg_preamble(self);
 
-        let mut _prev_position = point(std::f32::MIN, std::f32::MIN);
+        let mut _prev_position = point(f32::MIN, f32::MIN);
         self.current_event_id = self.events.first_id();
         while self.events.valid_id(self.current_event_id) {
             self.initialize_events(attrib_store, output)?;
@@ -1702,7 +1702,7 @@ impl FillTessellator {
 
         if !is_after(intersection_position, self.current_position) {
             tess_log!(self, "fixup the intersection");
-            intersection_position.y = self.current_position.y.next_after(std::f32::INFINITY);
+            intersection_position.y = self.current_position.y.next_after(f32::INFINITY);
         }
 
         assert!(
@@ -2211,16 +2211,16 @@ impl<'l> FillVertex<'l> {
         match first {
             VertexSource::Endpoint { id } => {
                 let a = store.get(id);
-                assert!(a.len() == num_attributes);
-                assert!(self.attrib_buffer.len() == num_attributes);
+                assert_eq!(a.len(), num_attributes);
+                assert_eq!(self.attrib_buffer.len(), num_attributes);
                 self.attrib_buffer[..num_attributes].clone_from_slice(&a[..num_attributes]);
             }
             VertexSource::Edge { from, to, t } => {
                 let a = store.get(from);
                 let b = store.get(to);
-                assert!(a.len() == num_attributes);
-                assert!(b.len() == num_attributes);
-                assert!(self.attrib_buffer.len() == num_attributes);
+                assert_eq!(a.len(), num_attributes);
+                assert_eq!(b.len(), num_attributes);
+                assert_eq!(self.attrib_buffer.len(), num_attributes);
                 for i in 0..num_attributes {
                     self.attrib_buffer[i] = a[i] * (1.0 - t) + b[i] * t;
                 }
@@ -2232,8 +2232,8 @@ impl<'l> FillVertex<'l> {
             match next {
                 Some(VertexSource::Endpoint { id }) => {
                     let a = store.get(id);
-                    assert!(a.len() == num_attributes);
-                    assert!(self.attrib_buffer.len() == num_attributes);
+                    assert_eq!(a.len(), num_attributes);
+                    assert_eq!(self.attrib_buffer.len(), num_attributes);
                     for (i, &att) in a.iter().enumerate() {
                         self.attrib_buffer[i] += att;
                     }
@@ -2241,9 +2241,9 @@ impl<'l> FillVertex<'l> {
                 Some(VertexSource::Edge { from, to, t }) => {
                     let a = store.get(from);
                     let b = store.get(to);
-                    assert!(a.len() == num_attributes);
-                    assert!(b.len() == num_attributes);
-                    assert!(self.attrib_buffer.len() == num_attributes);
+                    assert_eq!(a.len(), num_attributes);
+                    assert_eq!(b.len(), num_attributes);
+                    assert_eq!(self.attrib_buffer.len(), num_attributes);
                     for i in 0..num_attributes {
                         self.attrib_buffer[i] += a[i] * (1.0 - t) + b[i] * t;
                     }
@@ -2450,13 +2450,12 @@ impl<'l> FillBuilder<'l> {
         self.reserve(16, 8);
 
         let tan_pi_over_8 = 0.41421357;
-        let cos_pi_over_4 = f32::consts::FRAC_1_SQRT_2;
         let d = radius * tan_pi_over_8;
 
         let start = center + vector(-radius, 0.0);
         self.begin(start, attributes);
         let ctrl_0 = center + vector(-radius, -d * dir);
-        let mid_0 = center + vector(-1.0, -dir) * radius * cos_pi_over_4;
+        let mid_0 = center + vector(-1.0, -dir) * radius * FRAC_1_SQRT_2;
         let ctrl_1 = center + vector(-d, -radius * dir);
         let mid_1 = center + vector(0.0, -radius * dir);
         self.quadratic_bezier_to(ctrl_0, mid_0, attributes);
@@ -2467,7 +2466,7 @@ impl<'l> FillBuilder<'l> {
 
         self.begin(mid_1, attributes);
         let ctrl_0 = center + vector(d, -radius * dir);
-        let mid_2 = center + vector(1.0, -dir) * radius * cos_pi_over_4;
+        let mid_2 = center + vector(1.0, -dir) * radius * FRAC_1_SQRT_2;
         let ctrl_1 = center + vector(radius, -d * dir);
         let mid_3 = center + vector(radius, 0.0);
         self.quadratic_bezier_to(ctrl_0, mid_2, attributes);
@@ -2478,7 +2477,7 @@ impl<'l> FillBuilder<'l> {
 
         self.begin(mid_3, attributes);
         let ctrl_0 = center + vector(radius, d * dir);
-        let mid_4 = center + vector(1.0, dir) * radius * cos_pi_over_4;
+        let mid_4 = center + vector(1.0, dir) * radius * FRAC_1_SQRT_2;
         let ctrl_1 = center + vector(d, radius * dir);
         let mid_5 = center + vector(0.0, radius * dir);
         self.quadratic_bezier_to(ctrl_0, mid_4, attributes);
@@ -2489,7 +2488,7 @@ impl<'l> FillBuilder<'l> {
 
         self.begin(mid_5, attributes);
         let ctrl_0 = center + vector(-d, radius * dir);
-        let mid_6 = center + vector(-1.0, dir) * radius * cos_pi_over_4;
+        let mid_6 = center + vector(-1.0, dir) * radius * FRAC_1_SQRT_2;
         let ctrl_1 = center + vector(-radius, d * dir);
         self.quadratic_bezier_to(ctrl_0, mid_6, attributes);
         self.end(false);

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -364,7 +364,7 @@ struct PendingEdge {
 ///   from the point of view of the tessellator.
 /// - The tessellator does not handle curves, and uses an approximation that introduces a
 ///   number of line segments and therefore endpoints between the original endpoints of any
-///   quadratic or cubic bézier curve.
+///   quadratic or cubic Bézier curve.
 ///
 /// This complicates the task of adding extra data to vertices without loosing the association
 /// during tessellation.
@@ -1048,7 +1048,7 @@ impl FillTessellator {
                 continue;
             }
 
-            let egde_is_before_current_point =
+            let edge_is_before_current_point =
                 if points_are_equal(self.current_position, active_edge.to) {
                     // We just found our first edge that connects with the current point.
                     // We might find other ones in the next iterations.
@@ -1081,7 +1081,7 @@ impl FillTessellator {
                     }
                 };
 
-            if !egde_is_before_current_point {
+            if !edge_is_before_current_point {
                 break;
             }
 

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -1737,7 +1737,7 @@ impl FillTessellator {
                 inserted_evt = Some(self.events.insert_sorted(
                     intersection_position,
                     EdgeData {
-                        range: remapped_ta as f32..active_edge.range_end,
+                        range: remapped_ta..active_edge.range_end,
                         winding: active_edge.winding,
                         to: active_edge.to,
                         is_edge: true,
@@ -1751,7 +1751,7 @@ impl FillTessellator {
                 self.events.insert_sorted(
                     active_edge.to,
                     EdgeData {
-                        range: active_edge.range_end..remapped_ta as f32,
+                        range: active_edge.range_end..remapped_ta,
                         winding: -active_edge.winding,
                         to: intersection_position,
                         is_edge: true,
@@ -1772,7 +1772,7 @@ impl FillTessellator {
 
             if is_after(edge_below.to, intersection_position) {
                 let edge_data = EdgeData {
-                    range: remapped_tb as f32..edge_below.range_end,
+                    range: remapped_tb..edge_below.range_end,
                     winding: edge_below.winding,
                     to: edge_below.to,
                     is_edge: true,
@@ -1795,7 +1795,7 @@ impl FillTessellator {
                 self.events.insert_sorted(
                     edge_below.to,
                     EdgeData {
-                        range: edge_below.range_end..remapped_tb as f32,
+                        range: edge_below.range_end..remapped_tb,
                         winding: -edge_below.winding,
                         to: intersection_position,
                         is_edge: true,

--- a/crates/tessellation/src/fill_tests.rs
+++ b/crates/tessellation/src/fill_tests.rs
@@ -132,14 +132,14 @@ fn test_path_with_rotations(path: Path, step: f32, expected_triangle_count: Opti
     while angle.radians < PI * 2.0 {
         //println!("\n\n ==================== angle = {:?}", angle);
 
-        let tranformed_path = path.clone().transformed(&Rotation::new(angle));
+        let transformed_path = path.clone().transformed(&Rotation::new(angle));
 
         test_path_internal(
-            tranformed_path.as_slice(),
+            transformed_path.as_slice(),
             FillRule::EvenOdd,
             expected_triangle_count,
         );
-        test_path_internal(tranformed_path.as_slice(), FillRule::NonZero, None);
+        test_path_internal(transformed_path.as_slice(), FillRule::NonZero, None);
 
         angle.radians += step;
     }
@@ -678,7 +678,7 @@ fn test_overlapping_with_intersection() {
 #[test]
 fn test_split_with_intersections() {
     // This is a reduced test case that was showing a bug where duplicate intersections
-    // were found during a split event, due to the sweep line beeing into a temporarily
+    // were found during a split event, due to the sweep line being into a temporarily
     // inconsistent state when insert_edge was called.
 
     let mut builder = Path::builder();

--- a/crates/tessellation/src/fill_tests.rs
+++ b/crates/tessellation/src/fill_tests.rs
@@ -23,7 +23,7 @@ fn tessellate(path: PathSlice, fill_rule: FillRule, log: bool) -> Result<usize, 
         tess.set_logging(log);
         tess.tessellate(&builder.build(), &options, &mut vertex_builder)?;
     }
-    return Ok(buffers.indices.len() / 3);
+    Ok(buffers.indices.len() / 3)
 }
 
 #[test]

--- a/crates/tessellation/src/fill_tests.rs
+++ b/crates/tessellation/src/fill_tests.rs
@@ -5,6 +5,7 @@ use crate::path::{Path, PathSlice};
 use crate::{FillOptions, FillRule, FillTessellator, FillVertex, TessellationError, VertexId};
 
 use std::env;
+use std::f32::consts::PI;
 
 fn tessellate(path: PathSlice, fill_rule: FillRule, log: bool) -> Result<usize, TessellationError> {
     let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
@@ -127,8 +128,6 @@ fn test_path_internal(
 }
 
 fn test_path_with_rotations(path: Path, step: f32, expected_triangle_count: Option<usize>) {
-    use std::f32::consts::PI;
-
     let mut angle = Angle::radians(0.0);
     while angle.radians < PI * 2.0 {
         //println!("\n\n ==================== angle = {:?}", angle);

--- a/crates/tessellation/src/fuzz_tests.rs
+++ b/crates/tessellation/src/fuzz_tests.rs
@@ -20,7 +20,7 @@ fn tessellate(path: PathSlice, fill_rule: FillRule, log: bool) -> Result<usize, 
         tess.tessellate(&builder.build(), &options, &mut vertex_builder)
             .unwrap();
     }
-    return Ok(buffers.indices.len() / 3);
+    Ok(buffers.indices.len() / 3)
 }
 
 fn test_path(path: PathSlice) {

--- a/crates/tessellation/src/geometry_builder.rs
+++ b/crates/tessellation/src/geometry_builder.rs
@@ -535,7 +535,7 @@ impl GeometryBuilder for NoOutput {
 
 impl FillGeometryBuilder for NoOutput {
     fn add_fill_vertex(&mut self, _vertex: FillVertex) -> Result<VertexId, GeometryBuilderError> {
-        if self.next_vertex == std::u32::MAX {
+        if self.next_vertex == u32::MAX {
             return Err(GeometryBuilderError::TooManyVertices);
         }
         self.next_vertex += 1;
@@ -545,7 +545,7 @@ impl FillGeometryBuilder for NoOutput {
 
 impl StrokeGeometryBuilder for NoOutput {
     fn add_stroke_vertex(&mut self, _: StrokeVertex) -> Result<VertexId, GeometryBuilderError> {
-        if self.next_vertex == std::u32::MAX {
+        if self.next_vertex == u32::MAX {
             return Err(GeometryBuilderError::TooManyVertices);
         }
         self.next_vertex += 1;
@@ -563,33 +563,33 @@ pub trait MaxIndex {
 }
 
 impl MaxIndex for u8 {
-    const MAX: usize = std::u8::MAX as usize;
+    const MAX: usize = u8::MAX as usize;
 }
 impl MaxIndex for i8 {
-    const MAX: usize = std::i8::MAX as usize;
+    const MAX: usize = i8::MAX as usize;
 }
 impl MaxIndex for u16 {
-    const MAX: usize = std::u16::MAX as usize;
+    const MAX: usize = u16::MAX as usize;
 }
 impl MaxIndex for i16 {
-    const MAX: usize = std::i16::MAX as usize;
+    const MAX: usize = i16::MAX as usize;
 }
 impl MaxIndex for u32 {
-    const MAX: usize = std::u32::MAX as usize;
+    const MAX: usize = u32::MAX as usize;
 }
 impl MaxIndex for i32 {
-    const MAX: usize = std::i32::MAX as usize;
+    const MAX: usize = i32::MAX as usize;
 }
 // The tessellators internally use u32 indices so we can't have more than u32::MAX
 impl MaxIndex for u64 {
-    const MAX: usize = std::u32::MAX as usize;
+    const MAX: usize = u32::MAX as usize;
 }
 impl MaxIndex for i64 {
-    const MAX: usize = std::u32::MAX as usize;
+    const MAX: usize = u32::MAX as usize;
 }
 impl MaxIndex for usize {
-    const MAX: usize = std::u32::MAX as usize;
+    const MAX: usize = u32::MAX as usize;
 }
 impl MaxIndex for isize {
-    const MAX: usize = std::u32::MAX as usize;
+    const MAX: usize = u32::MAX as usize;
 }

--- a/crates/tessellation/src/geometry_builder.rs
+++ b/crates/tessellation/src/geometry_builder.rs
@@ -80,7 +80,7 @@
 //! }
 //!
 //! // The vertex constructor. This is the object that will be used to create the custom
-//! // verticex from the information provided by the tessellators.
+//! // vertices from the information provided by the tessellators.
 //! struct WithColor([f32; 4]);
 //!
 //! impl FillVertexConstructor<MyVertex> for WithColor {

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -163,7 +163,7 @@
 //! ### Flattening and tolerance
 //!
 //! Most tessellators in this crate currently operate on flattened paths (paths or shapes represented
-//! by sequences of line segments). when paths contain Bézier curves or arcs, the latter need to be
+//! by sequences of line segments). when paths contain bézier curves or arcs, the latter need to be
 //! approximated with sequences of line segments. This approximation depends on a `tolerance` parameter
 //! which represents the maximum distance between a curve and its flattened approximation.
 //!

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -144,7 +144,7 @@
 //! generate vertex buffers and index buffers with custom vertex types.
 //!
 //! The structs [VertexBuffers](geometry_builder/struct.VertexBuffers.html) and
-//! [geometry_buider::BuffersBuilder](geometry_builder/struct.BuffersBuilder.html) are provided
+//! [geometry_builder::BuffersBuilder](geometry_builder/struct.BuffersBuilder.html) are provided
 //! for convenience. `VertexBuffers<T>` is contains a `Vec<T>` for the vertices and a `Vec<u16>`
 //! for the indices.
 //!
@@ -163,7 +163,7 @@
 //! ### Flattening and tolerance
 //!
 //! Most tessellators in this crate currently operate on flattened paths (paths or shapes represented
-//! by sequences of line segments). when paths contain bézier curves or arcs, the latter need to be
+//! by sequences of line segments). when paths contain Bézier curves or arcs, the latter need to be
 //! approximated with sequences of line segments. This approximation depends on a `tolerance` parameter
 //! which represents the maximum distance between a curve and its flattened approximation.
 //!

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -230,7 +230,6 @@ pub use crate::path::{AttributeIndex, Attributes, FillRule, LineCap, LineJoin, S
 use crate::path::EndpointId;
 
 use std::ops::{Add, Sub};
-use std::u32;
 use thiserror::Error;
 
 /// The fill tessellator's result type.

--- a/crates/tessellation/src/math_utils.rs
+++ b/crates/tessellation/src/math_utils.rs
@@ -1,4 +1,4 @@
-//! Various math tools that are mostly usefull for the tessellators.
+//! Various math tools that are mostly useful for the tessellators.
 
 use crate::math::*;
 

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -1679,7 +1679,8 @@ fn compute_join_side_positions_fixed_width(
     //  - Better integrating curves with the tessellator instead of only considering the previous and next
     //    flattened segment.
     let extruded_normal = front_normal * vertex.half_width;
-    let unclipped_miter = (join.line_join == LineJoin::Miter || join.line_join == LineJoin::MiterClip)
+    let unclipped_miter = (join.line_join == LineJoin::Miter
+        || join.line_join == LineJoin::MiterClip)
         && !miter_limit_is_exceeded(front_normal, miter_limit);
 
     let mut fold = false;
@@ -1997,7 +1998,6 @@ fn tessellate_round_join(
 
     crate::stroke::tessellate_arc(
         (start_angle.radians, end_angle.radians),
-        radius,
         start_vertex,
         end_vertex,
         num_subdivisions,
@@ -2200,7 +2200,8 @@ fn tessellate_first_edge(
                 vector: side_position - second.side_points[side].prev,
             };
 
-            let intersection = clip_line.to_f64()
+            let intersection = clip_line
+                .to_f64()
                 .intersection(&side_line.to_f64())
                 .map(|p| p.to_f32())
                 .unwrap_or(first.side_points[side].next);
@@ -2244,17 +2245,20 @@ fn get_clip_intersections(
     let clip_line = Line {
         point: normal.normalize().to_point() * clip_distance,
         vector: tangent(normal),
-    }.to_f64();
+    }
+    .to_f64();
 
     let prev_line = Line {
         point: previous_normal.to_point(),
         vector: tangent(previous_normal),
-    }.to_f64();
+    }
+    .to_f64();
 
     let next_line = Line {
         point: next_normal.to_point(),
         vector: tangent(next_normal),
-    }.to_f64();
+    }
+    .to_f64();
 
     let i1 = clip_line
         .intersection(&prev_line)
@@ -2456,7 +2460,6 @@ pub(crate) fn tessellate_round_cap(
 
     tessellate_arc(
         (start_angle.radians, mid_angle.radians),
-        radius,
         start_vertex,
         mid_vertex,
         num_subdivisions,
@@ -2469,7 +2472,6 @@ pub(crate) fn tessellate_round_cap(
 
     tessellate_arc(
         (mid_angle.radians, end_angle.radians),
-        radius,
         mid_vertex,
         end_vertex,
         num_subdivisions,
@@ -2569,7 +2571,6 @@ pub(crate) fn tessellate_empty_round_cap(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn tessellate_arc(
     angle: (f32, f32),
-    radius: f32,
     va: VertexId,
     vb: VertexId,
     num_recursions: u32,
@@ -2593,7 +2594,6 @@ pub(crate) fn tessellate_arc(
 
     tessellate_arc(
         (angle.0, mid_angle),
-        radius,
         va,
         vertex_id,
         num_recursions - 1,
@@ -2603,7 +2603,6 @@ pub(crate) fn tessellate_arc(
     )?;
     tessellate_arc(
         (mid_angle, angle.1),
-        radius,
         vertex_id,
         vb,
         num_recursions - 1,
@@ -2688,7 +2687,7 @@ impl<'a, 'b> StrokeVertex<'a, 'b> {
     #[inline]
     pub fn interpolated_attributes(&mut self) -> Attributes {
         if self.0.buffer_is_valid {
-            return &self.0.buffer[..];
+            return self.0.buffer;
         }
 
         match self.0.src {
@@ -2701,7 +2700,7 @@ impl<'a, 'b> StrokeVertex<'a, 'b> {
                 }
                 self.0.buffer_is_valid = true;
 
-                &self.0.buffer[..]
+                self.0.buffer
             }
         }
     }
@@ -2793,7 +2792,7 @@ fn test_path(path: PathSlice, options: &StrokeOptions, expected_triangle_count: 
     let mut tess = StrokeTessellator::new();
     tess.tessellate_path(
         path,
-        &options,
+        options,
         &mut TestBuilder {
             builder: simple_builder(&mut buffers),
         },
@@ -3229,7 +3228,7 @@ fn single_segment_closed() {
     tess.tessellate(&path, &options, &mut simple_builder(&mut output))
         .unwrap();
 
-    assert!(output.indices.len() > 0);
+    assert!(!output.indices.is_empty());
 
     let mut path = Path::builder_with_attributes(1);
     path.begin(point(0.0, 0.0), &[1.0]);
@@ -3243,7 +3242,7 @@ fn single_segment_closed() {
     tess.tessellate(&path, &options, &mut simple_builder(&mut output))
         .unwrap();
 
-    assert!(output.indices.len() > 0);
+    assert!(!output.indices.is_empty());
 }
 
 #[test]
@@ -3265,7 +3264,6 @@ fn issue_819() {
     let mut output: VertexBuffers<Point, u16> = VertexBuffers::new();
     tess.tessellate(&path.build(), &options, &mut simple_builder(&mut output))
         .unwrap();
-
 
     let mut path = Path::builder_with_attributes(1);
     path.begin(point(650.539978027344, 173.559997558594), &[0.0]);

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -16,7 +16,6 @@ use crate::{
     LineCap, LineJoin, Side, SimpleAttributeStore, StrokeGeometryBuilder, StrokeOptions,
     TessellationError, TessellationResult, VertexId, VertexSource,
 };
-
 use std::f32::consts::PI;
 
 const SIDE_POSITIVE: usize = 0;
@@ -328,17 +327,17 @@ impl Default for EndpointData {
     fn default() -> Self {
         EndpointData {
             position: Point::zero(),
-            half_width: std::f32::NAN,
-            advancement: std::f32::NAN,
+            half_width: f32::NAN,
+            advancement: f32::NAN,
             line_join: LineJoin::Miter,
             src: VertexSource::Endpoint {
                 id: EndpointId::INVALID,
             },
             side_points: [SidePoints {
-                prev: point(std::f32::NAN, std::f32::NAN),
-                prev_vertex: VertexId(std::u32::MAX),
-                next: point(std::f32::NAN, std::f32::NAN),
-                next_vertex: VertexId(std::u32::MAX),
+                prev: point(f32::NAN, f32::NAN),
+                prev_vertex: VertexId(u32::MAX),
+                next: point(f32::NAN, f32::NAN),
+                next_vertex: VertexId(u32::MAX),
                 single_vertex: None,
             }; 2],
             fold: [false, false],
@@ -657,8 +656,8 @@ impl<'l> StrokeBuilderImpl<'l> {
 
         let mut validator = DebugValidator::new();
 
-        let mut current_endpoint = EndpointId(std::u32::MAX);
-        let mut current_position = point(std::f32::NAN, std::f32::NAN);
+        let mut current_endpoint = EndpointId(u32::MAX);
+        let mut current_position = point(f32::NAN, f32::NAN);
 
         for evt in path.into_iter() {
             match evt {
@@ -770,8 +769,8 @@ impl<'l> StrokeBuilderImpl<'l> {
     ) -> TessellationResult {
         let mut validator = DebugValidator::new();
 
-        let mut current_endpoint = EndpointId(std::u32::MAX);
-        let mut current_position = point(std::f32::NAN, std::f32::NAN);
+        let mut current_endpoint = EndpointId(u32::MAX);
+        let mut current_position = point(f32::NAN, f32::NAN);
 
         let half_width = self.options.line_width * 0.5;
 
@@ -876,7 +875,7 @@ impl<'l> StrokeBuilderImpl<'l> {
         let mut validator = DebugValidator::new();
 
         let mut id = EndpointId(0);
-        let mut current_position = point(std::f32::NAN, std::f32::NAN);
+        let mut current_position = point(f32::NAN, f32::NAN);
 
         for evt in input {
             match evt {
@@ -1214,7 +1213,7 @@ impl<'l> StrokeBuilderImpl<'l> {
         // Make sure we re-compute the advancement instead of using the one found at the
         // beginning of the sub-path.
         let advancement = p.advancement;
-        p.advancement = std::f32::NAN;
+        p.advancement = f32::NAN;
         let segment_added = if self.options.variable_line_width.is_some() {
             self.step_impl(p, attributes)?
         } else {
@@ -2757,9 +2756,9 @@ fn test_path(path: PathSlice, options: &StrokeOptions, expected_triangle_count: 
             self.builder.end_geometry();
         }
         fn add_triangle(&mut self, a: VertexId, b: VertexId, c: VertexId) {
-            assert!(a != b);
-            assert!(a != c);
-            assert!(b != c);
+            assert_ne!(a, b);
+            assert_ne!(a, c);
+            assert_ne!(b, c);
             let pa = self.builder.buffers().vertices[a.0 as usize];
             let pb = self.builder.buffers().vertices[b.0 as usize];
             let pc = self.builder.buffers().vertices[c.0 as usize];
@@ -2781,7 +2780,7 @@ fn test_path(path: PathSlice, options: &StrokeOptions, expected_triangle_count: 
             assert!(!attributes.position().y.is_nan());
             assert!(!attributes.normal().x.is_nan());
             assert!(!attributes.normal().y.is_nan());
-            assert!(attributes.normal().square_length() != 0.0);
+            assert_ne!(attributes.normal().square_length(), 0.0);
             assert!(!attributes.advancement().is_nan());
             self.builder.add_stroke_vertex(attributes)
         }
@@ -2946,9 +2945,9 @@ fn test_too_many_vertices() {
     impl GeometryBuilder for Builder {
         fn begin_geometry(&mut self) {}
         fn add_triangle(&mut self, a: VertexId, b: VertexId, c: VertexId) {
-            assert!(a != b);
-            assert!(a != c);
-            assert!(b != c);
+            assert_ne!(a, b);
+            assert_ne!(a, c);
+            assert_ne!(b, c);
         }
         fn end_geometry(&mut self) {
             // Expected to abort the geometry.

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -122,13 +122,13 @@ impl StrokeTessellator {
     ) -> TessellationResult {
         debug_assert!(
             options.variable_line_width.is_none(),
-            "Varible line width requires custom attributes. Try tessellate_with_ids or tessellate_path",
+            "Variable line width requires custom attributes. Try tessellate_with_ids or tessellate_path",
         );
 
         let mut buffer = Vec::new();
-        let stroker = StrokeBuilderImpl::new(options, &mut buffer, builder);
+        let builder = StrokeBuilderImpl::new(options, &mut buffer, builder);
 
-        stroker.tessellate_fw(input)
+        builder.tessellate_fw(input)
     }
 
     /// Compute the tessellation from a path iterator.
@@ -147,9 +147,9 @@ impl StrokeTessellator {
             self.attrib_buffer.push(0.0);
         }
 
-        let stroker = StrokeBuilderImpl::new(options, &mut self.attrib_buffer, output);
+        let builder = StrokeBuilderImpl::new(options, &mut self.attrib_buffer, output);
 
-        stroker.tessellate_with_ids(path, positions, custom_attributes)
+        builder.tessellate_with_ids(path, positions, custom_attributes)
     }
 
     /// Compute the tessellation from a path slice.
@@ -1667,7 +1667,7 @@ fn compute_join_side_positions_fixed_width(
 
     // The folding code path's threshold is a tad too eager when dealing with flattened curves due to
     // how flattening can create segments that are much smaller than the line width. In practice the
-    // curve tends to cover the spike of the back vertex in a lot of cases. Unfortuenately at the moment
+    // curve tends to cover the spike of the back vertex in a lot of cases. Unfortunately at the moment
     // the stroke tessellators force miter joins to be clipped in the folding case. Work around it by
     // disabling folding when a miter join is not clipped. That's often an indication that the join is not
     // sharp enough to generate a huge spike, although the spiking artifact will show up in some cases.
@@ -1812,7 +1812,7 @@ fn compute_edge_attachment_positions(p0: &mut EndpointData, p1: &mut EndpointDat
     let mut vwidth_angle = sin_vwidth_angle.asin();
     // If the distance between the joins (d) is smaller than either of the half
     // widths, we end up in a situation where sin_vwidth_angle is not in [-1, 1],
-    // which causes vwidth_anfle to be NaN. Prevent that here for safety's sake
+    // which causes vwidth_angle to be NaN. Prevent that here for safety's sake
     // but it would be better to handle that earlier to do something that looks
     // more plausible with round joins.
     if vwidth_angle.is_nan() {
@@ -3247,7 +3247,7 @@ fn single_segment_closed() {
 #[test]
 fn issue_819() {
     // In this test case, the last point of the path is within merge range
-    // of both the first and second points while the latters aren't within
+    // of both the first and second points while the latter ones aren't within
     // merge range of one-another. As a result they are both skipped when
     // closing the path.
 
@@ -3280,7 +3280,7 @@ fn issue_819() {
 
 #[test]
 fn issue_821() {
-    let mut stroker = StrokeTessellator::new();
+    let mut tessellator = StrokeTessellator::new();
 
     let options = StrokeOptions::default()
         .with_tolerance(0.001)
@@ -3300,7 +3300,7 @@ fn issue_821() {
     let path = path.build();
     let mut mesh = VertexBuffers::new();
     let mut builder = simple_builder(&mut mesh);
-    stroker
+    tessellator
         .tessellate_path(&path, &options, &mut builder)
         .unwrap();
 }

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -6,7 +6,7 @@ use lyon::tessellation::geometry_builder::*;
 use lyon::tessellation::{FillOptions, FillTessellator};
 use lyon::tessellation::{StrokeOptions, StrokeTessellator};
 
-use lyon::algorithms::{walk, rounded_polygon};
+use lyon::algorithms::{rounded_polygon, walk};
 
 use winit::dpi::PhysicalSize;
 use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
@@ -141,7 +141,6 @@ fn main() {
     build_logo_path(&mut builder);
     let path = builder.build();
 
-
     let arrow_points = [
         point(-1.0, -0.3),
         point(0.0, -0.3),
@@ -186,7 +185,7 @@ fn main() {
         .tessellate_path(
             &arrow_path,
             &FillOptions::tolerance(tolerance),
-            &mut BuffersBuilder::new(&mut geometry, WithId(arrows_prim_id as u32)),
+            &mut BuffersBuilder::new(&mut geometry, WithId(arrows_prim_id)),
         )
         .unwrap();
 
@@ -409,7 +408,7 @@ fn main() {
         label: None,
         layout: Some(&pipeline_layout),
         vertex: wgpu::VertexState {
-            module: &vs_module,
+            module: vs_module,
             entry_point: "main",
             buffers: &[wgpu::VertexBufferLayout {
                 array_stride: std::mem::size_of::<GpuVertex>() as u64,
@@ -434,7 +433,7 @@ fn main() {
             }],
         },
         fragment: Some(wgpu::FragmentState {
-            module: &fs_module,
+            module: fs_module,
             entry_point: "main",
             targets: &[Some(wgpu::ColorTargetState {
                 format: wgpu::TextureFormat::Bgra8Unorm,
@@ -470,7 +469,7 @@ fn main() {
         label: None,
         layout: Some(&pipeline_layout),
         vertex: wgpu::VertexState {
-            module: &bg_vs_module,
+            module: bg_vs_module,
             entry_point: "main",
             buffers: &[wgpu::VertexBufferLayout {
                 array_stride: std::mem::size_of::<Point>() as u64,
@@ -483,7 +482,7 @@ fn main() {
             }],
         },
         fragment: Some(wgpu::FragmentState {
-            module: &bg_fs_module,
+            module: bg_fs_module,
             entry_point: "main",
             targets: &[Some(wgpu::ColorTargetState {
                 format: wgpu::TextureFormat::Bgra8Unorm,
@@ -500,7 +499,7 @@ fn main() {
             unclipped_depth: false,
             conservative: false,
         },
-        depth_stencil: depth_stencil_state.clone(),
+        depth_stencil: depth_stencil_state,
         multisample: wgpu::MultisampleState {
             count: sample_count,
             mask: !0,
@@ -595,8 +594,8 @@ fn main() {
             label: Some("Encoder"),
         });
 
-        cpu_primitives[stroke_prim_id as usize].width = scene.stroke_width;
-        cpu_primitives[stroke_prim_id as usize].color = [
+        cpu_primitives[stroke_prim_id].width = scene.stroke_width;
+        cpu_primitives[stroke_prim_id].color = [
             (time_secs * 0.8 - 1.6).sin() * 0.1 + 0.1,
             (time_secs * 0.5 - 1.6).sin() * 0.1 + 0.1,
             (time_secs - 1.6).sin() * 0.1 + 0.1,
@@ -699,7 +698,7 @@ fn main() {
             pass.set_index_buffer(ibo.slice(..), wgpu::IndexFormat::Uint16);
             pass.set_vertex_buffer(0, vbo.slice(..));
 
-            pass.draw_indexed(fill_range.clone(), 0, 0..(num_instances as u32));
+            pass.draw_indexed(fill_range.clone(), 0, 0..num_instances);
             pass.draw_indexed(stroke_range.clone(), 0, 0..1);
             pass.draw_indexed(arrow_range.clone(), 0, 0..(arrow_count as u32));
 

--- a/examples/wgpu_svg/src/main.rs
+++ b/examples/wgpu_svg/src/main.rs
@@ -14,8 +14,6 @@ use futures::executor::block_on;
 
 use wgpu::util::DeviceExt;
 
-use std::f64::NAN;
-
 const WINDOW_SIZE: f32 = 800.0;
 
 pub const FALLBACK_COLOR: usvg::Color = usvg::Color {
@@ -86,12 +84,12 @@ fn main() {
     let mut primitives = Vec::new();
 
     let mut prev_transform = usvg::Transform {
-        a: NAN,
-        b: NAN,
-        c: NAN,
-        d: NAN,
-        e: NAN,
-        f: NAN,
+        a: f64::NAN,
+        b: f64::NAN,
+        c: f64::NAN,
+        d: f64::NAN,
+        e: f64::NAN,
+        f: f64::NAN,
     };
     let view_box = rtree.svg_node().view_box;
     for node in rtree.root().descendants() {


### PR DESCRIPTION
* removed a number of unneeded lifetimes
* spelling
* `cargo fmt`
* added cargo fmt & clippy to the CI
* added Default and Debug to the `PathParser`
* lots of unneeded `&`
* discovered a bug in clippy in the process (link in code)
* made walk.rs faster (index access is always slower than iterative one because iterative doesn't need to do bounds check on each access
* fix deprecated constants
* use `DebugValidator` in the `PathCommands` (will use less memory now when Debug is not enabled)