### PR TITLE
Clean up format params

### DIFF
--- a/cli/src/flatten.rs
+++ b/cli/src/flatten.rs
@@ -39,8 +39,8 @@ pub fn flatten(mut cmd: PathCmd) -> Result<(), FlattenError> {
             }
         }
 
-        writeln!(&mut *cmd.output, "vertices: {}", num_vertices)?;
-        writeln!(&mut *cmd.output, "paths: {}", num_paths)?;
+        writeln!(&mut *cmd.output, "vertices: {num_vertices}")?;
+        writeln!(&mut *cmd.output, "paths: {num_paths}")?;
 
         return Ok(());
     }

--- a/cli/src/fuzzing.rs
+++ b/cli/src/fuzzing.rs
@@ -56,10 +56,10 @@ pub fn run(cmd: FuzzCmd) -> bool {
         }
     );
     if let Some(num) = cmd.min_points {
-        println!("minimum number of points per path: {}", num);
+        println!("minimum number of points per path: {num}");
     }
     if let Some(num) = cmd.max_points {
-        println!("maximum number of points per path: {}", num);
+        println!("maximum number of points per path: {num}");
     }
     println!("----");
     loop {
@@ -75,7 +75,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
 
             if status.is_err() {
                 println!(" !! Error while tessellating");
-                println!("    Path #{}", i);
+                println!("    Path #{i}");
                 find_reduced_test_case(path.as_slice(), &|path: Path| {
                     FillTessellator::new()
                         .tessellate(&path, &options, &mut NoOutput::new())
@@ -129,7 +129,7 @@ pub fn run(cmd: FuzzCmd) -> bool {
 
         i += 1;
         if i % 500 == 0 {
-            println!(" -- tested {} paths", i);
+            println!(" -- tested {i} paths");
         }
     }
 }

--- a/cli/src/show.rs
+++ b/cli/src/show.rs
@@ -587,7 +587,7 @@ pub fn show_path(cmd: TessellateCmd, render_options: RenderCmd) {
         let frame = match surface.get_current_texture() {
             Ok(frame) => frame,
             Err(e) => {
-                println!("Swap-chain error: {:?}", e);
+                println!("Swap-chain error: {e:?}");
                 return;
             }
         };

--- a/cli/src/tessellate/format.rs
+++ b/cli/src/tessellate/format.rs
@@ -28,15 +28,15 @@ pub fn format_output(
                 }
                 "indices" => {
                     output.push_str(&format_iter(buffers.indices.iter(), sep, pattern, |x| {
-                        format!("{}", x)
+                        format!("{x}")
                     }));
                 }
                 "triangles" => {
                     let triangles: Tuples<_, (_, _, _)> = buffers.indices.iter().tuples();
-                    output.push_str(&format_iter(triangles, sep, pattern, |x| format!("{}", x)));
+                    output.push_str(&format_iter(triangles, sep, pattern, |x| format!("{x}")));
                 }
                 invalid => {
-                    eprintln!("ERROR: `@{}...@` does not name an expansion", invalid);
+                    eprintln!("ERROR: `@{invalid}...@` does not name an expansion");
                     std::process::exit(1);
                 }
             }
@@ -66,7 +66,7 @@ where
                 let replace = Regex::new(&regex_escape_brackets(var)).unwrap();
                 buf = replace.replace_all(&buf, value).to_string();
             } else {
-                eprintln!("ERROR: `{}` does not name a variable", var);
+                eprintln!("ERROR: `{var}` does not name a variable");
                 std::process::exit(1)
             }
         }
@@ -77,9 +77,9 @@ where
 
 fn format_float(value: f32, precision: Option<usize>) -> String {
     if let Some(p) = precision {
-        format!("{0:.1$}", value, p)
+        format!("{value:.p$}")
     } else {
-        format!("{}", value)
+        format!("{value}")
     }
 }
 

--- a/crates/algorithms/src/fit.rs
+++ b/crates/algorithms/src/fit.rs
@@ -68,7 +68,7 @@ fn simple_fit() {
         use crate::geom::euclid::approxeq::ApproxEq;
         let result = a.min.approx_eq(&b.min) && a.max.approx_eq(&b.max);
         if !result {
-            std::println!("{:?} == {:?}", a, b);
+            std::println!("{a:?} == {b:?}");
         }
         result
     }

--- a/crates/extra/src/debugging.rs
+++ b/crates/extra/src/debugging.rs
@@ -27,8 +27,7 @@ pub fn path_to_polygons(path: PathSlice) -> Polygons {
             }
             _ => {
                 println!(
-                    " -- path_to_polygons: warning! Unsupported event type {:?}",
-                    evt
+                    " -- path_to_polygons: warning! Unsupported event type {evt:?}"
                 );
             }
         }
@@ -100,7 +99,7 @@ pub fn find_reduced_test_case<F: Fn(Path) -> bool + panic::UnwindSafe + panic::R
     }
     println!("    test_path(builder.build().as_slice());\n");
     println!("    // SVG path syntax:");
-    println!("    // \"{:?}\"", path);
+    println!("    // \"{path:?}\"");
     println!("}}\n\n");
 
     path

--- a/crates/extra/src/parser.rs
+++ b/crates/extra/src/parser.rs
@@ -653,7 +653,7 @@ fn bad_numbers() {
         match r {
             Err(ParseError::Number { .. }) => true,
             _ => {
-                println!("{:?}", r);
+                println!("{r:?}");
                 false
             }
         }

--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -1032,7 +1032,7 @@ fn test_bounding_box() {
             || !r1.min.y.approx_eq(&r2.min.y)
             || !r1.max.y.approx_eq(&r2.max.y)
         {
-            std::println!("\n   left: {:?}\n   right: {:?}", r1, r2);
+            std::println!("\n   left: {r1:?}\n   right: {r2:?}");
             return false;
         }
 
@@ -1105,7 +1105,7 @@ fn test_bounding_box() {
 
     let mut angle = Angle::zero();
     for _ in 0..10 {
-        std::println!("angle: {:?}", angle);
+        std::println!("angle: {angle:?}");
         let r = Arc {
             center: point(0.0, 0.0),
             radii: vector(4.0, 4.0),
@@ -1126,7 +1126,7 @@ fn test_bounding_box() {
 
     let mut angle = Angle::zero();
     for _ in 0..10 {
-        std::println!("angle: {:?}", angle);
+        std::println!("angle: {angle:?}");
         let r = Arc {
             center: point(0.0, 0.0),
             radii: vector(4.0, 4.0),

--- a/crates/geom/src/cubic_bezier.rs
+++ b/crates/geom/src/cubic_bezier.rs
@@ -1387,8 +1387,8 @@ impl<S: Scalar> Iterator for Flattened<S> {
 
 #[cfg(test)]
 fn print_arrays(a: &[Point<f32>], b: &[Point<f32>]) {
-    std::println!("left:  {:?}", a);
-    std::println!("right: {:?}", b);
+    std::println!("left:  {a:?}");
+    std::println!("right: {b:?}");
 }
 
 #[cfg(test)]
@@ -1403,7 +1403,7 @@ fn assert_approx_eq(a: &[Point<f32>], b: &[Point<f32>]) {
         let dy = f32::abs(a[i].y - b[i].y);
         if dx > threshold || dy > threshold {
             print_arrays(a, b);
-            std::println!("diff = {:?} {:?}", dx, dy);
+            std::println!("diff = {dx:?} {dy:?}");
             panic!("The arrays are not equal");
         }
     }
@@ -1845,7 +1845,7 @@ fn test_line_segment_intersections() {
     fn assert_approx_eq(a: ArrayVec<(f32, f32), 3>, b: &[(f32, f32)], epsilon: f32) {
         for i in 0..a.len() {
             if f32::abs(a[i].0 - b[i].0) > epsilon || f32::abs(a[i].1 - b[i].1) > epsilon {
-                std::println!("{:?} != {:?}", a, b);
+                std::println!("{a:?} != {b:?}");
             }
             assert!((a[i].0 - b[i].0).abs() <= epsilon && (a[i].1 - b[i].1).abs() <= epsilon);
         }
@@ -1895,7 +1895,7 @@ fn test_parameters_for_value() {
     fn assert_approx_eq(a: ArrayVec<f32, 3>, b: &[f32], epsilon: f32) {
         for i in 0..a.len() {
             if f32::abs(a[i] - b[i]) > epsilon {
-                std::println!("{:?} != {:?}", a, b);
+                std::println!("{a:?} != {b:?}");
             }
             assert!((a[i] - b[i]).abs() <= epsilon);
         }

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -980,7 +980,7 @@ fn solve_y_for_x() {
     let eqn = line.equation();
 
     if let Some(y) = eqn.solve_y_for_x(line.point.x) {
-        std::println!("{:?} != {:?}", y, line.point.y);
+        std::println!("{y:?} != {:?}", line.point.y);
         assert!(f64::abs(y - line.point.y) < 0.000001)
     }
 
@@ -998,7 +998,7 @@ fn solve_y_for_x() {
         let eqn = line.equation();
 
         if let Some(y) = eqn.solve_y_for_x(line.point.x) {
-            std::println!("{:?} != {:?}", y, line.point.y);
+            std::println!("{y:?} != {:?}", line.point.y);
             assert!(f64::abs(y - line.point.y) < 0.000001)
         }
 
@@ -1201,7 +1201,7 @@ fn clipped() {
     fn approx_eq(a: LineSegment<f32>, b: LineSegment<f32>) -> bool {
         let ok = a.from.approx_eq(&b.from) && a.to.approx_eq(&b.to);
         if !ok {
-            std::println!("{:?} != {:?}", a, b);
+            std::println!("{a:?} != {b:?}");
         }
 
         ok

--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -1428,7 +1428,7 @@ fn issue_678() {
     };
 
     let intersections = quadratic.line_intersections(&line);
-    std::println!("{:?}", intersections);
+    std::println!("{intersections:?}");
 
     assert_eq!(intersections.len(), 1);
 }

--- a/crates/geom/src/utils.rs
+++ b/crates/geom/src/utils.rs
@@ -131,7 +131,7 @@ fn cubic_polynomial() {
     fn assert_approx_eq(a: ArrayVec<f32, 3>, b: &[f32], epsilon: f32) {
         for i in 0..a.len() {
             if f32::abs(a[i] - b[i]) > epsilon {
-                std::println!("{:?} != {:?}", a, b);
+                std::println!("{a:?} != {b:?}");
             }
             assert!((a[i] - b[i]).abs() <= epsilon);
         }

--- a/crates/path/src/commands.rs
+++ b/crates/path/src/commands.rs
@@ -329,12 +329,12 @@ impl<'l> fmt::Debug for PathCommandsSlice<'l> {
         write!(f, "\"")?;
         for evt in self.iter() {
             match evt {
-                IdEvent::Line { to, .. } => write!(f, "L {:?}", to),
-                IdEvent::Quadratic { ctrl, to, .. } => write!(f, "Q {:?} {:?} ", ctrl, to),
+                IdEvent::Line { to, .. } => write!(f, "L {to:?}"),
+                IdEvent::Quadratic { ctrl, to, .. } => write!(f, "Q {ctrl:?} {to:?} "),
                 IdEvent::Cubic {
                     ctrl1, ctrl2, to, ..
-                } => write!(f, "C {:?} {:?} {:?} ", ctrl1, ctrl2, to),
-                IdEvent::Begin { at, .. } => write!(f, "M {:?} ", at),
+                } => write!(f, "C {ctrl1:?} {ctrl2:?} {to:?} "),
+                IdEvent::Begin { at, .. } => write!(f, "M {at:?} "),
                 IdEvent::End { close: true, .. } => write!(f, "Z "),
                 IdEvent::End { close: false, .. } => Ok(()),
             }?;
@@ -399,12 +399,12 @@ where
         write!(f, "{{ ")?;
         for evt in self.events() {
             match evt {
-                Event::Line { to, .. } => write!(f, "L {:?}", to),
-                Event::Quadratic { ctrl, to, .. } => write!(f, "Q {:?} {:?} ", ctrl, to),
+                Event::Line { to, .. } => write!(f, "L {to:?}"),
+                Event::Quadratic { ctrl, to, .. } => write!(f, "Q {ctrl:?} {to:?} "),
                 Event::Cubic {
                     ctrl1, ctrl2, to, ..
-                } => write!(f, "C {:?} {:?} {:?} ", ctrl1, ctrl2, to),
-                Event::Begin { at, .. } => write!(f, "M {:?} ", at),
+                } => write!(f, "C {ctrl1:?} {ctrl2:?} {to:?} "),
+                Event::Begin { at, .. } => write!(f, "M {at:?} "),
                 Event::End { close: true, .. } => write!(f, "Z "),
                 Event::End { close: false, .. } => Ok(()),
             }?;

--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -1477,8 +1477,8 @@ fn test_reverse_path_simple() {
         b: Option<Event<(Point, Attributes<'l>), Point>>,
     ) -> bool {
         if a != b {
-            std::println!("left: {:?}", a);
-            std::println!("right: {:?}", b);
+            std::println!("left: {a:?}");
+            std::println!("right: {b:?}");
         }
 
         a == b
@@ -1552,8 +1552,8 @@ fn test_reverse_path() {
         b: Option<Event<(Point, Attributes<'l>), Point>>,
     ) -> bool {
         if a != b {
-            std::println!("left: {:?}", a);
-            std::println!("right: {:?}", b);
+            std::println!("left: {a:?}");
+            std::println!("right: {b:?}");
         }
 
         a == b

--- a/crates/path/src/path_buffer.rs
+++ b/crates/path/src/path_buffer.rs
@@ -178,7 +178,7 @@ impl<'l> fmt::Debug for PathBufferSlice<'l> {
             self.verbs.len(),
         )?;
         for idx in self.indices() {
-            write!(formatter, "#{:?}: ", idx)?;
+            write!(formatter, "#{idx:?}: ")?;
             self.get(idx).fmt(formatter)?;
             write!(formatter, ", ")?;
         }

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -2835,7 +2835,7 @@ fn fill_vertex_source_02() {
                 for i in 0..a.len() {
                     let are_equal = (a[i] - b[i]).abs() < 0.001;
                     if !are_equal {
-                        println!("{:?} != {:?}", a, b);
+                        println!("{a:?} != {b:?}");
                     }
                     assert!(are_equal);
                 }

--- a/crates/tessellation/src/geometry_builder.rs
+++ b/crates/tessellation/src/geometry_builder.rs
@@ -454,7 +454,7 @@ where
 
     fn add_triangle(&mut self, a: VertexId, b: VertexId, c: VertexId) {
         if a == b || a == c || b == c {
-            println!("bad triangle {:?} {:?} {:?}", a, b, c);
+            println!("bad triangle {a:?} {b:?} {c:?}");
         }
         debug_assert!(a != b);
         debug_assert!(a != c);

--- a/examples/wgpu/src/main.rs
+++ b/examples/wgpu/src/main.rs
@@ -582,7 +582,7 @@ fn main() {
         let frame = match surface.get_current_texture() {
             Ok(texture) => texture,
             Err(e) => {
-                println!("Swap-chain error: {:?}", e);
+                println!("Swap-chain error: {e:?}");
                 return;
             }
         };
@@ -720,7 +720,7 @@ fn main() {
         let now = Instant::now();
         time_secs = (now - start).as_secs_f32();
         if now >= next_report {
-            println!("{} FPS", frame_count);
+            println!("{frame_count} FPS");
             frame_count = 0;
             next_report = now + Duration::from_secs(1);
         }

--- a/examples/wgpu_svg/src/main.rs
+++ b/examples/wgpu_svg/src/main.rs
@@ -440,7 +440,7 @@ fn main() {
         let frame = match surface.get_current_texture() {
             Ok(frame) => frame,
             Err(e) => {
-                println!("Swap-chain error: {:?}", e);
+                println!("Swap-chain error: {e:?}");
                 return;
             }
         };


### PR DESCRIPTION
This made all formats easier to read

`cargo clippy --fix -- -A clippy::all -W clippy::uninlined_format_args`