### PR TITLE
Fix workflow to simplify build debugging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,4 +55,7 @@ jobs:
           node-version: 10.5
 
       - name: Compile and test wasm
-        run: cd wasm_test && cargo +nightly build --target wasm32-unknown-unknown && node test.js
+        run: |
+          cd wasm_test
+          cargo +nightly build --target wasm32-unknown-unknown
+          node test.js


### PR DESCRIPTION
Having && in a workflow makes debugging much harder (uncertain which exact command causes a build failure), without adding any extra benefit.

Unlike Dockerfile, where this is a sad nesessity due to the dockerfile lang design.

P.S. This will help debug several latest PRs i made that fail in WASM build