### PR TITLE
Order trait impls same as trait declaration, toml fix

### DIFF
--- a/crates/algorithms/src/hatching.rs
+++ b/crates/algorithms/src/hatching.rs
@@ -658,11 +658,11 @@ pub struct RegularHatchingPattern<Cb: FnMut(&HatchSegment)> {
 }
 
 impl<Cb: FnMut(&HatchSegment)> HatchBuilder for RegularHatchingPattern<Cb> {
-    fn next_offset(&mut self, _row: u32) -> f32 {
-        self.interval
-    }
     fn add_segment(&mut self, segment: &HatchSegment) {
         (self.callback)(segment)
+    }
+    fn next_offset(&mut self, _row: u32) -> f32 {
+        self.interval
     }
 }
 
@@ -673,13 +673,6 @@ struct HatchesToDots<'l> {
 }
 
 impl<'l> HatchBuilder for HatchesToDots<'l> {
-    fn next_offset(&mut self, row: u32) -> f32 {
-        let val = self.builder.next_row_offset(self.column, row);
-        self.column = 0;
-
-        val
-    }
-
     fn add_segment(&mut self, segment: &HatchSegment) {
         let row = segment.row;
         let mut u = self.builder.first_column_offset(row);
@@ -712,6 +705,13 @@ impl<'l> HatchBuilder for HatchesToDots<'l> {
 
             u += du;
         }
+    }
+
+    fn next_offset(&mut self, row: u32) -> f32 {
+        let val = self.builder.next_row_offset(self.column, row);
+        self.column = 0;
+
+        val
     }
 }
 

--- a/crates/algorithms/src/walk.rs
+++ b/crates/algorithms/src/walk.rs
@@ -312,12 +312,12 @@ impl<'l> PathBuilder for PathWalker<'l> {
         self.begin(to, attributes)
     }
 
-    fn line_to(&mut self, to: Point, attributes: Attributes) -> EndpointId {
-        self.line_to(to, attributes)
-    }
-
     fn end(&mut self, close: bool) {
         self.end(close)
+    }
+
+    fn line_to(&mut self, to: Point, attributes: Attributes) -> EndpointId {
+        self.line_to(to, attributes)
     }
 
     fn quadratic_bezier_to(

--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -755,9 +755,6 @@ impl<S: Scalar> Segment for Arc<S> {
     fn derivative(&self, t: S) -> Vector<S> {
         self.sample_tangent(t)
     }
-    fn split_range(&self, t_range: Range<S>) -> Self {
-        self.split_range(t_range)
-    }
     fn split(&self, t: S) -> (Self, Self) {
         self.split(t)
     }
@@ -766,6 +763,9 @@ impl<S: Scalar> Segment for Arc<S> {
     }
     fn after_split(&self, t: S) -> Self {
         self.after_split(t)
+    }
+    fn split_range(&self, t_range: Range<S>) -> Self {
+        self.split_range(t_range)
     }
     fn flip(&self) -> Self {
         self.flip()

--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -179,11 +179,6 @@ mod scalar {
 
         const EPSILON: Self = 1e-4;
 
-        #[inline]
-        fn value(v: f32) -> Self {
-            v
-        }
-
         fn epsilon_for(reference: Self) -> Self {
             // The thresholds are chosen by looking at the table at
             // https://blog.demofox.org/2017/11/21/floating-point-precision/ plus a bit
@@ -198,6 +193,11 @@ mod scalar {
                 65536..=8_388_607 => 0.5,
                 _ => 1.0,
             }
+        }
+
+        #[inline]
+        fn value(v: f32) -> Self {
+            v
         }
     }
 
@@ -223,11 +223,6 @@ mod scalar {
 
         const EPSILON: Self = 1e-8;
 
-        #[inline]
-        fn value(v: f32) -> Self {
-            v as f64
-        }
-
         fn epsilon_for(reference: Self) -> Self {
             let magnitude = reference.abs() as i64;
             match magnitude {
@@ -236,6 +231,11 @@ mod scalar {
                 8_388_608..=4_294_967_295 => 1e-3,
                 _ => 1e-1,
             }
+        }
+
+        #[inline]
+        fn value(v: f32) -> Self {
+            v as f64
         }
     }
 }

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -521,9 +521,6 @@ impl<S: Scalar> Segment for LineSegment<S> {
     fn dy(&self, _t: S) -> S {
         self.to.y - self.from.y
     }
-    fn split_range(&self, t_range: Range<S>) -> Self {
-        self.split_range(t_range)
-    }
     fn split(&self, t: S) -> (Self, Self) {
         self.split(t)
     }
@@ -532,6 +529,9 @@ impl<S: Scalar> Segment for LineSegment<S> {
     }
     fn after_split(&self, t: S) -> Self {
         self.after_split(t)
+    }
+    fn split_range(&self, t_range: Range<S>) -> Self {
+        self.split_range(t_range)
     }
     fn flip(&self) -> Self {
         self.flip()

--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -655,7 +655,7 @@ impl<S: Scalar> QuadraticBezierSegment<S> {
         result
     }
 
-    /// Computes the intersections (if any) between this segment a line segment.
+    /// Computes the intersections (if any) between this segment and a line segment.
     ///
     /// The result is provided in the form of the `t` parameters of each
     /// point along curve and segment. To get the intersection points, sample

--- a/crates/lyon/Cargo.toml
+++ b/crates/lyon/Cargo.toml
@@ -21,6 +21,6 @@ extra = ["lyon_extra"]
 profiling = ["lyon_tessellation/profiling"]
 
 [dependencies]
-lyon_tessellation = { version = "1.0.5", path = "../tessellation/" }
-lyon_algorithms = { version = "1.0.2", path = "../algorithms/" }
-lyon_extra = { version = "1.0.0", optional = true, path = "../extra/" }
+lyon_tessellation = { version = "1.0.5", path = "../tessellation" }
+lyon_algorithms = { version = "1.0.2", path = "../algorithms" }
+lyon_extra = { version = "1.0.0", optional = true, path = "../extra" }

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -1391,6 +1391,10 @@ impl<Builder: PathBuilder> SvgPathBuilder for WithSvg<Builder> {
         self.move_to(to);
     }
 
+    fn close(&mut self) {
+        self.close();
+    }
+
     fn line_to(&mut self, to: Point) {
         self.line_to(to);
     }
@@ -1401,10 +1405,6 @@ impl<Builder: PathBuilder> SvgPathBuilder for WithSvg<Builder> {
 
     fn cubic_bezier_to(&mut self, ctrl1: Point, ctrl2: Point, to: Point) {
         self.cubic_bezier_to(ctrl1, ctrl2, to);
-    }
-
-    fn close(&mut self) {
-        self.close();
     }
 
     fn relative_move_to(&mut self, to: Vector) {

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -415,12 +415,12 @@ pub trait AttributeStore {
 }
 
 impl AttributeStore for () {
-    fn num_attributes(&self) -> usize {
-        0
-    }
-
     fn get(&self, _: EndpointId) -> Attributes {
         NO_ATTRIBUTES
+    }
+
+    fn num_attributes(&self) -> usize {
+        0
     }
 }
 

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -2684,8 +2684,8 @@ fn fill_vertex_source_01() {
     }
 
     impl GeometryBuilder for CheckVertexSources {
-        fn abort_geometry(&mut self) {}
         fn add_triangle(&mut self, _: VertexId, _: VertexId, _: VertexId) {}
+        fn abort_geometry(&mut self) {}
     }
 
     impl FillGeometryBuilder for CheckVertexSources {

--- a/crates/tessellation/src/geometry_builder.rs
+++ b/crates/tessellation/src/geometry_builder.rs
@@ -447,11 +447,6 @@ where
         self.first_index = self.buffers.indices.len() as Index;
     }
 
-    fn abort_geometry(&mut self) {
-        self.buffers.vertices.truncate(self.first_vertex as usize);
-        self.buffers.indices.truncate(self.first_index as usize);
-    }
-
     fn add_triangle(&mut self, a: VertexId, b: VertexId, c: VertexId) {
         if a == b || a == c || b == c {
             println!("bad triangle {a:?} {b:?} {c:?}");
@@ -465,6 +460,11 @@ where
         self.buffers.indices.push((a + self.vertex_offset).into());
         self.buffers.indices.push((b + self.vertex_offset).into());
         self.buffers.indices.push((c + self.vertex_offset).into());
+    }
+
+    fn abort_geometry(&mut self) {
+        self.buffers.vertices.truncate(self.first_vertex as usize);
+        self.buffers.indices.truncate(self.first_index as usize);
     }
 }
 

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -2942,16 +2942,17 @@ fn test_too_many_vertices() {
     struct Builder {
         max_vertices: u32,
     }
+
     impl GeometryBuilder for Builder {
         fn begin_geometry(&mut self) {}
+        fn end_geometry(&mut self) {
+            // Expected to abort the geometry.
+            panic!();
+        }
         fn add_triangle(&mut self, a: VertexId, b: VertexId, c: VertexId) {
             assert_ne!(a, b);
             assert_ne!(a, c);
             assert_ne!(b, c);
-        }
-        fn end_geometry(&mut self) {
-            // Expected to abort the geometry.
-            panic!();
         }
         fn abort_geometry(&mut self) {}
     }
@@ -3027,8 +3028,8 @@ fn stroke_vertex_source_01() {
     }
 
     impl GeometryBuilder for CheckVertexSources {
-        fn abort_geometry(&mut self) {}
         fn add_triangle(&mut self, _: VertexId, _: VertexId, _: VertexId) {}
+        fn abort_geometry(&mut self) {}
     }
 
     fn eq(a: Point, b: Point) -> bool {


### PR DESCRIPTION
* Make all trait implementations order their implementation the same as the trait declaration, just for consistency.
* One minor issue (per IntelliJ) that dependency paths should not end with a slash
* minor doc fix