### PR TITLE
Update actions on GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -50,7 +50,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 10.5
 


### PR DESCRIPTION
The following updates are performed:

* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* update [`actions/setup-node`](https://github.com/actions/setup-node) to v3

Still using the older versions of those actions will generate some warning like in this run: https://github.com/nical/lyon/actions/runs/4676216713

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1, Swatinem/rust-cache@v1, actions/setup-node@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/checkout` and `actions/setup-node`, because their newer versions use Node.js 16.
