### PR TITLE
Fix failing wasm build on GHA.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 10.5
+          node-version: 14.21
 
       - name: Compile and test wasm
         run: |


### PR DESCRIPTION
Updating Node.js from 10.5 to 14.21, because Node.js is the oldest maintenance release which has not reached its end of life yet. (See <https://github.com/nodejs/release#release-schedule> for the Node.js release schedule.)

An alternative would be to use the `--experimental-wasm-se` flag on the old Node.js 10 version as the error message in failing builds like <https://github.com/nical/lyon/actions/runs/4676216713/jobs/8282243984> suggests, but this is no longer required in newer Node.js versions. So updating Node.js not only fixes the build but also gets us to a still maintained version.