### PR TITLE
Bump float-next-after dependency from 0.1.5 to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,12 +547,9 @@ checksum = "75224bec9bfe1a65e2d34132933f2de7fe79900c96a0174307554244ece8150e"
 
 [[package]]
 name = "float_next_after"
-version = "0.1.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
-dependencies = [
- "num-traits",
-]
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fnv"

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -21,7 +21,7 @@ profiling = []
 
 [dependencies]
 lyon_path = { version = "1.0.3", path = "../path" }
-float_next_after = "0.1.5"
+float_next_after = "1.0.0"
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 thiserror = "1.0"
 


### PR DESCRIPTION
This doesn't get picked up by dependabot automatically. This would resolve some conflicting dependencies, so a thanks in advance if it's possible to work this through! 