### PR TITLE
Prevent the tessellator to panic when comparing a sorting key equal to NaN

### DIFF
--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -1985,7 +1985,7 @@ impl FillTessellator {
     #[cfg_attr(feature = "profiling", inline(never))]
     fn sort_edges_below(&mut self) {
         self.edges_below
-            .sort_unstable_by(|a, b| a.sort_key.partial_cmp(&b.sort_key).unwrap());
+            .sort_unstable_by(|a, b| a.sort_key.partial_cmp(&b.sort_key).unwrap_or(Ordering::Equal));
     }
 
     #[cfg_attr(feature = "profiling", inline(never))]


### PR DESCRIPTION
Motivation : we've noticed a few crashes where the fill tessellator will panic due to unwrapping a None value on the partial comparison of two sort keys.

We'd rather that the library never crashed but instead returned an appropriate Error. In the meantime, returning a default Ordering in such cases could be prevent the crashing of the app. This seems consistent with the way the same problem is handled line 1882.