### PR TITLE
Add `no_std` support for `lyon_tessellation`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "float_next_after",
  "lyon_extra",
  "lyon_path",
+ "num-traits",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,6 @@ dependencies = [
  "lyon_extra",
  "lyon_path",
  "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["std"]
-std = ["lyon_path/std"]
+std = ["lyon_path/std", "num-traits/std"]
 serialization = ["serde", "lyon_path/serialization"]
 debugger = []
 profiling = []
@@ -25,6 +25,7 @@ profiling = []
 lyon_path = { version = "1.0.3", path = "../path", default-features = false }
 float_next_after = "1.0.0"
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
+num-traits = { version = "0.2.15", default-features = false, features = ["libm"] }
 
 [dev-dependencies]
 lyon_extra = { version = "1.0.0", path = "../extra" }

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -15,12 +15,14 @@ name = "lyon_tessellation"
 path = "src/lib.rs"
 
 [features]
+default = ["std"]
+std = ["lyon_path/std"]
 serialization = ["serde", "lyon_path/serialization"]
 debugger = []
 profiling = []
 
 [dependencies]
-lyon_path = { version = "1.0.3", path = "../path" }
+lyon_path = { version = "1.0.3", path = "../path", default-features = false }
 float_next_after = "1.0.0"
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 thiserror = "1.0"

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -25,7 +25,6 @@ profiling = []
 lyon_path = { version = "1.0.3", path = "../path", default-features = false }
 float_next_after = "1.0.0"
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
-thiserror = "1.0"
 
 [dev-dependencies]
 lyon_extra = { version = "1.0.0", path = "../extra" }

--- a/crates/tessellation/src/basic_shapes.rs
+++ b/crates/tessellation/src/basic_shapes.rs
@@ -6,6 +6,9 @@ use crate::{
 
 use core::f32::consts::PI;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 pub fn fill_rectangle(rect: &Box2D, output: &mut dyn FillGeometryBuilder) -> TessellationResult {
     output.begin_geometry();
 

--- a/crates/tessellation/src/basic_shapes.rs
+++ b/crates/tessellation/src/basic_shapes.rs
@@ -4,7 +4,7 @@ use crate::{
     FillGeometryBuilder, FillOptions, FillVertex, TessellationError, TessellationResult, VertexId,
 };
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 pub fn fill_rectangle(rect: &Box2D, output: &mut dyn FillGeometryBuilder) -> TessellationResult {
     output.begin_geometry();

--- a/crates/tessellation/src/error.rs
+++ b/crates/tessellation/src/error.rs
@@ -1,0 +1,133 @@
+/// The fill tessellator's result type.
+pub type TessellationResult = Result<(), TessellationError>;
+
+/// An error that can happen while generating geometry.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GeometryBuilderError {
+    InvalidVertex,
+    TooManyVertices,
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Display for GeometryBuilderError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            GeometryBuilderError::InvalidVertex => {
+                std::write!(f, "Invalid vertex")
+            },
+            GeometryBuilderError::TooManyVertices => {
+                std::write!(f, "Too many vertices")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for GeometryBuilderError {}
+
+/// Describes an unexpected error happening during tessellation.
+///
+/// If you run into one of these, please consider
+/// [filing an issue](https://github.com/nical/lyon/issues/new).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum InternalError {
+    IncorrectActiveEdgeOrder(i16),
+    InsufficientNumberOfSpans,
+    InsufficientNumberOfEdges,
+    MergeVertexOutside,
+    InvalidNumberOfEdgesBelowVertex,
+    ErrorCode(i16),
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Display for InternalError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            InternalError::IncorrectActiveEdgeOrder(i) => {
+                std::write!(f, "Incorrect active edge order ({i})")
+            },
+            InternalError::InsufficientNumberOfSpans => {
+                std::write!(f, "Insufficient number of spans")
+            },
+            InternalError::InsufficientNumberOfEdges => {
+                std::write!(f, "Insufficient number of edges")
+            },
+            InternalError::MergeVertexOutside => {
+                std::write!(f, "Merge vertex is outside of the shape")
+            },
+            InternalError::InvalidNumberOfEdgesBelowVertex => {
+                std::write!(f, "Unexpected number of edges below a vertex")
+            },
+            InternalError::ErrorCode(i) => {
+                std::write!(f, "Error code: #{i}")
+            },
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InternalError {}
+
+/// The fill tessellator's error enumeration.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TessellationError {
+    // TODO Parameter typo
+    UnsupportedParamater(UnsupportedParamater),
+    GeometryBuilder(GeometryBuilderError),
+    Internal(InternalError),
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Display for TessellationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TessellationError::UnsupportedParamater(e) => {
+                std::write!(f, "Unsupported parameter: {e}")
+            },
+            TessellationError::GeometryBuilder(e) => {
+                std::write!(f, "Geometry builder error: {e}")
+            },
+            TessellationError::Internal(e) => {
+                std::write!(f, "Internal error: {e}")
+            },
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TessellationError {}
+
+impl core::convert::From<GeometryBuilderError> for TessellationError {
+    fn from(value: GeometryBuilderError) -> Self {
+        Self::GeometryBuilder(value)
+    }
+}
+
+impl core::convert::From<InternalError> for TessellationError {
+    fn from(value: InternalError) -> Self {
+        Self::Internal(value)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum UnsupportedParamater {
+    PositionIsNaN,
+    ToleranceIsNaN,
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Display for UnsupportedParamater {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            UnsupportedParamater::PositionIsNaN => {
+                std::write!(f, "Position is not a number")
+            },
+            UnsupportedParamater::ToleranceIsNaN => {
+                std::write!(f, "Tolerance threshold is not a number")
+            },
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnsupportedParamater {}

--- a/crates/tessellation/src/event_queue.rs
+++ b/crates/tessellation/src/event_queue.rs
@@ -5,9 +5,10 @@ use crate::path::private::DebugValidator;
 use crate::path::{EndpointId, IdEvent, PathEvent, PositionStore};
 use crate::Orientation;
 
-use std::cmp::Ordering;
-use std::mem::swap;
-use std::ops::Range;
+use core::cmp::Ordering;
+use core::mem::swap;
+use core::ops::Range;
+use alloc::vec::Vec;
 
 #[inline]
 fn reorient(p: Point) -> Point {
@@ -27,7 +28,7 @@ pub(crate) struct Event {
 #[derive(Clone, Debug)]
 pub(crate) struct EdgeData {
     pub to: Point,
-    pub range: std::ops::Range<f32>,
+    pub range: core::ops::Range<f32>,
     pub winding: i16,
     pub is_edge: bool,
     pub from_id: EndpointId,
@@ -412,26 +413,26 @@ impl EventQueue {
         current_sibling
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, feature = "std"))]
     fn log(&self) {
         let mut iter_count = self.events.len() * self.events.len();
 
-        println!("--");
+        std::println!("--");
         let mut current = self.first;
         while (current as usize) < self.events.len() {
             assert!(iter_count > 0);
             iter_count -= 1;
 
-            print!("[");
+            std::print!("[");
             let mut current_sibling = current;
             while (current_sibling as usize) < self.events.len() {
-                print!("{:?},", self.events[current_sibling as usize].position);
+                std::print!("{:?},", self.events[current_sibling as usize].position);
                 current_sibling = self.events[current_sibling as usize].next_sibling;
             }
-            print!("]  ");
+            std::print!("]  ");
             current = self.events[current as usize].next_event;
         }
-        println!("\n--");
+        std::println!("\n--");
     }
 
     fn assert_sorted(&self) {

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -21,7 +21,7 @@ use core::ops::Range;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, feature = "std"))]
 use std::env;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -21,6 +21,9 @@ use core::ops::Range;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 #[cfg(all(debug_assertions, feature = "std"))]
 use std::env;
 

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -24,9 +24,6 @@ use alloc::vec::Vec;
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
 
-#[cfg(all(debug_assertions, feature = "std"))]
-use std::env;
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Side {
     Left,
@@ -550,8 +547,8 @@ impl Default for FillTessellator {
 impl FillTessellator {
     /// Constructor.
     pub fn new() -> Self {
-        #[cfg(debug_assertions)]
-        let log = env::var("LYON_FORCE_LOGGING").is_ok();
+        #[cfg(all(debug_assertions, feature = "std"))]
+        let log = std::env::var("LYON_FORCE_LOGGING").is_ok();
         #[cfg(not(debug_assertions))]
         let log = false;
 
@@ -813,8 +810,8 @@ impl FillTessellator {
     /// Enable/disable some verbose logging during the tessellation, for
     /// debugging purposes.
     pub fn set_logging(&mut self, is_enabled: bool) {
-        #[cfg(debug_assertions)]
-        let forced = env::var("LYON_FORCE_LOGGING").is_ok();
+        #[cfg(all(debug_assertions, feature = "std"))]
+        let forced = std::env::var("LYON_FORCE_LOGGING").is_ok();
 
         #[cfg(not(debug_assertions))]
         let forced = false;

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -549,7 +549,7 @@ impl FillTessellator {
     pub fn new() -> Self {
         #[cfg(all(debug_assertions, feature = "std"))]
         let log = std::env::var("LYON_FORCE_LOGGING").is_ok();
-        #[cfg(not(debug_assertions))]
+        #[cfg(not(all(debug_assertions, feature = "std")))]
         let log = false;
 
         FillTessellator {
@@ -813,7 +813,7 @@ impl FillTessellator {
         #[cfg(all(debug_assertions, feature = "std"))]
         let forced = std::env::var("LYON_FORCE_LOGGING").is_ok();
 
-        #[cfg(not(debug_assertions))]
+        #[cfg(not(all(debug_assertions, feature = "std")))]
         let forced = false;
 
         self.log = is_enabled || forced;

--- a/crates/tessellation/src/fill_tests.rs
+++ b/crates/tessellation/src/fill_tests.rs
@@ -4,8 +4,8 @@ use crate::math::*;
 use crate::path::{Path, PathSlice};
 use crate::{FillOptions, FillRule, FillTessellator, FillVertex, TessellationError, VertexId};
 
-use std::env;
-use std::f32::consts::PI;
+use core::f32::consts::PI;
+use alloc::vec::Vec;
 
 fn tessellate(path: PathSlice, fill_rule: FillRule, log: bool) -> Result<usize, TessellationError> {
     let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
@@ -77,23 +77,26 @@ fn test_too_many_vertices() {
     );
 }
 
+#[cfg(test)]
 fn test_path(path: PathSlice) {
     test_path_internal(path, FillRule::EvenOdd, None);
     test_path_internal(path, FillRule::NonZero, None);
 }
 
+#[cfg(test)]
 fn test_path_and_count_triangles(path: PathSlice, expected_triangle_count: usize) {
     test_path_internal(path, FillRule::EvenOdd, Some(expected_triangle_count));
     test_path_internal(path, FillRule::NonZero, None);
 }
 
+#[cfg(test)]
 fn test_path_internal(
     path: PathSlice,
     fill_rule: FillRule,
     expected_triangle_count: Option<usize>,
 ) {
-    let add_logging = env::var("LYON_ENABLE_LOGGING").is_ok();
-    let find_test_case = env::var("LYON_REDUCED_TESTCASE").is_ok();
+    let add_logging = std::env::var("LYON_ENABLE_LOGGING").is_ok();
+    let find_test_case = std::env::var("LYON_REDUCED_TESTCASE").is_ok();
 
     let res = if find_test_case {
         ::std::panic::catch_unwind(|| tessellate(path, fill_rule, false))
@@ -127,6 +130,7 @@ fn test_path_internal(
     panic!("Test failed with fill rule {:?}.", fill_rule);
 }
 
+#[cfg(test)]
 fn test_path_with_rotations(path: Path, step: f32, expected_triangle_count: Option<usize>) {
     let mut angle = Angle::radians(0.0);
     while angle.radians < PI * 2.0 {
@@ -799,7 +803,7 @@ fn angle_precision() {
 
 #[test]
 fn n_segments_intersecting() {
-    use std::f32::consts::PI;
+    use core::f32::consts::PI;
 
     // This test creates a lot of segments that intersect at the same
     // position (center). Very good at finding precision issues.

--- a/crates/tessellation/src/geometry_builder.rs
+++ b/crates/tessellation/src/geometry_builder.rs
@@ -192,8 +192,9 @@
 use crate::math::Point;
 use crate::{FillVertex, Index, StrokeVertex, VertexId};
 
-use std::convert::From;
-use std::ops::Add;
+use core::convert::From;
+use core::ops::Add;
+use alloc::vec::Vec;
 use thiserror::Error;
 
 /// An error that can happen while generating geometry.
@@ -448,8 +449,9 @@ where
     }
 
     fn add_triangle(&mut self, a: VertexId, b: VertexId, c: VertexId) {
+        #[cfg(feature = "std")]
         if a == b || a == c || b == c {
-            println!("bad triangle {a:?} {b:?} {c:?}");
+            std::println!("bad triangle {a:?} {b:?} {c:?}");
         }
         debug_assert!(a != b);
         debug_assert!(a != c);

--- a/crates/tessellation/src/geometry_builder.rs
+++ b/crates/tessellation/src/geometry_builder.rs
@@ -191,20 +191,11 @@
 
 use crate::math::Point;
 use crate::{FillVertex, Index, StrokeVertex, VertexId};
+pub use crate::error::GeometryBuilderError;
 
 use core::convert::From;
 use core::ops::Add;
 use alloc::vec::Vec;
-use thiserror::Error;
-
-/// An error that can happen while generating geometry.
-#[derive(Error, Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum GeometryBuilderError {
-    #[error("Invalid vertex")]
-    InvalidVertex,
-    #[error("Too many vertices")]
-    TooManyVertices,
-}
 
 /// An interface separating tessellators and other geometry generation algorithms from the
 /// actual vertex construction.

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -198,6 +198,7 @@ use lyon_extra as extra;
 pub extern crate serde;
 
 mod basic_shapes;
+mod error;
 mod event_queue;
 mod fill;
 pub mod geometry_builder;
@@ -232,56 +233,15 @@ pub use crate::geometry_builder::{
     GeometryBuilderError, StrokeGeometryBuilder, StrokeVertexConstructor, VertexBuffers,
 };
 
+#[doc(inline)]
+pub use crate::error::*;
+
 pub use crate::path::{AttributeIndex, Attributes, FillRule, LineCap, LineJoin, Side};
 
 use crate::path::EndpointId;
 
 use core::ops::{Add, Sub};
 use alloc::vec::Vec;
-use thiserror::Error;
-
-/// The fill tessellator's result type.
-pub type TessellationResult = Result<(), TessellationError>;
-
-/// Describes an unexpected error happening during tessellation.
-///
-/// If you run into one of these, please consider
-/// [filing an issue](https://github.com/nical/lyon/issues/new).
-#[derive(Error, Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum InternalError {
-    #[error("Incorrect active edge order ({0})")]
-    IncorrectActiveEdgeOrder(i16),
-    #[error("Insufficient number of spans")]
-    InsufficientNumberOfSpans,
-    #[error("Insufficient number of edges")]
-    InsufficientNumberOfEdges,
-    #[error("Merge vertex is outside of the shape")]
-    MergeVertexOutside,
-    #[error("Unexpected number of edges below a vertex")]
-    InvalidNumberOfEdgesBelowVertex,
-    #[error("Error code: #{0}")]
-    ErrorCode(i16),
-}
-
-/// The fill tessellator's error enumeration.
-#[derive(Error, Clone, Debug, PartialEq)]
-pub enum TessellationError {
-    // TODO Parameter typo
-    #[error("Unsupported parameter: {0}")]
-    UnsupportedParamater(UnsupportedParamater),
-    #[error("Geometry builder error: {0}")]
-    GeometryBuilder(#[from] GeometryBuilderError),
-    #[error("Internal error: {0}")]
-    Internal(#[from] InternalError),
-}
-
-#[derive(Error, Clone, Debug, PartialEq)]
-pub enum UnsupportedParamater {
-    #[error("Position is not a number")]
-    PositionIsNaN,
-    #[error("Tolerance threshold is not a number")]
-    ToleranceIsNaN,
-}
 
 /// Before or After. Used to describe position relative to a join.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -3,6 +3,8 @@
 #![deny(unconditional_recursion)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::too_many_arguments)]
+#![no_std]
+
 // TODO: Tessellation pipeline diagram needs to be updated.
 
 //! Tessellation of 2D fill and stroke operations.
@@ -181,6 +183,11 @@
 #![allow(dead_code)]
 //#![allow(needless_return, new_without_default_derive)] // clippy
 
+extern crate alloc;
+
+#[cfg(any(test, feature = "std"))]
+extern crate std;
+
 pub use lyon_path as path;
 
 #[cfg(test)]
@@ -229,7 +236,8 @@ pub use crate::path::{AttributeIndex, Attributes, FillRule, LineCap, LineJoin, S
 
 use crate::path::EndpointId;
 
-use std::ops::{Add, Sub};
+use core::ops::{Add, Sub};
+use alloc::vec::Vec;
 use thiserror::Error;
 
 /// The fill tessellator's result type.

--- a/crates/tessellation/src/math_utils.rs
+++ b/crates/tessellation/src/math_utils.rs
@@ -2,6 +2,9 @@
 
 use crate::math::*;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 /// Compute a normal vector at a point P such that ```x ---e1----> P ---e2---> x```
 ///
 /// The resulting vector is not normalized. The length is such that extruding the shape

--- a/crates/tessellation/src/monotone.rs
+++ b/crates/tessellation/src/monotone.rs
@@ -2,6 +2,8 @@ use crate::fill::{is_after, Side};
 use crate::math::{point, Point};
 use crate::{FillGeometryBuilder, VertexId};
 
+use alloc::vec::Vec;
+
 /// Helper class that generates a triangulation from a sequence of vertices describing a monotone
 /// polygon (used internally by the `FillTessellator`).
 pub(crate) struct BasicMonotoneTessellator {
@@ -69,7 +71,7 @@ impl BasicMonotoneTessellator {
                 let winding = (a.pos - b.pos).cross(current.pos - b.pos) >= 0.0;
 
                 if !winding {
-                    std::mem::swap(&mut a, &mut b);
+                    core::mem::swap(&mut a, &mut b);
                 }
 
                 self.push_triangle(&a, &b, &current);
@@ -83,7 +85,7 @@ impl BasicMonotoneTessellator {
                 let mut b = *self.stack.last().unwrap();
 
                 if current.side.is_right() {
-                    std::mem::swap(&mut a, &mut b);
+                    core::mem::swap(&mut a, &mut b);
                 }
 
                 let cross = (current.pos - b.pos).cross(a.pos - b.pos);
@@ -138,7 +140,7 @@ impl BasicMonotoneTessellator {
 
 #[test]
 fn test_monotone_tess() {
-    println!(" ------------ ");
+    std::println!(" ------------ ");
     {
         let mut tess = BasicMonotoneTessellator::new();
         tess.begin(point(0.0, 0.0), VertexId(0));
@@ -146,7 +148,7 @@ fn test_monotone_tess() {
         tess.end(point(1.0, 2.0), VertexId(2));
         assert_eq!(tess.triangles.len(), 1);
     }
-    println!(" ------------ ");
+    std::println!(" ------------ ");
     {
         let mut tess = BasicMonotoneTessellator::new();
         tess.begin(point(0.0, 0.0), VertexId(0));
@@ -157,7 +159,7 @@ fn test_monotone_tess() {
         tess.end(point(0.0, 5.0), VertexId(5));
         assert_eq!(tess.triangles.len(), 4);
     }
-    println!(" ------------ ");
+    std::println!(" ------------ ");
     {
         let mut tess = BasicMonotoneTessellator::new();
         tess.begin(point(0.0, 0.0), VertexId(0));
@@ -169,7 +171,7 @@ fn test_monotone_tess() {
         tess.end(point(0.0, 6.0), VertexId(6));
         assert_eq!(tess.triangles.len(), 5);
     }
-    println!(" ------------ ");
+    std::println!(" ------------ ");
     {
         let mut tess = BasicMonotoneTessellator::new();
         tess.begin(point(0.0, 0.0), VertexId(0));
@@ -181,7 +183,7 @@ fn test_monotone_tess() {
         tess.end(point(0.0, 6.0), VertexId(6));
         assert_eq!(tess.triangles.len(), 5);
     }
-    println!(" ------------ ");
+    std::println!(" ------------ ");
 }
 
 struct SideEvents {
@@ -340,7 +342,7 @@ impl AdvancedMonotoneTessellator {
             }
             (Some(mut v1), Some(mut v2)) => {
                 if is_after(v1.pos, v2.pos) {
-                    std::mem::swap(&mut v1, &mut v2);
+                    core::mem::swap(&mut v1, &mut v2);
                 }
                 self.tess.monotone_vertex(v1);
                 self.tess.monotone_vertex(v2);
@@ -376,7 +378,7 @@ fn flush_side(
             let mut b = a + step;
             last_index = b + step;
             if s == Side::Right {
-                std::mem::swap(&mut a, &mut b);
+                core::mem::swap(&mut a, &mut b);
             }
             tess.push_triangle_ids(side.events[a], side.events[b], side.events[last_index]);
         }
@@ -385,7 +387,7 @@ fn flush_side(
             let mut b = last_index;
             let mut c = last_index + step;
             if s == Side::Right {
-                std::mem::swap(&mut b, &mut c);
+                core::mem::swap(&mut b, &mut c);
             }
 
             tess.push_triangle_ids(side.events[0], side.events[b], side.events[c]);

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -16,7 +16,9 @@ use crate::{
     LineCap, LineJoin, Side, SimpleAttributeStore, StrokeGeometryBuilder, StrokeOptions,
     TessellationError, TessellationResult, VertexId, VertexSource,
 };
-use std::f32::consts::PI;
+
+use core::f32::consts::PI;
+use alloc::vec::Vec;
 
 const SIDE_POSITIVE: usize = 0;
 const SIDE_NEGATIVE: usize = 1;
@@ -1980,8 +1982,8 @@ fn tessellate_round_join(
 
     if side == SIDE_NEGATIVE {
         // Flip to keep consistent winding order.
-        std::mem::swap(&mut start_angle, &mut end_angle);
-        std::mem::swap(&mut start_vertex, &mut end_vertex);
+        core::mem::swap(&mut start_angle, &mut end_angle);
+        core::mem::swap(&mut start_vertex, &mut end_vertex);
     }
 
     // Compute the required number of subdivisions,

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -20,6 +20,9 @@ use crate::{
 use core::f32::consts::PI;
 use alloc::vec::Vec;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 const SIDE_POSITIVE: usize = 0;
 const SIDE_NEGATIVE: usize = 1;
 


### PR DESCRIPTION
- Removed `lyon_tessellation` rigid dependency on default features from `lyon_path`
- Added new crate feature `std`, enabled by default, which enables `std` feature of `lyon_path` dependency
- Replaced imports from `std` with their corresponding imports from `alloc` and `core`
- Required enabling feature `std` to display printed debug assertions
- Annotated some test functions with `#[cfg(test)]` to be explicit about their dependence on `std`

