### PR TITLE
Fix overly strict CubicBezierSegment::is_linear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_geom"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "arrayvec 0.7.1",
  "euclid",

--- a/crates/geom/Cargo.toml
+++ b/crates/geom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_geom"
-version = "1.0.4"
+version = "1.0.5"
 description = "2D quadratic and cubic bézier arcs and line segment math on top of euclid."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"


### PR DESCRIPTION
A factor was missing, causing the function to be more conservative than it should be.