### PR TITLE
Fix PathBuffer::clear not clearing its path list

### DIFF
--- a/crates/path/Cargo.toml
+++ b/crates/path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_path"
-version = "1.0.4"
+version = "1.0.5"
 description = "Types and utilities to store, build and iterate over 2D paths."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"

--- a/crates/path/src/path_buffer.rs
+++ b/crates/path/src/path_buffer.rs
@@ -94,6 +94,7 @@ impl PathBuffer {
     pub fn clear(&mut self) {
         self.points.clear();
         self.verbs.clear();
+        self.paths.clear();
     }
 
     #[inline]


### PR DESCRIPTION
Found this while trying to cache a PathBuffer for reuse.

Without this change, clearing will leave PathBuffer in an invalid state, with `paths` containing stale indices. Any subsequent paths added will either reference incorrect `points` and `verbs` or panic trying to reach out of bounds.

Or in my case panic when the paths I'm building change shape.