### PR TITLE
Use `f64` when approximating SVG arcs with quadratic beziers

### DIFF
--- a/crates/geom/src/arc.rs
+++ b/crates/geom/src/arc.rs
@@ -3,6 +3,8 @@
 use core::mem::swap;
 use core::ops::Range;
 
+use num_traits::NumCast;
+
 use crate::scalar::{cast, Float, Scalar};
 use crate::segment::{BoundingBox, Segment};
 use crate::{point, vector, Angle, Box2D, Point, Rotation, Transform, Vector};
@@ -31,6 +33,16 @@ pub struct SvgArc<S> {
 }
 
 impl<S: Scalar> Arc<S> {
+    pub fn cast<NewS: NumCast>(self) -> Arc<NewS> {
+        Arc {
+            center: self.center.cast(),
+            radii: self.radii.cast(),
+            start_angle: self.start_angle.cast(),
+            sweep_angle: self.sweep_angle.cast(),
+            x_rotation: self.x_rotation.cast(),
+        }
+    }
+
     /// Create simple circle.
     pub fn circle(center: Point<S>, radius: S) -> Self {
         Arc {

--- a/crates/geom/src/quadratic_bezier.rs
+++ b/crates/geom/src/quadratic_bezier.rs
@@ -4,6 +4,7 @@ use crate::traits::Transformation;
 use crate::{point, Box2D, Point, Vector};
 use crate::{CubicBezierSegment, Line, LineEquation, LineSegment, Triangle};
 use arrayvec::ArrayVec;
+use num_traits::NumCast;
 
 use core::mem;
 use core::ops::Range;
@@ -22,6 +23,14 @@ pub struct QuadraticBezierSegment<S> {
 }
 
 impl<S: Scalar> QuadraticBezierSegment<S> {
+    pub fn cast<NewS: NumCast>(self) -> QuadraticBezierSegment<NewS> {
+        QuadraticBezierSegment {
+            from: self.from.cast(),
+            ctrl: self.ctrl.cast(),
+            to: self.to.cast(),
+        }
+    }
+
     /// Sample the curve at t (expecting t between 0 and 1).
     pub fn sample(&self, t: S) -> Point<S> {
         let t2 = t * t;

--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -1303,7 +1303,8 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
             self.builder.line_to(arc_start, &self.attribute_buffer);
         }
 
-        arc.for_each_quadratic_bezier(&mut |curve| {
+        arc.cast::<f64>().for_each_quadratic_bezier(&mut |curve| {
+            let curve = curve.cast::<f32>();
             self.builder
                 .quadratic_bezier_to(curve.ctrl, curve.to, &self.attribute_buffer);
             self.current_position = curve.to;


### PR DESCRIPTION
Helps with #910. This is not a definitive nor general fix, but at least for now avoids the issue when tesselating SVG paths.