### PR TITLE
Fix double close in the parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "lyon_extra"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "lyon_path",
  "thiserror",

--- a/crates/extra/Cargo.toml
+++ b/crates/extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lyon_extra"
-version = "1.0.2"
+version = "1.0.3"
 description = "Various optional utilities for the lyon crate."
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/lyon"

--- a/crates/extra/src/parser.rs
+++ b/crates/extra/src/parser.rs
@@ -307,6 +307,7 @@ impl PathParser {
                 'm' | 'M' => {
                     if self.need_end {
                         output.end(false);
+                        self.need_end = false;
                     }
 
                     let to = self.parse_endpoint(is_relative, src)?;
@@ -752,4 +753,15 @@ fn issue_895() {
     parse("M 1.e-9 1.4e-4z").unwrap();
     parse("M 1.6e-9 1.4e-4 z").unwrap();
     parse("M0 1.6e-9L0 1.4e-4").unwrap();
+}
+
+#[test]
+fn issue_919() {
+    let mut builder = lyon_path::Path::builder();
+    let mut parser = PathParser::new();
+    let _ = parser.parse(
+        &ParserOptions::DEFAULT,
+        &mut Source::new("0 0M".chars()),
+        &mut builder,
+    );
 }


### PR DESCRIPTION
The problem happens if parsing the endpoint fails in a move-to command.

Fixes #919 