### PR TITLE
Fix incorrect miter clip length

### DIFF
--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -1723,7 +1723,7 @@ fn compute_join_side_positions_fixed_width(
             let n0 = join.side_points[front_side].prev - join.position;
             let n1 = join.side_points[front_side].next - join.position;
             let (prev_normal, next_normal) =
-                get_clip_intersections(n0, n1, front_normal, miter_limit * 2.0 * vertex.half_width);
+                get_clip_intersections(n0, n1, front_normal, miter_limit * vertex.half_width);
             join.side_points[front_side].prev = join.position + prev_normal;
             join.side_points[front_side].next = join.position + next_normal;
         }
@@ -2118,7 +2118,7 @@ fn compute_join_side_positions(
         let n0 = join.side_points[side].prev - join.position;
         let n1 = join.side_points[side].next - join.position;
         let (prev_normal, next_normal) =
-            get_clip_intersections(n0, n1, normal, miter_limit * 2.0 * join.half_width);
+            get_clip_intersections(n0, n1, normal, miter_limit * join.half_width);
         join.side_points[side].prev = join.position + prev_normal;
         join.side_points[side].next = join.position + next_normal;
         nan_check!(n0, n1, prev_normal, next_normal);
@@ -3409,7 +3409,8 @@ fn correct_miter_clip_length() {
         .unwrap();
 
     // miter_length =  line_width * miter_limit
-    let expected_max_y = path_max_y + line_width * miter_limit;
+    // miter_clip = miter_length * 0.5
+    let expected_max_y = path_max_y + line_width * miter_limit * 0.5;
 
     assert_eq!(expected_max_y, max_y);
 }

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -1723,7 +1723,7 @@ fn compute_join_side_positions_fixed_width(
             let n0 = join.side_points[front_side].prev - join.position;
             let n1 = join.side_points[front_side].next - join.position;
             let (prev_normal, next_normal) =
-                get_clip_intersections(n0, n1, front_normal, miter_limit * 0.5 * vertex.half_width);
+                get_clip_intersections(n0, n1, front_normal, miter_limit * 2.0 * vertex.half_width);
             join.side_points[front_side].prev = join.position + prev_normal;
             join.side_points[front_side].next = join.position + next_normal;
         }
@@ -2118,7 +2118,7 @@ fn compute_join_side_positions(
         let n0 = join.side_points[side].prev - join.position;
         let n1 = join.side_points[side].next - join.position;
         let (prev_normal, next_normal) =
-            get_clip_intersections(n0, n1, normal, miter_limit * 0.5 * join.half_width);
+            get_clip_intersections(n0, n1, normal, miter_limit * 2.0 * join.half_width);
         join.side_points[side].prev = join.position + prev_normal;
         join.side_points[side].next = join.position + next_normal;
         nan_check!(n0, n1, prev_normal, next_normal);


### PR DESCRIPTION
If I'm understanding it correctly `MiterClip` should clip at a distance of the miter limit multiplied by the stroke width, but at the moment it actually clips to a quarter of this because the half width is being halved again instead of doubled in the clip distance calculation.

Possibly related to #923 but I could not reproduce the bug exactly as described (falling back to bevel as opposed to just getting the clip length wrong).

Before fix:
![miter-limit-bug-before](https://github.com/user-attachments/assets/8f1c8bad-7edd-4f38-b38b-38d6c86f1680)

After fix:
![miter-limit-bug-after](https://github.com/user-attachments/assets/7e4b9ede-89f0-4b11-a628-43860bd16bfa)
