### PR TITLE
Use a more precise method to approximate elliptical arcs with quads

### DIFF
--- a/crates/path/src/builder.rs
+++ b/crates/path/src/builder.rs
@@ -1303,8 +1303,7 @@ impl<Builder: PathBuilder> WithSvg<Builder> {
             self.builder.line_to(arc_start, &self.attribute_buffer);
         }
 
-        arc.cast::<f64>().for_each_quadratic_bezier(&mut |curve| {
-            let curve = curve.cast::<f32>();
+        arc.for_each_quadratic_bezier(&mut |curve| {
             self.builder
                 .quadratic_bezier_to(curve.ctrl, curve.to, &self.attribute_buffer);
             self.current_position = curve.to;


### PR DESCRIPTION
Fixes #910 

The previous version used a line intersection which suffers a lot from float precision. The new version is based on the math from Maisonobe's paper "Drawing an elliptical arc using polylines, quadratic or cubic Bézier curves".