### PR TITLE
Fix some vertex index overflow issues in geometry builders

### DIFF
--- a/crates/tessellation/src/geometry_builder.rs
+++ b/crates/tessellation/src/geometry_builder.rs
@@ -334,6 +334,20 @@ impl<'l, OutputVertex: 'l, OutputIndex: 'l, Ctor>
     pub fn buffers<'a, 'b: 'a>(&'b self) -> &'a VertexBuffers<OutputVertex, OutputIndex> {
         self.buffers
     }
+
+    fn add_vertex_impl(&mut self, vertex: OutputVertex) -> Result<VertexId, GeometryBuilderError>
+    where
+        OutputIndex: MaxIndex
+    {
+        let len = self.buffers.vertices.len();
+        let id = len
+            .checked_add(self.vertex_offset as usize)
+            .filter(|i| *i <= OutputIndex::MAX)
+            .ok_or(GeometryBuilderError::TooManyVertices)?;
+
+        self.buffers.vertices.push(vertex);
+        Ok(VertexId(id as Index))
+    }
 }
 
 /// A wrapper for stroke and fill geometry builders that inverts the triangle face winding.
@@ -456,9 +470,9 @@ where
         debug_assert!(a != VertexId::INVALID);
         debug_assert!(b != VertexId::INVALID);
         debug_assert!(c != VertexId::INVALID);
-        self.buffers.indices.push((a + self.vertex_offset).into());
-        self.buffers.indices.push((b + self.vertex_offset).into());
-        self.buffers.indices.push((c + self.vertex_offset).into());
+        self.buffers.indices.push(a.into());
+        self.buffers.indices.push(b.into());
+        self.buffers.indices.push(c.into());
     }
 
     fn abort_geometry(&mut self) {
@@ -474,15 +488,9 @@ where
     OutputIndex: Add + From<VertexId> + MaxIndex,
     Ctor: FillVertexConstructor<OutputVertex>,
 {
-    fn add_fill_vertex(&mut self, vertex: FillVertex) -> Result<VertexId, GeometryBuilderError> {
-        self.buffers
-            .vertices
-            .push(self.vertex_constructor.new_vertex(vertex));
-        let len = self.buffers.vertices.len();
-        if len > OutputIndex::MAX {
-            return Err(GeometryBuilderError::TooManyVertices);
-        }
-        Ok(VertexId((len - 1) as Index))
+    fn add_fill_vertex(&mut self, v: FillVertex) -> Result<VertexId, GeometryBuilderError> {
+        let v = self.vertex_constructor.new_vertex(v);
+        self.add_vertex_impl(v)
     }
 }
 
@@ -494,14 +502,8 @@ where
     Ctor: StrokeVertexConstructor<OutputVertex>,
 {
     fn add_stroke_vertex(&mut self, v: StrokeVertex) -> Result<VertexId, GeometryBuilderError> {
-        self.buffers
-            .vertices
-            .push(self.vertex_constructor.new_vertex(v));
-        let len = self.buffers.vertices.len();
-        if len > OutputIndex::MAX {
-            return Err(GeometryBuilderError::TooManyVertices);
-        }
-        Ok(VertexId((len - 1) as Index))
+        let v = self.vertex_constructor.new_vertex(v);
+        self.add_vertex_impl(v)
     }
 }
 
@@ -591,4 +593,32 @@ impl MaxIndex for usize {
 }
 impl MaxIndex for isize {
     const MAX: usize = u32::MAX as usize;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overflow_with_vertex_offset() {
+        let mut buffers = VertexBuffers::default();
+        let mut builder = simple_builder(&mut buffers).with_vertex_offset(65534);
+        let builder = &mut builder as &mut dyn FillGeometryBuilder;
+
+        let dummy_queue = crate::event_queue::EventQueue::new();
+        let vertex = || crate::fill::FillVertex {
+            position: Point::new(0.0, 0.0),
+            events: &dummy_queue,
+            current_event: crate::event_queue::INVALID_EVENT_ID,
+            attrib_buffer: &mut [],
+            attrib_store: None,
+        };
+
+        builder.begin_geometry();
+        assert_eq!(builder.add_fill_vertex(vertex()), Ok(VertexId(65534)));
+        assert_eq!(builder.add_fill_vertex(vertex()), Ok(VertexId(65535)));
+        assert_eq!(builder.add_fill_vertex(vertex()), Err(GeometryBuilderError::TooManyVertices));
+        builder.abort_geometry();
+        assert!(buffers.vertices.is_empty() && buffers.indices.is_empty());
+    }
 }

--- a/crates/tessellation/src/geometry_builder.rs
+++ b/crates/tessellation/src/geometry_builder.rs
@@ -557,8 +557,8 @@ impl StrokeGeometryBuilder for NoOutput {
 /// Provides the maximum value of an index.
 ///
 /// This should be the maximum value representable by the index type up
-/// to u32::MAX because the tessellators can't internally represent more
-/// than u32::MAX indices.
+/// to `u32::MAX - 1` because the tessellators can't internally represent more
+/// than `u32::MAX - 1` indices.
 pub trait MaxIndex {
     const MAX: usize;
 }
@@ -576,23 +576,30 @@ impl MaxIndex for i16 {
     const MAX: usize = i16::MAX as usize;
 }
 impl MaxIndex for u32 {
-    const MAX: usize = u32::MAX as usize;
+    // u32::MAX is reserved as VertexId::INVALID
+    const MAX: usize = (u32::MAX - 1) as usize;
 }
 impl MaxIndex for i32 {
     const MAX: usize = i32::MAX as usize;
 }
-// The tessellators internally use u32 indices so we can't have more than u32::MAX
 impl MaxIndex for u64 {
-    const MAX: usize = u32::MAX as usize;
+    // The tessellators internally use u32 indices so we can't have more than for u32
+    const MAX: usize = <u32 as MaxIndex>::MAX;
 }
 impl MaxIndex for i64 {
-    const MAX: usize = u32::MAX as usize;
+    const MAX: usize = <u32 as MaxIndex>::MAX;
 }
 impl MaxIndex for usize {
-    const MAX: usize = u32::MAX as usize;
+    #[cfg(target_pointer_width = "64")]
+    const MAX: usize = <u64 as MaxIndex>::MAX;
+    #[cfg(target_pointer_width = "32")]
+    const MAX: usize = <u32 as MaxIndex>::MAX;
 }
 impl MaxIndex for isize {
-    const MAX: usize = u32::MAX as usize;
+    #[cfg(target_pointer_width = "64")]
+    const MAX: usize = <i64 as MaxIndex>::MAX;
+    #[cfg(target_pointer_width = "32")]
+    const MAX: usize = <i32 as MaxIndex>::MAX;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Make sure that using `BuffersBuilder::with_vertex_offset` with large values cannot overflow `OutputVertex` indices.
- Fix `MaxIndex` bounds for `u32, u64, i64, usize, isize`: `VertexId::INVALID` wasn't properly excluded, and `isize` had the entirely wrong value on 32-bit targets.