### PR TITLE
`FillTessellator`: fix vertex attributes along Bezier curves

### DIFF
--- a/crates/tessellation/src/event_queue.rs
+++ b/crates/tessellation/src/event_queue.rs
@@ -782,9 +782,14 @@ impl EventQueueBuilder {
         let mut prev = segment.from;
         let mut first = None;
         let is_first_edge = self.nth == 0;
-        segment.for_each_flattened_with_t(self.tolerance, &mut |line, t| {
+        segment.for_each_flattened_with_t(self.tolerance, &mut |line, mut t| {
             if line.from == line.to {
                 return;
+            }
+
+            if needs_swap {
+                t.start = 1.0 - t.start;
+                t.end = 1.0 - t.end;
             }
 
             if first.is_none() {
@@ -858,9 +863,14 @@ impl EventQueueBuilder {
         let mut prev = segment.from;
         let mut first = None;
         let is_first_edge = self.nth == 0;
-        segment.for_each_flattened_with_t(self.tolerance, &mut |line, t| {
+        segment.for_each_flattened_with_t(self.tolerance, &mut |line, mut t| {
             if line.from == line.to {
                 return;
+            }
+
+            if needs_swap {
+                t.start = 1.0 - t.start;
+                t.end = 1.0 - t.end;
             }
 
             if first.is_none() {

--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -3027,3 +3027,67 @@ fn fill_builder_vertex_source() {
         }
     }
 }
+
+#[test]
+fn fill_bezier_attributes() {
+    // Check attribute values along subdivized bezier curves.
+    //
+    //  *--*   *--*
+    // /    \ /    \
+    // \    / \    /
+    //  *--*   *--*
+    //
+    // attr = 5 * y + 10
+
+    let mut path = crate::path::Path::builder_with_attributes(1);
+    let _ = path.begin(point(1.0, 0.0), &[10.0]);
+    let _ = path.quadratic_bezier_to(point(0.0, 1.5), point(1.0, 3.0), &[25.0]);
+    let _ = path.line_to(point(2.0, 3.0), &[25.0]);
+    let _ = path.quadratic_bezier_to(point(3.0, 1.5), point(2.0, 0.0), &[10.0]);
+    path.end(true);
+    let _ = path.begin(point(5.0, 0.0), &[10.0]);
+    let _ = path.cubic_bezier_to(point(4.0, 1.0), point(4.0, 2.0), point(5.0, 3.0), &[25.0]);
+    let _ = path.line_to(point(6.0, 3.0), &[25.0]);
+    let _ = path.cubic_bezier_to(point(7.0, 2.0), point(7.0, 1.0), point(6.0, 0.0), &[10.0]);
+    path.end(true);
+
+    let path = path.build();
+
+    let mut tess = FillTessellator::new();
+    tess.tessellate_with_ids(
+        path.id_iter(),
+        &path,
+        Some(&path),
+        &FillOptions::default(),
+        &mut CheckAttributes { next_vertex: 0 },
+    )
+    .unwrap();
+
+    struct CheckAttributes {
+        next_vertex: u32,
+    }
+
+    impl GeometryBuilder for CheckAttributes {
+        fn add_triangle(&mut self, _: VertexId, _: VertexId, _: VertexId) {}
+    }
+
+    impl FillGeometryBuilder for CheckAttributes {
+        fn add_fill_vertex(
+            &mut self,
+            mut vertex: FillVertex,
+        ) -> Result<VertexId, GeometryBuilderError> {
+            let pos = vertex.position();
+
+            let expected = 5.0 * pos.y + 10.0;
+            let actual = vertex.interpolated_attributes()[0];
+            if (actual - expected).abs() > 0.0001 {
+                panic!("at pos {:?}, expected = {}, actual = {}", pos, expected, actual);
+            }
+
+            let id = self.next_vertex;
+            self.next_vertex += 1;
+
+            Ok(VertexId(id))
+        }
+    }
+}


### PR DESCRIPTION
Closes #958.

As explained in the linked issue, when reversing the orientation of a curve in `EventQueueBuilder::{quadratic, cubic}_bezier_segment`, `t` needs to be exchanged with `1-t` to leave the parametrization unchanged.