### PR TITLE
Add SVG 2 arcs joins with optional rounded miter clipping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1227,7 @@ dependencies = [
  "lyon_path",
  "num-traits",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2006,6 +2013,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2070,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/bench/tess/src/arcs.rs
+++ b/bench/tess/src/arcs.rs
@@ -1,0 +1,79 @@
+//! Same-input comparisons with reused tessellator and output allocations.
+
+use bencher::Bencher;
+use lyon::math::{point, Point};
+use lyon::path::Path;
+use lyon::tessellation::geometry_builder::{simple_builder, VertexBuffers};
+use lyon::tessellation::{LineJoin, StrokeOptions, StrokeTessellator};
+
+fn arcs_curved(bench: &mut Bencher) {
+    run(bench, false, LineJoin::Arcs, 4.0);
+}
+
+fn arcs_clipped(bench: &mut Bencher) {
+    run(bench, false, LineJoin::Arcs, 1.5);
+}
+
+fn arcs_lines(bench: &mut Bencher) {
+    run(bench, true, LineJoin::Arcs, 4.0);
+}
+
+fn round_curved(bench: &mut Bencher) {
+    run(bench, false, LineJoin::Round, 4.0);
+}
+
+fn miter_clip_lines(bench: &mut Bencher) {
+    run(bench, true, LineJoin::MiterClip, 4.0);
+}
+
+fn run(bench: &mut Bencher, lines: bool, join: LineJoin, limit: f32) {
+    let path = path(lines);
+    let options = StrokeOptions::default()
+        .with_line_join(join)
+        .with_line_width(8.0)
+        .with_miter_limit(limit)
+        .with_tolerance(0.1);
+    let mut tessellator = StrokeTessellator::new();
+    let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
+    bench.iter(|| {
+        buffers.clear();
+        tessellator
+            .tessellate_path(&path, &options, &mut simple_builder(&mut buffers))
+            .unwrap();
+        buffers.indices.len()
+    });
+}
+
+fn path(lines: bool) -> Path {
+    let mut builder = Path::builder();
+    for i in 0..64 {
+        let x = i as f32 * 40.0;
+        builder.begin(point(x, 0.0));
+        if lines {
+            builder.line_to(point(x + 20.0, 0.0));
+            builder.line_to(point(x + 5.0, 10.0));
+        } else {
+            builder.cubic_bezier_to(
+                point(x + 12.0, -12.0),
+                point(x + 25.0, -8.0),
+                point(x + 20.0, 0.0),
+            );
+            builder.cubic_bezier_to(
+                point(x + 32.0, -4.0),
+                point(x + 36.0, 15.0),
+                point(x + 5.0, 10.0),
+            );
+        }
+        builder.end(false);
+    }
+    builder.build()
+}
+
+benchmark_group!(
+    arcs_tess,
+    arcs_curved,
+    arcs_clipped,
+    arcs_lines,
+    round_curved,
+    miter_clip_lines
+);

--- a/bench/tess/src/arcs.rs
+++ b/bench/tess/src/arcs.rs
@@ -4,32 +4,37 @@ use bencher::Bencher;
 use lyon::math::{point, Point};
 use lyon::path::Path;
 use lyon::tessellation::geometry_builder::{simple_builder, VertexBuffers};
-use lyon::tessellation::{LineJoin, StrokeOptions, StrokeTessellator};
+use lyon::tessellation::{ArcsClip, LineJoin, StrokeOptions, StrokeTessellator};
 
 fn arcs_curved(bench: &mut Bencher) {
-    run(bench, false, LineJoin::Arcs, 4.0);
+    run(bench, false, LineJoin::Arcs, 4.0, ArcsClip::Butt);
 }
 
 fn arcs_clipped(bench: &mut Bencher) {
-    run(bench, false, LineJoin::Arcs, 1.5);
+    run(bench, false, LineJoin::Arcs, 1.5, ArcsClip::Butt);
+}
+
+fn arcs_round_clip(bench: &mut Bencher) {
+    run(bench, false, LineJoin::Arcs, 1.5, ArcsClip::Round);
 }
 
 fn arcs_lines(bench: &mut Bencher) {
-    run(bench, true, LineJoin::Arcs, 4.0);
+    run(bench, true, LineJoin::Arcs, 4.0, ArcsClip::Butt);
 }
 
 fn round_curved(bench: &mut Bencher) {
-    run(bench, false, LineJoin::Round, 4.0);
+    run(bench, false, LineJoin::Round, 4.0, ArcsClip::Butt);
 }
 
 fn miter_clip_lines(bench: &mut Bencher) {
-    run(bench, true, LineJoin::MiterClip, 4.0);
+    run(bench, true, LineJoin::MiterClip, 4.0, ArcsClip::Butt);
 }
 
-fn run(bench: &mut Bencher, lines: bool, join: LineJoin, limit: f32) {
+fn run(bench: &mut Bencher, lines: bool, join: LineJoin, limit: f32, clip: ArcsClip) {
     let path = path(lines);
     let options = StrokeOptions::default()
         .with_line_join(join)
+        .with_arcs_clip(clip)
         .with_line_width(8.0)
         .with_miter_limit(limit)
         .with_tolerance(0.1);
@@ -72,6 +77,7 @@ fn path(lines: bool) -> Path {
 benchmark_group!(
     arcs_tess,
     arcs_curved,
+    arcs_round_clip,
     arcs_clipped,
     arcs_lines,
     round_curved,

--- a/bench/tess/src/main.rs
+++ b/bench/tess/src/main.rs
@@ -2,6 +2,9 @@ extern crate lyon;
 #[macro_use]
 extern crate bencher;
 
+mod arcs;
+use arcs::arcs_tess;
+
 use lyon::extra::rust_logo::build_logo_path;
 use lyon::math::Point;
 use lyon::path::iterator::PathIterator;
@@ -259,4 +262,4 @@ benchmark_group!(
     flattening_03_logo_builder
 );
 
-benchmark_main!(fill_tess, fill_events, stroke_tess, flattening);
+benchmark_main!(fill_tess, fill_events, stroke_tess, flattening, arcs_tess);

--- a/crates/path/src/lib.rs
+++ b/crates/path/src/lib.rs
@@ -203,6 +203,10 @@ pub enum LineJoin {
     /// The bevel shape is a triangle that fills the area between the two stroked
     /// segments.
     Bevel,
+    /// Extend the outer stroke edges with arcs derived from endpoint curvature.
+    ///
+    /// See the [SVG 2 join construction](https://www.w3.org/TR/2018/CR-SVG2-20181004/painting.html#LineJoinShape).
+    Arcs,
 }
 
 /// The positive or negative side of a vector or segment.

--- a/crates/tessellation/Cargo.toml
+++ b/crates/tessellation/Cargo.toml
@@ -29,3 +29,4 @@ num-traits = { version = "0.2.15", default-features = false, features = ["libm"]
 
 [dev-dependencies]
 lyon_extra = { version = "1.0.0", path = "../extra" }
+serde_json = "1.0"

--- a/crates/tessellation/examples/arcs.rs
+++ b/crates/tessellation/examples/arcs.rs
@@ -3,24 +3,29 @@
 
 use lyon_tessellation::path::{math::point, Path};
 use lyon_tessellation::{
-    BuffersBuilder, LineJoin, StrokeOptions, StrokeTessellator, StrokeVertex, VertexBuffers,
+    ArcsClip, BuffersBuilder, LineJoin, StrokeOptions, StrokeTessellator, StrokeVertex,
+    VertexBuffers,
 };
 use std::fmt::Write;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let destination = std::env::args().nth(1).unwrap_or_else(|| "joins.svg".into());
+    let destination = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "joins.svg".into());
     let variants = [
-        ("Round", LineJoin::Round),
-        ("Miter clip", LineJoin::MiterClip),
-        ("SVG 2 arcs", LineJoin::Arcs),
+        ("Round", LineJoin::Round, ArcsClip::Butt),
+        ("Miter clip", LineJoin::MiterClip, ArcsClip::Butt),
+        ("SVG 2 arcs", LineJoin::Arcs, ArcsClip::Butt),
+        ("SVG 2 + round clip", LineJoin::Arcs, ArcsClip::Round),
     ];
     let mut svg = String::from(
-        r##"<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="580" viewBox="0 0 1080 580"><rect width="1080" height="580" fill="#16191d"/><g fill="#edf2f7" font-family="sans-serif">"##,
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="580" viewBox="0 0 1440 580"><rect width="1440" height="580" fill="#16191d"/><g fill="#edf2f7" font-family="sans-serif">"##,
     );
     for (row, (name, path)) in cases().into_iter().enumerate() {
-        for (column, (label, join)) in variants.iter().enumerate() {
+        for (column, (label, join, clip)) in variants.iter().enumerate() {
             let options = StrokeOptions::default()
                 .with_line_join(*join)
+                .with_arcs_clip(*clip)
                 .with_line_width(40.0)
                 .with_miter_limit(1.5)
                 .with_tolerance(0.05);
@@ -32,13 +37,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             )?;
             let x = column * 360;
             let y = row * 280;
-            write!(svg, r#"<g transform="translate({x} {y})"><text x="18" y="26">{label}: {name}</text>"#)?;
+            write!(
+                svg,
+                r#"<g transform="translate({x} {y})"><text x="18" y="26">{label}: {name}</text>"#
+            )?;
+            svg.push_str(r##"<path fill="#40bed3" d=""##);
             for triangle in mesh.indices.chunks_exact(3) {
                 let [a, b, c] = [triangle[0], triangle[1], triangle[2]]
                     .map(|index| mesh.vertices[index as usize]);
-                write!(svg, r##"<path fill="#40bed3" d="M{},{} L{},{} {},{} Z"/>"##, a.x, a.y, b.x, b.y, c.x, c.y)?;
+                write!(
+                    svg,
+                    "M{},{} L{},{} {},{} Z ",
+                    a.x, a.y, b.x, b.y, c.x, c.y
+                )?;
             }
-            svg.push_str("</g>");
+            svg.push_str("\"/></g>");
         }
     }
     svg.push_str("</g></svg>");
@@ -50,13 +63,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn cases() -> Vec<(&'static str, Path)> {
     let mut curved = Path::builder();
     curved.begin(point(40.0, 205.0));
-    curved.cubic_bezier_to(point(175.0, 250.0), point(210.0, 170.0), point(140.0, 110.0));
+    curved.cubic_bezier_to(
+        point(175.0, 250.0),
+        point(210.0, 170.0),
+        point(140.0, 110.0),
+    );
     curved.cubic_bezier_to(point(205.0, 72.0), point(260.0, 80.0), point(320.0, 130.0));
     curved.end(false);
     let mut mixed = Path::builder();
     mixed.begin(point(310.0, 80.0));
     mixed.line_to(point(150.0, 120.0));
-    mixed.cubic_bezier_to(point(260.0, 140.0), point(125.0, 215.0), point(325.0, 225.0));
+    mixed.cubic_bezier_to(
+        point(260.0, 140.0),
+        point(125.0, 215.0),
+        point(325.0, 225.0),
+    );
     mixed.end(false);
     vec![("curved", curved.build()), ("line / curve", mixed.build())]
 }

--- a/crates/tessellation/examples/arcs.rs
+++ b/crates/tessellation/examples/arcs.rs
@@ -1,0 +1,62 @@
+//! Generate a mesh-rendered join comparison, without browser arcs support.
+//! cargo run -p lyon_tessellation --example arcs -- joins.svg
+
+use lyon_tessellation::path::{math::point, Path};
+use lyon_tessellation::{
+    BuffersBuilder, LineJoin, StrokeOptions, StrokeTessellator, StrokeVertex, VertexBuffers,
+};
+use std::fmt::Write;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let destination = std::env::args().nth(1).unwrap_or_else(|| "joins.svg".into());
+    let variants = [
+        ("Round", LineJoin::Round),
+        ("Miter clip", LineJoin::MiterClip),
+        ("SVG 2 arcs", LineJoin::Arcs),
+    ];
+    let mut svg = String::from(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="580" viewBox="0 0 1080 580"><rect width="1080" height="580" fill="#16191d"/><g fill="#edf2f7" font-family="sans-serif">"##,
+    );
+    for (row, (name, path)) in cases().into_iter().enumerate() {
+        for (column, (label, join)) in variants.iter().enumerate() {
+            let options = StrokeOptions::default()
+                .with_line_join(*join)
+                .with_line_width(40.0)
+                .with_miter_limit(1.5)
+                .with_tolerance(0.05);
+            let mut mesh: VertexBuffers<_, u32> = VertexBuffers::new();
+            StrokeTessellator::new().tessellate_path(
+                &path,
+                &options,
+                &mut BuffersBuilder::new(&mut mesh, |v: StrokeVertex| v.position()),
+            )?;
+            let x = column * 360;
+            let y = row * 280;
+            write!(svg, r#"<g transform="translate({x} {y})"><text x="18" y="26">{label}: {name}</text>"#)?;
+            for triangle in mesh.indices.chunks_exact(3) {
+                let [a, b, c] = [triangle[0], triangle[1], triangle[2]]
+                    .map(|index| mesh.vertices[index as usize]);
+                write!(svg, r##"<path fill="#40bed3" d="M{},{} L{},{} {},{} Z"/>"##, a.x, a.y, b.x, b.y, c.x, c.y)?;
+            }
+            svg.push_str("</g>");
+        }
+    }
+    svg.push_str("</g></svg>");
+    std::fs::write(&destination, svg)?;
+    println!("{destination}");
+    Ok(())
+}
+
+fn cases() -> Vec<(&'static str, Path)> {
+    let mut curved = Path::builder();
+    curved.begin(point(40.0, 205.0));
+    curved.cubic_bezier_to(point(175.0, 250.0), point(210.0, 170.0), point(140.0, 110.0));
+    curved.cubic_bezier_to(point(205.0, 72.0), point(260.0, 80.0), point(320.0, 130.0));
+    curved.end(false);
+    let mut mixed = Path::builder();
+    mixed.begin(point(310.0, 80.0));
+    mixed.line_to(point(150.0, 120.0));
+    mixed.cubic_bezier_to(point(260.0, 140.0), point(125.0, 215.0), point(325.0, 225.0));
+    mixed.end(false);
+    vec![("curved", curved.build()), ("line / curve", mixed.build())]
+}

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -310,6 +310,23 @@ pub enum Orientation {
     Vertical,
 }
 
+/// Shape of miter-limit cuts for [`LineJoin::Arcs`].
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum ArcsClip {
+    /// A flat cut, as specified by SVG 2.
+    #[default]
+    Butt,
+    /// An experimental, tangent-continuous rounded cut.
+    ///
+    /// The tip is fitted to the two cut-edge directions; it is not necessarily
+    /// a semicircle. It may extend beyond the miter limit. Invalid or non-convex
+    /// fits keep the flat cut. Unclipped joins and round fallbacks are unchanged.
+    /// This is a Lyon extension, not SVG behavior.
+    Round,
+}
+
 /// Parameters for the tessellator.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
@@ -352,6 +369,12 @@ pub struct StrokeOptions {
     /// See [Flattening and tolerance](index.html#flattening-and-tolerance).
     /// Default value: `StrokeOptions::DEFAULT_TOLERANCE`.
     pub tolerance: f32,
+
+    /// Shape of miter-limit cuts, used only with [`LineJoin::Arcs`].
+    ///
+    /// Defaults to [`ArcsClip::Butt`] (SVG 2). Independent of the path end caps.
+    #[cfg_attr(feature = "serialization", serde(default))]
+    pub arcs_clip: ArcsClip,
 }
 
 impl StrokeOptions {
@@ -376,6 +399,7 @@ impl StrokeOptions {
         variable_line_width: None,
         miter_limit: Self::DEFAULT_MITER_LIMIT,
         tolerance: Self::DEFAULT_TOLERANCE,
+        arcs_clip: ArcsClip::Butt,
     };
 
     #[inline]
@@ -411,6 +435,20 @@ impl StrokeOptions {
     #[inline]
     pub const fn with_line_join(mut self, join: LineJoin) -> Self {
         self.line_join = join;
+        self
+    }
+
+    /// Sets the shape of miter-limit cuts for [`LineJoin::Arcs`].
+    ///
+    /// ```
+    /// use lyon_tessellation::{ArcsClip, LineJoin, StrokeOptions};
+    /// let options = StrokeOptions::default()
+    ///     .with_line_join(LineJoin::Arcs)
+    ///     .with_arcs_clip(ArcsClip::Round);
+    /// ```
+    #[inline]
+    pub const fn with_arcs_clip(mut self, clip: ArcsClip) -> Self {
+        self.arcs_clip = clip;
         self
     }
 

--- a/crates/tessellation/src/lib.rs
+++ b/crates/tessellation/src/lib.rs
@@ -206,6 +206,8 @@ pub mod geometry_builder;
 mod math_utils;
 mod monotone;
 mod stroke;
+mod stroke_arcs;
+mod stroke_arcs_mesh;
 
 #[cfg(test)]
 #[rustfmt::skip]
@@ -341,7 +343,7 @@ pub struct StrokeOptions {
 
     /// See the SVG specification.
     ///
-    /// Must be greater than or equal to 1.0.
+    /// Must be greater than or equal to 0.0.
     /// Default value: `StrokeOptions::DEFAULT_MITER_LIMIT`.
     pub miter_limit: f32,
 
@@ -353,10 +355,10 @@ pub struct StrokeOptions {
 }
 
 impl StrokeOptions {
-    /// Minimum miter limit as defined by the SVG specification.
+    /// Minimum miter limit as defined by SVG 2.
     ///
-    /// See [StrokeMiterLimitProperty](https://svgwg.org/specs/strokes/#StrokeMiterlimitProperty)
-    pub const MINIMUM_MITER_LIMIT: f32 = 1.0;
+    /// See [stroke-miterlimit](https://www.w3.org/TR/SVG2/painting.html#StrokeMiterlimitProperty)
+    pub const MINIMUM_MITER_LIMIT: f32 = 0.0;
     /// Default miter limit as defined by the SVG specification.
     ///
     /// See [StrokeMiterLimitProperty](https://svgwg.org/specs/strokes/#StrokeMiterlimitProperty)
@@ -683,7 +685,14 @@ fn test_with_miter_limit() {
 }
 
 #[test]
+fn test_with_zero_miter_limit() {
+    let stroke_options = StrokeOptions::default().with_miter_limit(0.0);
+
+    assert_eq!(stroke_options.miter_limit, 0.0);
+}
+
+#[test]
 #[should_panic]
 fn test_with_invalid_miter_limit() {
-    let _ = StrokeOptions::default().with_miter_limit(0.0);
+    let _ = StrokeOptions::default().with_miter_limit(-0.1);
 }

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -12,6 +12,11 @@ use crate::path::private::DebugValidator;
 use crate::path::{
     AttributeStore, Attributes, EndpointId, IdEvent, PathEvent, PathSlice, PositionStore, Winding,
 };
+use crate::stroke_arcs::{
+    self, JoinConstruction, JoinInput, ParallelRectangleJoin, Point64, RadialClipJoin,
+    ResolvedArcsJoin, SegmentEnd, TurnSide, Vector64,
+};
+use crate::stroke_arcs_mesh::{ArcsMesh, ArcsOutput, ValidatedFan};
 use crate::{
     LineCap, LineJoin, Side, SimpleAttributeStore, StrokeGeometryBuilder, StrokeOptions,
     TessellationError, TessellationResult, VertexId, VertexSource,
@@ -35,6 +40,29 @@ macro_rules! nan_check {
 // It would be good to spend some time simplifying it.
 
 /// A Context object that can tessellate stroke operations for complex paths.
+///
+/// ## Arcs joins
+///
+/// [`LineJoin::Arcs`] uses endpoint tangents and curvature from the original
+/// quadratic or cubic segments, before flattening. It adjusts disjoint support
+/// circles and clips the resulting join using the SVG 2 miter limit.
+///
+/// Pass the original path to preserve curvature. A pre-flattened path contains
+/// only lines, so its arcs joins behave like miter-clip joins. Elliptical arcs
+/// converted to Beziers use the curvature of those Beziers.
+///
+/// The SVG 2 excessive-curvature rule selects round joins. Numerically
+/// degenerate inputs or joins that cannot be triangulated also use round joins.
+/// Variable-width strokes use the width at the join; they do not account for
+/// derivatives of the width profile when constructing offset supports.
+///
+/// ```
+/// use lyon_tessellation::{LineJoin, StrokeOptions};
+/// let options = StrokeOptions::default()
+///     .with_line_join(LineJoin::Arcs)
+///     .with_line_width(8.0)
+///     .with_miter_limit(4.0);
+/// ```
 ///
 /// ## Overview
 ///
@@ -108,6 +136,8 @@ macro_rules! nan_check {
 pub struct StrokeTessellator {
     attrib_buffer: Vec<f32>,
     builder_attrib_store: SimpleAttributeStore,
+    // Keep opt-in join data out of EndpointData and reuse its mesh allocations.
+    arcs: ArcsState,
 }
 
 impl StrokeTessellator {
@@ -115,6 +145,7 @@ impl StrokeTessellator {
         StrokeTessellator {
             attrib_buffer: Vec::new(),
             builder_attrib_store: SimpleAttributeStore::new(0),
+            arcs: ArcsState::default(),
         }
     }
 
@@ -125,13 +156,22 @@ impl StrokeTessellator {
         options: &StrokeOptions,
         builder: &mut dyn StrokeGeometryBuilder,
     ) -> TessellationResult {
+        self.tessellate_impl(input, options, builder)
+    }
+
+    fn tessellate_impl<Output: StrokeGeometryBuilder + ?Sized>(
+        &mut self,
+        input: impl IntoIterator<Item = PathEvent>,
+        options: &StrokeOptions,
+        builder: &mut Output,
+    ) -> TessellationResult {
         debug_assert!(
             options.variable_line_width.is_none(),
             "Variable line width requires custom attributes. Try tessellate_with_ids or tessellate_path",
         );
 
         let mut buffer = Vec::new();
-        let builder = StrokeBuilderImpl::new(options, &mut buffer, builder);
+        let builder = StrokeBuilderImpl::new(options, &mut buffer, &mut self.arcs, builder);
 
         builder.tessellate_fw(input)
     }
@@ -145,6 +185,17 @@ impl StrokeTessellator {
         options: &StrokeOptions,
         output: &mut dyn StrokeGeometryBuilder,
     ) -> TessellationResult {
+        self.tessellate_with_ids_impl(path, positions, custom_attributes, options, output)
+    }
+
+    fn tessellate_with_ids_impl<Output: StrokeGeometryBuilder + ?Sized>(
+        &mut self,
+        path: impl IntoIterator<Item = IdEvent>,
+        positions: &impl PositionStore,
+        custom_attributes: Option<&dyn AttributeStore>,
+        options: &StrokeOptions,
+        output: &mut Output,
+    ) -> TessellationResult {
         let custom_attributes = custom_attributes.unwrap_or(&());
 
         self.attrib_buffer.clear();
@@ -152,7 +203,8 @@ impl StrokeTessellator {
             self.attrib_buffer.push(0.0);
         }
 
-        let builder = StrokeBuilderImpl::new(options, &mut self.attrib_buffer, output);
+        let builder =
+            StrokeBuilderImpl::new(options, &mut self.attrib_buffer, &mut self.arcs, output);
 
         builder.tessellate_with_ids(path, positions, custom_attributes)
     }
@@ -167,12 +219,33 @@ impl StrokeTessellator {
         options: &'l StrokeOptions,
         builder: &'l mut dyn StrokeGeometryBuilder,
     ) -> TessellationResult {
-        let path = path.into();
+        self.tessellate_path_impl(path.into(), options, builder)
+    }
 
+    /// Compute the tessellation from a path slice with static output dispatch.
+    ///
+    /// This produces the same geometry as [`StrokeTessellator::tessellate_path`]
+    /// while allowing the compiler to specialize the hot stroke-output calls for
+    /// the concrete builder type.
+    pub fn tessellate_path_with_builder<'l, Output: StrokeGeometryBuilder>(
+        &'l mut self,
+        path: impl Into<PathSlice<'l>>,
+        options: &'l StrokeOptions,
+        builder: &'l mut Output,
+    ) -> TessellationResult {
+        self.tessellate_path_impl(path.into(), options, builder)
+    }
+
+    fn tessellate_path_impl<'l, Output: StrokeGeometryBuilder + ?Sized>(
+        &'l mut self,
+        path: PathSlice<'l>,
+        options: &'l StrokeOptions,
+        builder: &'l mut Output,
+    ) -> TessellationResult {
         if path.num_attributes() > 0 {
-            self.tessellate_with_ids(path.id_iter(), &path, Some(&path), options, builder)
+            self.tessellate_with_ids_impl(path.id_iter(), &path, Some(&path), options, builder)
         } else {
-            self.tessellate(path.iter(), options, builder)
+            self.tessellate_impl(path.iter(), options, builder)
         }
     }
 
@@ -223,6 +296,7 @@ impl StrokeTessellator {
             options,
             &mut self.attrib_buffer,
             &mut self.builder_attrib_store,
+            &mut self.arcs,
             output,
         ))
     }
@@ -247,6 +321,7 @@ impl StrokeTessellator {
             options,
             &mut self.attrib_buffer,
             &mut self.builder_attrib_store,
+            &mut self.arcs,
             output,
         )
     }
@@ -351,26 +426,169 @@ impl Default for EndpointData {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) enum EndpointDifferential {
+    None,
+    Regular {
+        unit_tangent: Vector,
+        curvature: f64,
+    },
+    Degenerate,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+struct EndpointDifferentials {
+    incoming: EndpointDifferential,
+    outgoing: EndpointDifferential,
+}
+
+impl Default for EndpointDifferential {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+struct ArcsState {
+    point_buffer: PointBuffer<EndpointDifferentials>,
+    firsts: ArrayVec<EndpointDifferentials, 2>,
+    next: EndpointDifferentials,
+    mesh: ArcsMesh,
+    vertex_ids: Vec<VertexId>,
+}
+
+impl Default for ArcsState {
+    fn default() -> Self {
+        Self {
+            point_buffer: PointBuffer::new(),
+            firsts: ArrayVec::new(),
+            next: EndpointDifferentials::default(),
+            mesh: ArcsMesh::default(),
+            vertex_ids: Vec::new(),
+        }
+    }
+}
+
+impl ArcsState {
+    fn reset_differentials(&mut self, point_count: usize) {
+        self.point_buffer.clear();
+        self.firsts.clear();
+        self.next = EndpointDifferentials::default();
+        for _ in 0..point_count {
+            self.point_buffer.push(EndpointDifferentials::default());
+        }
+    }
+
+    fn record_segment(&mut self, differentials: SegmentDifferentials) {
+        self.point_buffer.last_mut().outgoing = differentials.start;
+        self.next.incoming = differentials.end;
+    }
+
+    fn push_next(&mut self, is_endpoint: bool) {
+        let next = self.take_next(is_endpoint);
+        self.point_buffer.push(next);
+    }
+
+    fn replace_last_with_next(&mut self, is_endpoint: bool) {
+        let next = self.take_next(is_endpoint);
+        self.point_buffer.replace_last(next);
+    }
+
+    fn take_next(&mut self, is_endpoint: bool) -> EndpointDifferentials {
+        if !is_endpoint {
+            return EndpointDifferentials::default();
+        }
+
+        let next = self.next;
+        self.next = EndpointDifferentials::default();
+        next
+    }
+
+    fn capture_firsts(&mut self) {
+        let (prev, join) = self.point_buffer.last_two();
+        self.firsts.push(*prev);
+        self.firsts.push(*join);
+    }
+
+    fn prepare_first_for_close(&mut self, last_position: Point, first_position: Point) {
+        let mut first = self.firsts[0];
+        if last_position == first_position {
+            self.point_buffer.last_mut().outgoing = first.outgoing;
+        } else {
+            let closing = line_differentials(last_position, first_position);
+            self.point_buffer.last_mut().outgoing = closing.start;
+            first.incoming = closing.end;
+        }
+        self.next = first;
+    }
+
+    fn prepare_second_for_close(&mut self) {
+        self.next = self.firsts[1];
+    }
+
+    fn clear(&mut self) {
+        self.reset_differentials(0);
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ArcsJoinFallback {
+    Round,
+}
+
+#[allow(clippy::large_enum_variant)] // Join preparation must not allocate in the stroke hot path.
+enum PreparedArcsJoin {
+    Curved(ResolvedArcsJoin),
+    ParallelRectangle(PreparedParallelRectangle),
+    RadialClip(PreparedRadialClip),
+}
+
+#[cfg(not(test))]
+const _: () = assert!(core::mem::size_of::<PreparedArcsJoin>() <= 152);
+
+#[derive(Copy, Clone)]
+struct PreparedParallelRectangle {
+    near_left: Point,
+    near_right: Point,
+    far_left: Point,
+    far_right: Point,
+}
+
+#[derive(Copy, Clone)]
+struct PreparedRadialClip {
+    turn: TurnSide,
+    incoming_offset_point: Point,
+    outgoing_offset_point: Point,
+    incoming: Point,
+    outgoing: Point,
+}
+
+#[derive(Copy, Clone)]
+struct SegmentDifferentials {
+    start: EndpointDifferential,
+    end: EndpointDifferential,
+}
+
 /// A builder object that tessellates a stroked path via the `PathBuilder`
 /// interface.
 ///
 /// Can be created using `StrokeTessellator::builder_with_attributes`.
 pub struct StrokeBuilder<'l> {
-    builder: StrokeBuilderImpl<'l>,
+    builder: StrokeBuilderImpl<'l, dyn StrokeGeometryBuilder + 'l>,
     attrib_store: &'l mut SimpleAttributeStore,
     validator: DebugValidator,
     prev: (Point, EndpointId, f32),
 }
 
 impl<'l> StrokeBuilder<'l> {
-    pub(crate) fn new(
+    fn new(
         options: &StrokeOptions,
         attrib_buffer: &'l mut Vec<f32>,
         attrib_store: &'l mut SimpleAttributeStore,
+        arcs: &'l mut ArcsState,
         output: &'l mut dyn StrokeGeometryBuilder,
     ) -> Self {
         StrokeBuilder {
-            builder: StrokeBuilderImpl::new(options, attrib_buffer, output),
+            builder: StrokeBuilderImpl::new(options, attrib_buffer, arcs, output),
             attrib_store,
             validator: DebugValidator::new(),
             prev: (Point::zero(), EndpointId::INVALID, 0.0),
@@ -379,7 +597,7 @@ impl<'l> StrokeBuilder<'l> {
 
     #[inline]
     pub fn set_line_join(&mut self, join: LineJoin) {
-        self.builder.options.line_join = join;
+        self.builder.set_line_join(join);
     }
 
     #[inline]
@@ -574,10 +792,10 @@ impl<'l> Build for StrokeBuilder<'l> {
 }
 
 /// A builder that tessellates a stroke directly without allocating any intermediate data structure.
-pub(crate) struct StrokeBuilderImpl<'l> {
+pub(crate) struct StrokeBuilderImpl<'l, Output: StrokeGeometryBuilder + ?Sized> {
     options: StrokeOptions,
     pub(crate) error: Option<TessellationError>,
-    pub(crate) output: &'l mut dyn StrokeGeometryBuilder,
+    pub(crate) output: &'l mut Output,
     vertex: StrokeVertexData<'l>,
     point_buffer: PointBuffer,
     firsts: ArrayVec<EndpointData, 2>,
@@ -585,15 +803,23 @@ pub(crate) struct StrokeBuilderImpl<'l> {
     sub_path_start_advancement: f32,
     square_merge_threshold: f32,
     may_need_empty_cap: bool,
+    arcs: &'l mut ArcsState,
+    arcs_differentials_enabled: bool,
 }
 
-impl<'l> StrokeBuilderImpl<'l> {
-    pub(crate) fn new(
+impl<'l, Output: StrokeGeometryBuilder + ?Sized> StrokeBuilderImpl<'l, Output> {
+    fn new(
         options: &StrokeOptions,
         attrib_buffer: &'l mut Vec<f32>,
-        output: &'l mut dyn StrokeGeometryBuilder,
+        arcs: &'l mut ArcsState,
+        output: &'l mut Output,
     ) -> Self {
         output.begin_geometry();
+
+        let arcs_differentials_enabled = options.line_join == LineJoin::Arcs;
+        if arcs_differentials_enabled {
+            arcs.reset_differentials(0);
+        }
 
         // Ideally we'd use the bounding rect of the path as an indication
         // of what is considered a very small distance between two points,
@@ -627,6 +853,8 @@ impl<'l> StrokeBuilderImpl<'l> {
             sub_path_start_advancement: 0.0,
             square_merge_threshold,
             may_need_empty_cap: false,
+            arcs,
+            arcs_differentials_enabled,
         }
     }
 
@@ -634,6 +862,27 @@ impl<'l> StrokeBuilderImpl<'l> {
     pub(crate) fn error<E: Into<TessellationError>>(&mut self, e: E) {
         if self.error.is_none() {
             self.error = Some(e.into());
+        }
+    }
+
+    fn set_line_join(&mut self, join: LineJoin) {
+        if join == LineJoin::Arcs && !self.arcs_differentials_enabled {
+            self.arcs.reset_differentials(self.point_buffer.count());
+            self.arcs_differentials_enabled = true;
+        }
+        self.options.line_join = join;
+    }
+
+    fn record_segment_differentials(&mut self, compute: impl FnOnce() -> SegmentDifferentials) {
+        if self.arcs_differentials_enabled {
+            self.arcs.record_segment(compute());
+        }
+    }
+
+    fn record_closing_differentials(&mut self, first_position: Point) {
+        if self.arcs_differentials_enabled {
+            self.arcs
+                .prepare_first_for_close(self.point_buffer.last().position, first_position);
         }
     }
 
@@ -687,8 +936,12 @@ impl<'l> StrokeBuilderImpl<'l> {
                 IdEvent::Line { to, .. } => {
                     validator.edge();
                     let half_width = base_width * attributes.get(to)[attrib_index] * 0.5;
+                    let from_position = current_position;
                     current_endpoint = to;
                     current_position = positions.get_endpoint(to);
+                    self.record_segment_differentials(|| {
+                        line_differentials(from_position, current_position)
+                    });
                     self.step(
                         EndpointData {
                             position: current_position,
@@ -800,8 +1053,12 @@ impl<'l> StrokeBuilderImpl<'l> {
                 }
                 IdEvent::Line { to, .. } => {
                     validator.edge();
+                    let from_position = current_position;
                     current_endpoint = to;
                     current_position = positions.get_endpoint(to);
+                    self.record_segment_differentials(|| {
+                        line_differentials(from_position, current_position)
+                    });
                     self.fixed_width_step(
                         EndpointData {
                             position: current_position,
@@ -981,6 +1238,8 @@ impl<'l> StrokeBuilderImpl<'l> {
         attributes: &dyn AttributeStore,
     ) {
         let half_width = width * 0.5;
+        let from = self.point_buffer.last().position;
+        self.record_segment_differentials(|| line_differentials(from, to));
         self.step(
             EndpointData {
                 position: to,
@@ -1002,6 +1261,7 @@ impl<'l> StrokeBuilderImpl<'l> {
         end_width: f32,
         attributes: &dyn AttributeStore,
     ) {
+        self.record_segment_differentials(|| quadratic_differentials(curve));
         flatten_quad(
             curve,
             self.options.tolerance,
@@ -1040,6 +1300,7 @@ impl<'l> StrokeBuilderImpl<'l> {
         end_width: f32,
         attributes: &dyn AttributeStore,
     ) {
+        self.record_segment_differentials(|| cubic_differentials(curve));
         curve.for_each_flattened_with_t(self.options.tolerance, &mut |line, t| {
             let is_flattening_step = t.end != 1.0;
             let src = if is_flattening_step {
@@ -1093,6 +1354,8 @@ impl<'l> StrokeBuilderImpl<'l> {
         attributes: &dyn AttributeStore,
     ) {
         let half_width = self.options.line_width * 0.5;
+        let from = self.point_buffer.last().position;
+        self.record_segment_differentials(|| line_differentials(from, to));
         self.fixed_width_step(
             EndpointData {
                 position: to,
@@ -1113,6 +1376,7 @@ impl<'l> StrokeBuilderImpl<'l> {
         attributes: &dyn AttributeStore,
     ) {
         let half_width = self.options.line_width * 0.5;
+        self.record_segment_differentials(|| quadratic_differentials(curve));
         flatten_quad(
             curve,
             self.options.tolerance,
@@ -1150,6 +1414,7 @@ impl<'l> StrokeBuilderImpl<'l> {
         attributes: &dyn AttributeStore,
     ) {
         let half_width = self.options.line_width * 0.5;
+        self.record_segment_differentials(|| cubic_differentials(curve));
         curve.for_each_flattened_with_t(self.options.tolerance, &mut |line, t| {
             let is_flattening_step = t.end != 1.0;
             let src = if is_flattening_step {
@@ -1190,6 +1455,9 @@ impl<'l> StrokeBuilderImpl<'l> {
 
         self.point_buffer.clear();
         self.firsts.clear();
+        if self.arcs_differentials_enabled {
+            self.arcs.clear();
+        }
     }
 
     pub(crate) fn build(self) -> TessellationResult {
@@ -1215,6 +1483,7 @@ impl<'l> StrokeBuilderImpl<'l> {
         assert!(!self.firsts.is_empty());
 
         let mut p = self.firsts[0];
+        self.record_closing_differentials(p.position);
         // Make sure we re-compute the advancement instead of using the one found at the
         // beginning of the sub-path.
         let advancement = p.advancement;
@@ -1239,6 +1508,9 @@ impl<'l> StrokeBuilderImpl<'l> {
 
         if self.firsts.len() >= 2 {
             let p2 = self.firsts[1];
+            if self.arcs_differentials_enabled {
+                self.arcs.prepare_second_for_close();
+            }
             if self.options.variable_line_width.is_some() {
                 self.step_impl(p2, attributes)?;
             } else {
@@ -1431,6 +1703,7 @@ impl<'l> StrokeBuilderImpl<'l> {
             } else {
                 false
             };
+            let mut arcs_join = None;
             if fast_path {
                 join.line_join = LineJoin::Miter;
                 // can fast-path.
@@ -1443,6 +1716,11 @@ impl<'l> StrokeBuilderImpl<'l> {
                     self.output,
                 )?;
             } else {
+                if join.line_join == LineJoin::Arcs {
+                    debug_assert!(self.arcs_differentials_enabled);
+                    let differentials = *self.arcs.point_buffer.last();
+                    arcs_join = prepare_arcs_join(join, differentials, &self.options);
+                }
                 compute_join_side_positions(
                     prev,
                     join,
@@ -1457,6 +1735,12 @@ impl<'l> StrokeBuilderImpl<'l> {
                     self.options.miter_limit,
                     SIDE_NEGATIVE,
                 );
+                if let Some(resolved) = arcs_join.as_ref() {
+                    if align_arcs_side_points(join, resolved).is_err() {
+                        join.line_join = LineJoin::Round;
+                        arcs_join = None;
+                    }
+                }
 
                 // Prevent folding when the other side is concave.
                 if join.side_points[SIDE_POSITIVE].single_vertex.is_some() {
@@ -1489,7 +1773,10 @@ impl<'l> StrokeBuilderImpl<'l> {
 
                 tessellate_join(
                     join,
+                    arcs_join.as_ref(),
                     &self.options,
+                    &mut self.arcs.mesh,
+                    &mut self.arcs.vertex_ids,
                     &mut self.vertex,
                     attributes,
                     self.output,
@@ -1498,20 +1785,28 @@ impl<'l> StrokeBuilderImpl<'l> {
                 if count == 2 {
                     self.firsts.push(*prev);
                     self.firsts.push(*join);
+                    if self.arcs_differentials_enabled {
+                        self.arcs.capture_firsts();
+                    }
                 }
             }
         }
 
         if skip {
+            if self.arcs_differentials_enabled {
+                self.arcs.replace_last_with_next(next.src.is_endpoint());
+            }
             self.point_buffer.replace_last(next);
         } else {
+            if self.arcs_differentials_enabled {
+                self.arcs.push_next(next.src.is_endpoint());
+            }
             self.point_buffer.push(next);
         }
 
         Ok(true)
     }
 
-    #[cfg_attr(feature = "profiling", inline(never))]
     pub(crate) fn step(&mut self, next: EndpointData, attributes: &dyn AttributeStore) {
         if let Err(e) = self.step_impl(next, attributes) {
             self.error(e);
@@ -1572,6 +1867,7 @@ impl<'l> StrokeBuilderImpl<'l> {
             } else {
                 false
             };
+            let mut arcs_join = None;
             if fast_path {
                 join.line_join = LineJoin::Miter;
                 // can fast-path.
@@ -1584,6 +1880,11 @@ impl<'l> StrokeBuilderImpl<'l> {
                     self.output,
                 )?;
             } else {
+                if join.line_join == LineJoin::Arcs {
+                    debug_assert!(self.arcs_differentials_enabled);
+                    let differentials = *self.arcs.point_buffer.last();
+                    arcs_join = prepare_arcs_join(join, differentials, &self.options);
+                }
                 compute_join_side_positions_fixed_width(
                     prev,
                     join,
@@ -1591,6 +1892,12 @@ impl<'l> StrokeBuilderImpl<'l> {
                     self.options.miter_limit,
                     &mut self.vertex,
                 )?;
+                if let Some(resolved) = arcs_join.as_ref() {
+                    if align_arcs_side_points(join, resolved).is_err() {
+                        join.line_join = LineJoin::Round;
+                        arcs_join = None;
+                    }
+                }
 
                 add_join_base_vertices(
                     join,
@@ -1614,7 +1921,10 @@ impl<'l> StrokeBuilderImpl<'l> {
 
             tessellate_join(
                 join,
+                arcs_join.as_ref(),
                 &self.options,
+                &mut self.arcs.mesh,
+                &mut self.arcs.vertex_ids,
                 &mut self.vertex,
                 attributes,
                 self.output,
@@ -1623,15 +1933,20 @@ impl<'l> StrokeBuilderImpl<'l> {
             if count == 2 {
                 self.firsts.push(*prev);
                 self.firsts.push(*join);
+                if self.arcs_differentials_enabled {
+                    self.arcs.capture_firsts();
+                }
             }
         }
 
+        if self.arcs_differentials_enabled {
+            self.arcs.push_next(next.src.is_endpoint());
+        }
         self.point_buffer.push(next);
 
         Ok(true)
     }
 
-    #[cfg_attr(feature = "profiling", inline(never))]
     pub(crate) fn fixed_width_step(&mut self, next: EndpointData, attributes: &dyn AttributeStore) {
         if let Err(e) = self.fixed_width_step_impl(next, attributes) {
             self.error(e);
@@ -1639,7 +1954,63 @@ impl<'l> StrokeBuilderImpl<'l> {
     }
 }
 
-#[cfg_attr(feature = "profiling", inline(never))]
+fn line_differentials(from: Point, to: Point) -> SegmentDifferentials {
+    let tangent = to - from;
+    let differential = regular_differential(tangent, Vector::zero());
+    SegmentDifferentials {
+        start: differential,
+        end: differential,
+    }
+}
+
+fn quadratic_differentials(curve: &QuadraticBezierSegment<f32>) -> SegmentDifferentials {
+    let second_derivative =
+        (curve.to.to_vector() - curve.ctrl.to_vector() * 2.0 + curve.from.to_vector()) * 2.0;
+    SegmentDifferentials {
+        start: regular_differential((curve.ctrl - curve.from) * 2.0, second_derivative),
+        end: regular_differential((curve.to - curve.ctrl) * 2.0, second_derivative),
+    }
+}
+
+fn cubic_differentials(curve: &CubicBezierSegment<f32>) -> SegmentDifferentials {
+    let start_second_derivative =
+        (curve.from.to_vector() - curve.ctrl1.to_vector() * 2.0 + curve.ctrl2.to_vector()) * 6.0;
+    let end_second_derivative =
+        (curve.to.to_vector() - curve.ctrl2.to_vector() * 2.0 + curve.ctrl1.to_vector()) * 6.0;
+    SegmentDifferentials {
+        start: regular_differential((curve.ctrl1 - curve.from) * 3.0, start_second_derivative),
+        end: regular_differential((curve.to - curve.ctrl2) * 3.0, end_second_derivative),
+    }
+}
+
+pub(crate) fn regular_differential(
+    tangent: Vector,
+    second_derivative: Vector,
+) -> EndpointDifferential {
+    let tangent_x = f64::from(tangent.x);
+    let tangent_y = f64::from(tangent.y);
+    let speed_squared = tangent_x * tangent_x + tangent_y * tangent_y;
+    if !speed_squared.is_finite() || speed_squared == 0.0 {
+        return EndpointDifferential::Degenerate;
+    }
+
+    let cross =
+        tangent_x * f64::from(second_derivative.y) - tangent_y * f64::from(second_derivative.x);
+    let inverse_speed = speed_squared.sqrt().recip();
+    let curvature = cross * inverse_speed * inverse_speed * inverse_speed;
+    if !curvature.is_finite() {
+        return EndpointDifferential::Degenerate;
+    }
+
+    EndpointDifferential::Regular {
+        unit_tangent: Vector::new(
+            (tangent_x * inverse_speed) as f32,
+            (tangent_y * inverse_speed) as f32,
+        ),
+        curvature,
+    }
+}
+
 fn compute_join_side_positions_fixed_width(
     prev: &EndpointData,
     join: &mut EndpointData,
@@ -1739,14 +2110,13 @@ fn compute_join_side_positions_fixed_width(
 // and varying line width causing the join to fold back. When this is the
 // case we are better off skipping this join.
 // "M 170 150 60 Q 215 120 240 140 2" is an example of this.
-#[cfg_attr(feature = "profiling", inline(never))]
 fn flattened_step(
     prev: &mut EndpointData,
     join: &mut EndpointData,
     next: &mut EndpointData,
     vertex: &mut StrokeVertexData,
     attributes: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) -> Result<bool, TessellationError> {
     let prev_edge = join.position - prev.position;
     let prev_length = prev_edge.length();
@@ -1805,7 +2175,6 @@ fn flattened_step(
     Ok(false)
 }
 
-#[cfg_attr(feature = "profiling", inline(never))]
 fn compute_edge_attachment_positions(p0: &mut EndpointData, p1: &mut EndpointData) {
     let edge = p1.position - p0.position;
     let d = edge.length();
@@ -1865,11 +2234,10 @@ fn compute_side_attachment_positions(
     nan_check!(p1.side_points[side].prev);
 }
 
-#[cfg_attr(feature = "profiling", inline(never))]
 fn add_edge_triangles(
     p0: &EndpointData,
     p1: &EndpointData,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) {
     let mut p0_neg = p0.side_points[SIDE_NEGATIVE].next_vertex;
     let mut p0_pos = p0.side_points[SIDE_POSITIVE].next_vertex;
@@ -1903,14 +2271,175 @@ fn add_edge_triangles(
     }
 }
 
-#[cfg_attr(feature = "profiling", inline(never))]
+fn resolve_arcs_join(
+    join: &EndpointData,
+    differentials: EndpointDifferentials,
+    options: &StrokeOptions,
+) -> Result<JoinConstruction, ArcsJoinFallback> {
+    let (
+        EndpointDifferential::Regular {
+            unit_tangent: incoming_tangent,
+            curvature: incoming_curvature,
+        },
+        EndpointDifferential::Regular {
+            unit_tangent: outgoing_tangent,
+            curvature: outgoing_curvature,
+        },
+    ) = (differentials.incoming, differentials.outgoing)
+    else {
+        return Err(ArcsJoinFallback::Round);
+    };
+
+    let input = JoinInput {
+        at: Point64::new(f64::from(join.position.x), f64::from(join.position.y)),
+        incoming: SegmentEnd {
+            tangent: Vector64::new(f64::from(incoming_tangent.x), f64::from(incoming_tangent.y)),
+            curvature: incoming_curvature,
+        },
+        outgoing: SegmentEnd {
+            tangent: Vector64::new(f64::from(outgoing_tangent.x), f64::from(outgoing_tangent.y)),
+            curvature: outgoing_curvature,
+        },
+        half_width: f64::from(join.half_width),
+        miter_limit: f64::from(options.miter_limit),
+    };
+
+    stroke_arcs::construct_svg2(input).map_err(|_| ArcsJoinFallback::Round)
+}
+
+fn prepare_arcs_join(
+    join: &mut EndpointData,
+    differentials: EndpointDifferentials,
+    options: &StrokeOptions,
+) -> Option<PreparedArcsJoin> {
+    debug_assert_eq!(join.line_join, LineJoin::Arcs);
+
+    let resolved = resolve_arcs_join(join, differentials, options);
+    match resolved {
+        Ok(JoinConstruction::Empty) => join.line_join = LineJoin::Miter,
+        Ok(JoinConstruction::MiterClip) => join.line_join = LineJoin::MiterClip,
+        Err(ArcsJoinFallback::Round) => {
+            join.line_join = LineJoin::Round;
+        }
+        Ok(JoinConstruction::ParallelRectangle(rectangle)) => {
+            if let Ok(rectangle) = prepare_parallel_rectangle(rectangle) {
+                return Some(PreparedArcsJoin::ParallelRectangle(rectangle));
+            }
+            join.line_join = LineJoin::Round;
+        }
+        Ok(JoinConstruction::RadialClip(radial_clip)) => {
+            if let Ok(radial_clip) = prepare_radial_clip(radial_clip) {
+                return Some(PreparedArcsJoin::RadialClip(radial_clip));
+            }
+            join.line_join = LineJoin::Round;
+        }
+        Ok(JoinConstruction::Arcs(resolved)) => return Some(PreparedArcsJoin::Curved(resolved)),
+    }
+
+    None
+}
+
+fn prepare_radial_clip(
+    radial_clip: RadialClipJoin,
+) -> Result<PreparedRadialClip, ArcsJoinFallback> {
+    Ok(PreparedRadialClip {
+        turn: radial_clip.turn,
+        incoming_offset_point: point64_to_point(radial_clip.incoming_offset_point)?,
+        outgoing_offset_point: point64_to_point(radial_clip.outgoing_offset_point)?,
+        incoming: point64_to_point(radial_clip.incoming)?,
+        outgoing: point64_to_point(radial_clip.outgoing)?,
+    })
+}
+
+fn prepare_parallel_rectangle(
+    rectangle: ParallelRectangleJoin,
+) -> Result<PreparedParallelRectangle, ArcsJoinFallback> {
+    Ok(PreparedParallelRectangle {
+        near_left: point64_to_point(rectangle.near_left)?,
+        near_right: point64_to_point(rectangle.near_right)?,
+        far_left: point64_to_point(rectangle.far_left)?,
+        far_right: point64_to_point(rectangle.far_right)?,
+    })
+}
+
+fn align_arcs_side_points(
+    join: &mut EndpointData,
+    prepared: &PreparedArcsJoin,
+) -> Result<(), ArcsJoinFallback> {
+    match prepared {
+        PreparedArcsJoin::Curved(resolved) => {
+            let incoming = point64_to_point(resolved.incoming_offset_point())?;
+            let outgoing = point64_to_point(resolved.outgoing_offset_point())?;
+            let side = arcs_outer_side(resolved.turn());
+            join.side_points[side].prev = incoming;
+            join.side_points[side].next = outgoing;
+            join.side_points[side].single_vertex = None;
+        }
+        PreparedArcsJoin::ParallelRectangle(rectangle) => {
+            join.side_points[SIDE_POSITIVE].prev = rectangle.near_left;
+            join.side_points[SIDE_POSITIVE].next = rectangle.near_right;
+            join.side_points[SIDE_POSITIVE].single_vertex = None;
+            join.side_points[SIDE_NEGATIVE].prev = rectangle.near_right;
+            join.side_points[SIDE_NEGATIVE].next = rectangle.near_left;
+            join.side_points[SIDE_NEGATIVE].single_vertex = None;
+            join.fold = [false, false];
+        }
+        PreparedArcsJoin::RadialClip(radial_clip) => {
+            let side = arcs_outer_side(radial_clip.turn);
+            join.side_points[side].prev = radial_clip.incoming_offset_point;
+            join.side_points[side].next = radial_clip.outgoing_offset_point;
+            join.side_points[side].single_vertex = None;
+        }
+    }
+    Ok(())
+}
+
+fn arcs_outer_side(turn: TurnSide) -> usize {
+    match turn {
+        TurnSide::Left => SIDE_NEGATIVE,
+        TurnSide::Right => SIDE_POSITIVE,
+    }
+}
+
+fn point64_to_point(value: Point64) -> Result<Point, ArcsJoinFallback> {
+    let minimum = f64::from(f32::MIN);
+    let maximum = f64::from(f32::MAX);
+    if !value.x.is_finite()
+        || !value.y.is_finite()
+        || value.x < minimum
+        || value.x > maximum
+        || value.y < minimum
+        || value.y > maximum
+    {
+        return Err(ArcsJoinFallback::Round);
+    }
+
+    Ok(point(value.x as f32, value.y as f32))
+}
+
 fn tessellate_join(
     join: &mut EndpointData,
+    arcs_join: Option<&PreparedArcsJoin>,
     options: &StrokeOptions,
+    arcs_mesh: &mut ArcsMesh,
+    arcs_vertex_ids: &mut Vec<VertexId>,
     vertex: &mut StrokeVertexData,
     attributes: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) -> Result<(), TessellationError> {
+    debug_assert!(join.line_join != LineJoin::Arcs || arcs_join.is_some());
+
+    if let Some(PreparedArcsJoin::ParallelRectangle(rectangle)) = arcs_join {
+        emit_parallel_arcs_rectangle(join, rectangle, vertex, attributes, output)?;
+        return Ok(());
+    }
+
+    if let Some(PreparedArcsJoin::RadialClip(radial_clip)) = arcs_join {
+        if emit_radial_arcs_clip(join, radial_clip, vertex, attributes, output)? {
+            return Ok(());
+        }
+    }
+
     let side_needs_join = [
         join.side_points[SIDE_POSITIVE].single_vertex.is_none() && !join.fold[SIDE_NEGATIVE],
         join.side_points[SIDE_NEGATIVE].single_vertex.is_none() && !join.fold[SIDE_POSITIVE],
@@ -1956,22 +2485,292 @@ fn tessellate_join(
             continue;
         }
 
-        if join.line_join == LineJoin::Round {
-            tessellate_round_join(join, side, options, vertex, attributes, output)?;
+        match join.line_join {
+            LineJoin::Round => {
+                tessellate_round_join(join, side, options, vertex, attributes, output)?;
+            }
+            LineJoin::Arcs => {
+                let emitted = if let Some(PreparedArcsJoin::Curved(resolved)) = arcs_join {
+                    side == arcs_outer_side(resolved.turn())
+                        && emit_arcs_join(
+                            join,
+                            resolved,
+                            side,
+                            options,
+                            arcs_mesh,
+                            arcs_vertex_ids,
+                            vertex,
+                            attributes,
+                            output,
+                        )?
+                } else {
+                    false
+                };
+                if !emitted {
+                    tessellate_round_join(join, side, options, vertex, attributes, output)?;
+                }
+            }
+            _ => {}
         }
     }
 
     Ok(())
 }
 
-#[cfg_attr(feature = "profiling", inline(never))]
+fn emit_parallel_arcs_rectangle(
+    join: &EndpointData,
+    rectangle: &PreparedParallelRectangle,
+    vertex: &mut StrokeVertexData,
+    attributes: &dyn AttributeStore,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
+) -> Result<(), TessellationError> {
+    if rectangle.far_left == join.side_points[SIDE_POSITIVE].prev
+        && rectangle.far_right == join.side_points[SIDE_NEGATIVE].prev
+    {
+        return Ok(());
+    }
+
+    vertex.position_on_path = join.position;
+    vertex.half_width = join.half_width;
+    vertex.side = Side::Positive;
+    vertex.normal = (rectangle.far_left - join.position) / join.half_width;
+    let far_left_vertex = output.add_stroke_vertex(StrokeVertex(vertex, attributes))?;
+    vertex.side = Side::Negative;
+    vertex.normal = (rectangle.far_right - join.position) / join.half_width;
+    let far_right_vertex = output.add_stroke_vertex(StrokeVertex(vertex, attributes))?;
+
+    let near_left_vertex = join.side_points[SIDE_POSITIVE].prev_vertex;
+    let near_right_vertex = join.side_points[SIDE_NEGATIVE].prev_vertex;
+    output.add_triangle(near_left_vertex, far_left_vertex, far_right_vertex);
+    output.add_triangle(near_left_vertex, far_right_vertex, near_right_vertex);
+    Ok(())
+}
+
+fn emit_radial_arcs_clip(
+    join: &EndpointData,
+    radial_clip: &PreparedRadialClip,
+    vertex: &mut StrokeVertexData,
+    attributes: &dyn AttributeStore,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
+) -> Result<bool, TessellationError> {
+    let outer_side = arcs_outer_side(radial_clip.turn);
+    let inner_side = 1 - outer_side;
+    if join.side_points[inner_side].single_vertex.is_none()
+        || join.fold[outer_side]
+        || join.fold[inner_side]
+    {
+        return Ok(false);
+    }
+
+    vertex.position_on_path = join.position;
+    vertex.half_width = join.half_width;
+    vertex.side = if outer_side == SIDE_POSITIVE {
+        Side::Positive
+    } else {
+        Side::Negative
+    };
+
+    vertex.normal = (radial_clip.incoming - join.position) / join.half_width;
+    let incoming_clip_vertex = output.add_stroke_vertex(StrokeVertex(vertex, attributes))?;
+    let outgoing_clip_vertex = if radial_clip.outgoing == radial_clip.incoming {
+        incoming_clip_vertex
+    } else {
+        vertex.normal = (radial_clip.outgoing - join.position) / join.half_width;
+        output.add_stroke_vertex(StrokeVertex(vertex, attributes))?
+    };
+
+    let inner_vertex = join.side_points[inner_side].prev_vertex;
+    let incoming_outer_vertex = join.side_points[outer_side].prev_vertex;
+    let outgoing_outer_vertex = join.side_points[outer_side].next_vertex;
+    match radial_clip.turn {
+        TurnSide::Left => {
+            output.add_triangle(inner_vertex, outgoing_outer_vertex, outgoing_clip_vertex);
+            if outgoing_clip_vertex != incoming_clip_vertex {
+                output.add_triangle(inner_vertex, outgoing_clip_vertex, incoming_clip_vertex);
+            }
+            output.add_triangle(inner_vertex, incoming_clip_vertex, incoming_outer_vertex);
+        }
+        TurnSide::Right => {
+            output.add_triangle(inner_vertex, incoming_outer_vertex, incoming_clip_vertex);
+            if incoming_clip_vertex != outgoing_clip_vertex {
+                output.add_triangle(inner_vertex, incoming_clip_vertex, outgoing_clip_vertex);
+            }
+            output.add_triangle(inner_vertex, outgoing_clip_vertex, outgoing_outer_vertex);
+        }
+    }
+
+    Ok(true)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_arcs_join(
+    join: &EndpointData,
+    resolved: &ResolvedArcsJoin,
+    side: usize,
+    options: &StrokeOptions,
+    mesh: &mut ArcsMesh,
+    vertex_ids: &mut Vec<VertexId>,
+    vertex: &mut StrokeVertexData,
+    attributes: &dyn AttributeStore,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
+) -> Result<bool, TessellationError> {
+    let tessellation = match mesh.tessellate_for_output(resolved, f64::from(options.tolerance)) {
+        Ok(tessellation) => tessellation,
+        Err(_) => return Ok(false),
+    };
+
+    match tessellation {
+        ArcsOutput::Triangle(triangle) => {
+            let Ok(position) = point64_to_point(triangle.middle) else {
+                return Ok(false);
+            };
+            if position == join.position {
+                return Ok(false);
+            }
+
+            vertex.position_on_path = join.position;
+            vertex.half_width = join.half_width;
+            vertex.side = if side == SIDE_POSITIVE {
+                Side::Positive
+            } else {
+                Side::Negative
+            };
+            vertex.normal = (position - join.position) / join.half_width;
+            let middle_vertex = output.add_stroke_vertex(StrokeVertex(vertex, attributes))?;
+            let vertex_ids = [
+                join.side_points[side].prev_vertex,
+                middle_vertex,
+                join.side_points[side].next_vertex,
+            ];
+            output.add_triangle(
+                vertex_ids[triangle.indices[0]],
+                vertex_ids[triangle.indices[2]],
+                vertex_ids[triangle.indices[1]],
+            );
+            Ok(true)
+        }
+        ArcsOutput::Quad(quad) => {
+            let Ok(first_position) = point64_to_point(quad.middle[0]) else {
+                return Ok(false);
+            };
+            let Ok(second_position) = point64_to_point(quad.middle[1]) else {
+                return Ok(false);
+            };
+            if first_position == join.position || second_position == join.position {
+                return Ok(false);
+            }
+
+            vertex.position_on_path = join.position;
+            vertex.half_width = join.half_width;
+            vertex.side = if side == SIDE_POSITIVE {
+                Side::Positive
+            } else {
+                Side::Negative
+            };
+            vertex.normal = (first_position - join.position) / join.half_width;
+            let first_middle = output.add_stroke_vertex(StrokeVertex(vertex, attributes))?;
+            vertex.normal = (second_position - join.position) / join.half_width;
+            let second_middle = output.add_stroke_vertex(StrokeVertex(vertex, attributes))?;
+            let vertex_ids = [
+                join.side_points[side].prev_vertex,
+                first_middle,
+                second_middle,
+                join.side_points[side].next_vertex,
+            ];
+            for triangle in quad.indices.chunks_exact(3) {
+                output.add_triangle(
+                    vertex_ids[usize::from(triangle[0])],
+                    vertex_ids[usize::from(triangle[2])],
+                    vertex_ids[usize::from(triangle[1])],
+                );
+            }
+            Ok(true)
+        }
+        ArcsOutput::Fan { vertices, fan } => emit_arcs_mesh_output(
+            join,
+            side,
+            vertices,
+            Some(fan),
+            &[],
+            vertex_ids,
+            vertex,
+            attributes,
+            output,
+        ),
+        ArcsOutput::Mesh { vertices, indices } => emit_arcs_mesh_output(
+            join, side, vertices, None, indices, vertex_ids, vertex, attributes, output,
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_arcs_mesh_output(
+    join: &EndpointData,
+    side: usize,
+    vertices: &[Point64],
+    fan: Option<ValidatedFan>,
+    indices: &[usize],
+    vertex_ids: &mut Vec<VertexId>,
+    vertex: &mut StrokeVertexData,
+    attributes: &dyn AttributeStore,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
+) -> Result<bool, TessellationError> {
+    if vertices.len() < 3 {
+        return Ok(false);
+    }
+
+    for point64 in &vertices[1..vertices.len() - 1] {
+        let Ok(position) = point64_to_point(*point64) else {
+            return Ok(false);
+        };
+        if position == join.position {
+            return Ok(false);
+        }
+    }
+
+    vertex_ids.clear();
+    vertex_ids.reserve(vertices.len());
+    vertex_ids.push(join.side_points[side].prev_vertex);
+
+    vertex.position_on_path = join.position;
+    vertex.half_width = join.half_width;
+    vertex.side = if side == SIDE_POSITIVE {
+        Side::Positive
+    } else {
+        Side::Negative
+    };
+    for point64 in &vertices[1..vertices.len() - 1] {
+        // The preflight above checked both components against the f32 range.
+        let position = point(point64.x as f32, point64.y as f32);
+        vertex.normal = (position - join.position) / join.half_width;
+        vertex_ids.push(output.add_stroke_vertex(StrokeVertex(vertex, attributes))?);
+    }
+    vertex_ids.push(join.side_points[side].next_vertex);
+
+    if let Some(fan) = fan {
+        for [first, second, third] in fan.triangles() {
+            output.add_triangle(vertex_ids[first], vertex_ids[third], vertex_ids[second]);
+        }
+    } else {
+        for triangle in indices.chunks_exact(3) {
+            output.add_triangle(
+                vertex_ids[triangle[0]],
+                vertex_ids[triangle[2]],
+                vertex_ids[triangle[1]],
+            );
+        }
+    }
+
+    Ok(true)
+}
+
 fn tessellate_round_join(
     join: &mut EndpointData,
     side: usize,
     options: &StrokeOptions,
     vertex: &mut StrokeVertexData,
     attributes: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) -> Result<(), TessellationError> {
     let center = join.position;
     let radius = join.half_width;
@@ -2018,12 +2817,11 @@ fn tessellate_round_join(
     )
 }
 
-#[cfg_attr(feature = "profiling", inline(never))]
 fn add_join_base_vertices(
     join: &mut EndpointData,
     vertex: &mut StrokeVertexData,
     attributes: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
     side: Side,
 ) -> Result<(), TessellationError> {
     vertex.side = side;
@@ -2054,7 +2852,6 @@ fn add_join_base_vertices(
 
 // TODO: the naming is a bit confusing. We do half of the work to compute the join's side positions
 // in compute_side_attachment_positions.
-#[cfg_attr(feature = "profiling", inline(never))]
 fn compute_join_side_positions(
     prev: &EndpointData,
     join: &mut EndpointData,
@@ -2132,7 +2929,7 @@ fn tessellate_last_edge(
     options: &StrokeOptions,
     vertex: &mut StrokeVertexData,
     attributes: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) -> Result<(), TessellationError> {
     let v = p1.position - p0.position;
     p1.advancement = p0.advancement + v.length();
@@ -2209,7 +3006,7 @@ fn tessellate_first_edge(
     options: &StrokeOptions,
     vertex: &mut StrokeVertexData,
     attributes: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) -> Result<(), TessellationError> {
     vertex.src = first.src;
     vertex.position_on_path = first.position;
@@ -2273,7 +3070,6 @@ fn tessellate_first_edge(
     }
 }
 
-#[cfg_attr(feature = "profiling", inline(never))]
 fn get_clip_intersections(
     previous_normal: Vector,
     next_normal: Vector,
@@ -2352,7 +3148,7 @@ fn approximate_thin_rectangle(builder: &mut StrokeBuilder, rect: &Box2D, attribu
     let options = builder.builder.options;
 
     let cap = match options.line_join {
-        LineJoin::Round => LineCap::Round,
+        LineJoin::Round | LineJoin::Arcs => LineCap::Round,
         _ => LineCap::Square,
     };
 
@@ -2366,22 +3162,22 @@ fn approximate_thin_rectangle(builder: &mut StrokeBuilder, rect: &Box2D, attribu
     builder.builder.options = options;
 }
 
-struct PointBuffer {
-    points: [EndpointData; 3],
+struct PointBuffer<T = EndpointData> {
+    points: [T; 3],
     start: usize,
     count: usize,
 }
 
-impl PointBuffer {
+impl<T: Copy + Default> PointBuffer<T> {
     fn new() -> Self {
         PointBuffer {
-            points: [EndpointData::default(); 3],
+            points: [T::default(); 3],
             start: 0,
             count: 0,
         }
     }
 
-    fn push(&mut self, point: EndpointData) {
+    fn push(&mut self, point: T) {
         if self.count < 3 {
             self.points[self.count] = point;
             self.count += 1;
@@ -2395,7 +3191,7 @@ impl PointBuffer {
         }
     }
 
-    fn replace_last(&mut self, point: EndpointData) {
+    fn replace_last(&mut self, point: T) {
         let mut idx = self.start;
         if idx == 0 {
             idx = self.count;
@@ -2412,36 +3208,41 @@ impl PointBuffer {
         self.count
     }
 
-    fn get(&self, idx: usize) -> &EndpointData {
+    fn get(&self, idx: usize) -> &T {
         assert!(idx < self.count);
         let idx = (idx + self.start) % 3;
 
         &self.points[idx]
     }
 
-    fn get_reverse(&self, idx: usize) -> &EndpointData {
+    fn get_reverse(&self, idx: usize) -> &T {
         assert!(idx < self.count);
         self.get(self.count - 1 - idx)
     }
 
-    fn get_mut(&mut self, idx: usize) -> &mut EndpointData {
+    fn get_mut(&mut self, idx: usize) -> &mut T {
         assert!(idx < self.count);
         let idx = (idx + self.start) % 3;
 
         &mut self.points[idx]
     }
 
-    fn last(&self) -> &EndpointData {
+    fn last(&self) -> &T {
         assert!(self.count > 0);
         self.get(self.count - 1)
     }
 
-    fn last_mut(&mut self) -> &mut EndpointData {
+    fn last_mut(&mut self) -> &mut T {
         assert!(self.count > 0);
         self.get_mut(self.count - 1)
     }
 
-    fn last_two_mut(&mut self) -> (&mut EndpointData, &mut EndpointData) {
+    fn last_two(&self) -> (&T, &T) {
+        assert!(self.count >= 2);
+        (self.get_reverse(1), self.get_reverse(0))
+    }
+
+    fn last_two_mut(&mut self) -> (&mut T, &mut T) {
         assert!(self.count >= 2);
         let i0 = (self.start + self.count - 1) % 3;
         let i1 = (self.start + self.count - 2) % 3;
@@ -2465,7 +3266,7 @@ pub(crate) fn tessellate_round_cap(
     is_start: bool,
     vertex: &mut StrokeVertexData,
     attributes: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) -> Result<(), TessellationError> {
     if radius < options.tolerance {
         return Ok(());
@@ -2523,7 +3324,7 @@ pub(crate) fn tessellate_empty_square_cap(
     position: Point,
     vertex: &mut StrokeVertexData,
     attributes: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) -> Result<(), TessellationError> {
     vertex.position_on_path = position;
 
@@ -2558,7 +3359,7 @@ pub(crate) fn tessellate_empty_round_cap(
     options: &StrokeOptions,
     vertex: &mut StrokeVertexData,
     attribute_store: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) -> Result<(), TessellationError> {
     let radius = vertex.half_width;
 
@@ -2612,7 +3413,7 @@ pub(crate) fn tessellate_arc(
     num_recursions: u32,
     vertex: &mut StrokeVertexData,
     attributes: &dyn AttributeStore,
-    output: &mut dyn StrokeGeometryBuilder,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
 ) -> Result<(), TessellationError> {
     if num_recursions == 0 {
         return Ok(());
@@ -2677,6 +3478,7 @@ impl<'a, 'b> StrokeVertex<'a, 'b> {
     ///
     /// The length of the provided normal is such that displacing the vertex along it
     /// inflates the stroke by 2.0 (1.0 on each side).
+    /// It can be zero for a clipped join vertex located on the path itself.
     #[inline]
     pub fn normal(&self) -> Vector {
         self.0.normal
@@ -2832,7 +3634,6 @@ fn test_path(path: PathSlice, options: &StrokeOptions, expected_triangle_count: 
             assert!(!attributes.position().y.is_nan());
             assert!(!attributes.normal().x.is_nan());
             assert!(!attributes.normal().y.is_nan());
-            assert_ne!(attributes.normal().square_length(), 0.0);
             assert!(!attributes.advancement().is_nan());
             self.builder.add_stroke_vertex(attributes)
         }
@@ -2857,6 +3658,22 @@ fn test_path(path: PathSlice, options: &StrokeOptions, expected_triangle_count: 
             "Unexpected number of triangles"
         );
     }
+}
+
+#[cfg(test)]
+fn mesh_contains_point(mesh: &VertexBuffers<Point, u16>, point: Point) -> bool {
+    mesh.indices.chunks_exact(3).any(|triangle| {
+        let a = mesh.vertices[triangle[0] as usize];
+        let b = mesh.vertices[triangle[1] as usize];
+        let c = mesh.vertices[triangle[2] as usize];
+        let ab = (b - a).cross(point - a);
+        let bc = (c - b).cross(point - b);
+        let ca = (a - c).cross(point - c);
+        let epsilon = 1.0e-6;
+
+        (ab >= -epsilon && bc >= -epsilon && ca >= -epsilon)
+            || (ab <= epsilon && bc <= epsilon && ca <= epsilon)
+    })
 }
 
 #[test]
@@ -2918,6 +3735,365 @@ fn test_square() {
             None,
         );
     }
+}
+
+#[test]
+fn arcs_join_records_curve_differentials_before_flattening() {
+    let mut builder = Path::builder_with_attributes(1);
+    builder.begin(point(0.0, 0.0), &[1.0]);
+    builder.line_to(point(10.0, 0.0), &[1.0]);
+    builder.quadratic_bezier_to(point(10.0, 5.0), point(15.0, 5.0), &[1.0]);
+    builder.cubic_bezier_to(
+        point(20.0, 5.0),
+        point(20.0, 10.0),
+        point(15.0, 10.0),
+        &[1.0],
+    );
+    builder.end(false);
+    let path = builder.build();
+
+    test_path(
+        path.as_slice(),
+        &StrokeOptions::default()
+            .with_line_join(LineJoin::Arcs)
+            .with_variable_line_width(0),
+        None,
+    );
+    test_path(
+        path.as_slice(),
+        &StrokeOptions::default().with_line_join(LineJoin::Arcs),
+        None,
+    );
+}
+
+#[test]
+fn arcs_join_preserves_differentials_between_quadratic_segments() {
+    let mut builder = Path::builder();
+    builder.begin(point(0.0, 0.0));
+    builder.quadratic_bezier_to(point(4.0, 24.0), point(12.0, 10.0));
+    builder.quadratic_bezier_to(point(16.0, -24.0), point(24.0, -10.0));
+    builder.end(false);
+    let path = builder.build();
+    let options = StrokeOptions::default()
+        .with_line_width(8.0)
+        .with_tolerance(0.1);
+    let mut arcs_mesh: VertexBuffers<Point, u16> = VertexBuffers::new();
+    let mut round_mesh: VertexBuffers<Point, u16> = VertexBuffers::new();
+
+    StrokeTessellator::new()
+        .tessellate_path(
+            &path,
+            &options.with_line_join(LineJoin::Arcs),
+            &mut simple_builder(&mut arcs_mesh),
+        )
+        .expect("the curve-to-curve arcs join should tessellate");
+    StrokeTessellator::new()
+        .tessellate_path(
+            &path,
+            &options.with_line_join(LineJoin::Round),
+            &mut simple_builder(&mut round_mesh),
+        )
+        .expect("the round comparison should tessellate");
+
+    assert_ne!(arcs_mesh.vertices, round_mesh.vertices);
+}
+
+#[test]
+fn endpoint_data_stays_within_the_hot_path_size_budget() {
+    assert!(core::mem::size_of::<EndpointData>() <= 112);
+}
+
+#[test]
+fn arcs_join_records_the_implicit_closing_line() {
+    let mut builder = Path::builder();
+    builder.begin(point(0.0, 0.0));
+    builder.line_to(point(10.0, 0.0));
+    builder.line_to(point(0.0, 10.0));
+    builder.end(true);
+    let path = builder.build();
+
+    test_path(
+        path.as_slice(),
+        &StrokeOptions::default().with_line_join(LineJoin::Arcs),
+        None,
+    );
+}
+
+#[test]
+fn cubic_differentials_preserve_signed_endpoint_curvature() {
+    let curve = CubicBezierSegment {
+        from: point(0.0, 0.0),
+        ctrl1: point(1.0, 0.0),
+        ctrl2: point(1.0, 1.0),
+        to: point(0.0, 1.0),
+    };
+
+    let differentials = cubic_differentials(&curve);
+
+    let EndpointDifferential::Regular {
+        unit_tangent: start_tangent,
+        curvature: start_curvature,
+    } = differentials.start
+    else {
+        panic!("the cubic start should be regular");
+    };
+    let EndpointDifferential::Regular {
+        unit_tangent: end_tangent,
+        curvature: end_curvature,
+    } = differentials.end
+    else {
+        panic!("the cubic end should be regular");
+    };
+    assert_eq!(start_tangent, vector(1.0, 0.0));
+    assert_eq!(end_tangent, vector(-1.0, 0.0));
+    assert!((start_curvature - 2.0 / 3.0).abs() < 1e-12);
+    assert!((end_curvature - 2.0 / 3.0).abs() < 1e-12);
+}
+
+#[test]
+fn arcs_join_resolves_endpoint_differentials_into_support_geometry() {
+    let join = EndpointData {
+        position: point(10.0, 5.0),
+        half_width: 2.0,
+        line_join: LineJoin::Arcs,
+        ..EndpointData::default()
+    };
+    let differentials = EndpointDifferentials {
+        incoming: EndpointDifferential::Regular {
+            unit_tangent: vector(1.0, 0.0),
+            curvature: 0.0,
+        },
+        outgoing: EndpointDifferential::Regular {
+            unit_tangent: vector(0.0, 1.0),
+            curvature: 0.1,
+        },
+    };
+
+    let resolution = resolve_arcs_join(&join, differentials, &StrokeOptions::default());
+
+    assert!(matches!(resolution, Ok(JoinConstruction::Arcs(_))));
+}
+
+#[test]
+fn arcs_join_emits_a_different_mesh_than_round_for_both_turn_directions() {
+    let options = StrokeOptions::default()
+        .with_line_width(4.0)
+        .with_tolerance(0.01);
+
+    for outgoing_y in [8.0, -8.0] {
+        let mut path = Path::builder();
+        path.begin(point(0.0, 0.0));
+        path.line_to(point(10.0, 0.0));
+        path.quadratic_bezier_to(point(10.0, outgoing_y), point(18.0, outgoing_y));
+        path.end(false);
+        let path = path.build();
+        let mut arcs_mesh: VertexBuffers<Point, u16> = VertexBuffers::new();
+        let mut round_mesh: VertexBuffers<Point, u16> = VertexBuffers::new();
+
+        StrokeTessellator::new()
+            .tessellate_path(
+                &path,
+                &options.with_line_join(LineJoin::Arcs),
+                &mut simple_builder(&mut arcs_mesh),
+            )
+            .expect("the arcs join should tessellate");
+        StrokeTessellator::new()
+            .tessellate_path(
+                &path,
+                &options.with_line_join(LineJoin::Round),
+                &mut simple_builder(&mut round_mesh),
+            )
+            .expect("the round join should tessellate");
+
+        assert_ne!(arcs_mesh.vertices, round_mesh.vertices);
+    }
+}
+
+#[test]
+fn shallow_arcs_join_does_not_silently_become_round() {
+    let mut path = Path::builder();
+    path.begin(point(0.0, 0.0));
+    path.line_to(point(10.0, 0.0));
+    path.cubic_bezier_to(point(13.0, 0.2), point(16.0, 1.0), point(19.0, 1.5));
+    path.end(false);
+    let path = path.build();
+    let options = StrokeOptions::default()
+        .with_line_width(4.0)
+        .with_tolerance(0.01);
+    let mut arcs_mesh: VertexBuffers<Point, u16> = VertexBuffers::new();
+    let mut round_mesh: VertexBuffers<Point, u16> = VertexBuffers::new();
+
+    StrokeTessellator::new()
+        .tessellate_path(
+            &path,
+            &options.with_line_join(LineJoin::Arcs),
+            &mut simple_builder(&mut arcs_mesh),
+        )
+        .expect("the shallow arcs join should tessellate");
+    StrokeTessellator::new()
+        .tessellate_path(
+            &path,
+            &options.with_line_join(LineJoin::Round),
+            &mut simple_builder(&mut round_mesh),
+        )
+        .expect("the round comparison should tessellate");
+
+    assert_ne!(arcs_mesh.vertices, round_mesh.vertices);
+}
+
+#[test]
+fn arcs_join_emits_the_svg_rectangle_for_opposite_parallel_tangents() {
+    let mut path = Path::builder();
+    path.begin(point(0.0, 0.0));
+    path.line_to(point(10.0, 0.0));
+    path.quadratic_bezier_to(point(2.0, 0.0), point(2.0, 8.0));
+    path.end(false);
+    let path = path.build();
+    let options = StrokeOptions::default()
+        .with_line_width(4.0)
+        .with_miter_limit(3.0)
+        .with_line_join(LineJoin::Arcs);
+    let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
+
+    StrokeTessellator::new()
+        .tessellate_path(&path, &options, &mut simple_builder(&mut buffers))
+        .expect("the parallel arcs fallback should tessellate");
+
+    let far_left = point(16.0, 2.0);
+    let far_right = point(16.0, -2.0);
+    assert!(
+        buffers
+            .vertices
+            .iter()
+            .any(|position| (*position - far_left).square_length() < 1.0e-6)
+            && buffers
+                .vertices
+                .iter()
+                .any(|position| (*position - far_right).square_length() < 1.0e-6)
+    );
+}
+
+#[test]
+fn arcs_join_emits_radial_clips_for_sub_unit_miter_limits() {
+    let options = StrokeOptions::default()
+        .with_line_width(4.0)
+        .with_miter_limit(0.5)
+        .with_line_join(LineJoin::Arcs);
+
+    for outgoing_y in [8.0, -8.0] {
+        let mut path = Path::builder();
+        path.begin(point(0.0, 0.0));
+        path.line_to(point(10.0, 0.0));
+        path.quadratic_bezier_to(point(10.0, outgoing_y), point(18.0, outgoing_y));
+        path.end(false);
+        let path = path.build();
+        let curve = QuadraticBezierSegment {
+            from: point(10.0, 0.0),
+            ctrl: point(10.0, outgoing_y),
+            to: point(18.0, outgoing_y),
+        };
+        let EndpointDifferential::Regular {
+            unit_tangent: tangent,
+            curvature,
+        } = quadratic_differentials(&curve).start
+        else {
+            panic!("the quadratic start should be regular");
+        };
+        let expected = stroke_arcs::construct(JoinInput {
+            at: Point64::new(10.0, 0.0),
+            incoming: SegmentEnd {
+                tangent: Vector64::new(1.0, 0.0),
+                curvature: 0.0,
+            },
+            outgoing: SegmentEnd {
+                tangent: Vector64::new(f64::from(tangent.x), f64::from(tangent.y)),
+                curvature,
+            },
+            half_width: 2.0,
+            miter_limit: 0.5,
+        })
+        .expect("the radial clip should resolve");
+        let JoinConstruction::RadialClip(expected) = expected else {
+            panic!("the sub-unit miter limit should select a radial clip");
+        };
+        let expected_incoming = point64_to_point(expected.incoming).expect("finite clip point");
+        let expected_outgoing = point64_to_point(expected.outgoing).expect("finite clip point");
+        let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
+
+        StrokeTessellator::new()
+            .tessellate_path(&path, &options, &mut simple_builder(&mut buffers))
+            .expect("the radial arcs clip should tessellate");
+
+        assert!(
+            buffers
+                .vertices
+                .iter()
+                .any(|position| (*position - expected_incoming).square_length() < 1.0e-6)
+                && buffers
+                    .vertices
+                    .iter()
+                    .any(|position| (*position - expected_outgoing).square_length() < 1.0e-6)
+        );
+        let clipped_corner = point(11.5, -outgoing_y.signum() * 1.5);
+        assert!(!mesh_contains_point(&buffers, clipped_corner));
+    }
+}
+
+#[test]
+fn arcs_join_supports_a_zero_miter_limit() {
+    let options = StrokeOptions::default()
+        .with_line_width(4.0)
+        .with_miter_limit(0.0)
+        .with_line_join(LineJoin::Arcs);
+
+    for outgoing_y in [8.0, -8.0] {
+        let mut path = Path::builder();
+        path.begin(point(0.0, 0.0));
+        path.line_to(point(10.0, 0.0));
+        path.quadratic_bezier_to(point(10.0, outgoing_y), point(18.0, outgoing_y));
+        path.end(false);
+        let path = path.build();
+
+        test_path(path.as_slice(), &options, None);
+    }
+}
+
+#[test]
+fn arcs_join_keeps_explicit_svg_fallback_states() {
+    let mut join = EndpointData {
+        half_width: 2.0,
+        line_join: LineJoin::Arcs,
+        ..EndpointData::default()
+    };
+    let line_differentials = EndpointDifferentials {
+        incoming: EndpointDifferential::Regular {
+            unit_tangent: vector(1.0, 0.0),
+            curvature: 0.0,
+        },
+        outgoing: EndpointDifferential::Regular {
+            unit_tangent: vector(0.0, 1.0),
+            curvature: 0.0,
+        },
+    };
+
+    let options = StrokeOptions::default();
+    let line_join = resolve_arcs_join(&join, line_differentials, &options);
+    let line_geometry = prepare_arcs_join(&mut join, line_differentials, &options);
+    let applied_line_fallback = join.line_join;
+    join.line_join = LineJoin::Arcs;
+    let degenerate_differentials = EndpointDifferentials {
+        outgoing: EndpointDifferential::Degenerate,
+        ..line_differentials
+    };
+    let degenerate_join = resolve_arcs_join(&join, degenerate_differentials, &options);
+    let degenerate_geometry = prepare_arcs_join(&mut join, degenerate_differentials, &options);
+
+    assert!(matches!(line_join, Ok(JoinConstruction::MiterClip)));
+    assert!(line_geometry.is_none());
+    assert_eq!(applied_line_fallback, LineJoin::MiterClip);
+    assert!(degenerate_join.is_err());
+    assert!(degenerate_geometry.is_none());
+    assert_eq!(join.line_join, LineJoin::Round);
 }
 
 #[test]

--- a/crates/tessellation/src/stroke.rs
+++ b/crates/tessellation/src/stroke.rs
@@ -18,7 +18,7 @@ use crate::stroke_arcs::{
 };
 use crate::stroke_arcs_mesh::{ArcsMesh, ArcsOutput, ValidatedFan};
 use crate::{
-    LineCap, LineJoin, Side, SimpleAttributeStore, StrokeGeometryBuilder, StrokeOptions,
+    ArcsClip, LineCap, LineJoin, Side, SimpleAttributeStore, StrokeGeometryBuilder, StrokeOptions,
     TessellationError, TessellationResult, VertexId, VertexSource,
 };
 
@@ -27,6 +27,9 @@ use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
+
+#[path = "stroke_round_clip.rs"]
+mod round_clip;
 
 const SIDE_POSITIVE: usize = 0;
 const SIDE_NEGATIVE: usize = 1;
@@ -1773,6 +1776,7 @@ impl<'l, Output: StrokeGeometryBuilder + ?Sized> StrokeBuilderImpl<'l, Output> {
 
                 tessellate_join(
                     join,
+                    [prev, &next],
                     arcs_join.as_ref(),
                     &self.options,
                     &mut self.arcs.mesh,
@@ -1921,6 +1925,7 @@ impl<'l, Output: StrokeGeometryBuilder + ?Sized> StrokeBuilderImpl<'l, Output> {
 
             tessellate_join(
                 join,
+                [prev, &next],
                 arcs_join.as_ref(),
                 &self.options,
                 &mut self.arcs.mesh,
@@ -2419,6 +2424,7 @@ fn point64_to_point(value: Point64) -> Result<Point, ArcsJoinFallback> {
 
 fn tessellate_join(
     join: &mut EndpointData,
+    neighbors: [&EndpointData; 2],
     arcs_join: Option<&PreparedArcsJoin>,
     options: &StrokeOptions,
     arcs_mesh: &mut ArcsMesh,
@@ -2431,11 +2437,43 @@ fn tessellate_join(
 
     if let Some(PreparedArcsJoin::ParallelRectangle(rectangle)) = arcs_join {
         emit_parallel_arcs_rectangle(join, rectangle, vertex, attributes, output)?;
+        if options.arcs_clip == ArcsClip::Round && options.miter_limit > 0.0 {
+            round_clip::emit(
+                join,
+                [rectangle.far_left, rectangle.far_right],
+                [
+                    rectangle.far_left - rectangle.near_left,
+                    rectangle.far_right - rectangle.near_right,
+                ]
+                .map(round_clip::vector64),
+                SIDE_POSITIVE,
+                options.tolerance,
+                vertex,
+                attributes,
+                output,
+            )?;
+        }
         return Ok(());
     }
 
     if let Some(PreparedArcsJoin::RadialClip(radial_clip)) = arcs_join {
         if emit_radial_arcs_clip(join, radial_clip, vertex, attributes, output)? {
+            if options.arcs_clip == ArcsClip::Round {
+                round_clip::emit(
+                    join,
+                    [radial_clip.incoming, radial_clip.outgoing],
+                    [
+                        radial_clip.incoming - join.position,
+                        radial_clip.outgoing - join.position,
+                    ]
+                    .map(round_clip::vector64),
+                    arcs_outer_side(radial_clip.turn),
+                    options.tolerance,
+                    vertex,
+                    attributes,
+                    output,
+                )?;
+            }
             return Ok(());
         }
     }
@@ -2506,9 +2544,48 @@ fn tessellate_join(
                 } else {
                     false
                 };
+                if emitted && options.arcs_clip == ArcsClip::Round {
+                    if let Some(PreparedArcsJoin::Curved(resolved)) = arcs_join {
+                        if let Some(ends) = resolved.clip_endpoints() {
+                            let ends = [point64_to_point(ends[0]), point64_to_point(ends[1])];
+                            if let [Ok(a), Ok(b)] = ends {
+                                round_clip::emit(
+                                    join,
+                                    [a, b],
+                                    resolved.clip_tangents(),
+                                    side,
+                                    options.tolerance,
+                                    vertex,
+                                    attributes,
+                                    output,
+                                )?;
+                            }
+                        }
+                    }
+                }
                 if !emitted {
                     tessellate_round_join(join, side, options, vertex, attributes, output)?;
                 }
+            }
+            LineJoin::MiterClip
+                if options.line_join == LineJoin::Arcs
+                    && options.arcs_clip == ArcsClip::Round =>
+            {
+                // A surviving pair of distinct outer vertices is the actual
+                // miter cut. Unclipped miters have a single shared vertex.
+                round_clip::emit(
+                    join,
+                    [join.side_points[side].prev, join.side_points[side].next],
+                    [
+                        round_clip::edge_tangent(neighbors[0], join, side),
+                        -round_clip::edge_tangent(join, neighbors[1], side),
+                    ],
+                    side,
+                    options.tolerance,
+                    vertex,
+                    attributes,
+                    output,
+                )?;
             }
             _ => {}
         }

--- a/crates/tessellation/src/stroke_arcs.rs
+++ b/crates/tessellation/src/stroke_arcs.rs
@@ -365,6 +365,23 @@ pub struct ResolvedArcsJoin {
 }
 
 impl ResolvedArcsJoin {
+    pub(crate) fn clip_endpoints(&self) -> Option<[Point64; 2]> {
+        self.clipped.then(|| {
+            [
+                boundary_end(self.incoming_boundary),
+                boundary_end(self.outgoing_boundary),
+            ]
+        })
+    }
+
+    /// Both directions point from the retained boundary towards the cut.
+    pub(crate) fn clip_tangents(&self) -> [Vector64; 2] {
+        [
+            boundary_end_tangent(self.incoming_boundary),
+            boundary_end_tangent(self.outgoing_boundary),
+        ]
+    }
+
     pub(crate) fn turn(&self) -> TurnSide {
         self.turn
     }
@@ -1068,6 +1085,16 @@ fn boundary_end(boundary: BoundaryPiece) -> Point64 {
     match boundary {
         BoundaryPiece::Line { end, .. } | BoundaryPiece::Arc { end, .. } => end,
     }
+}
+
+fn boundary_end_tangent(boundary: BoundaryPiece) -> Vector64 {
+    let tangent = match boundary {
+        BoundaryPiece::Line { start, end } => end - start,
+        BoundaryPiece::Arc {
+            end, center, sweep, ..
+        } => (end - center).left_normal() * if sweep.counter_clockwise() { 1.0 } else { -1.0 },
+    };
+    tangent * tangent.square_length().sqrt().recip()
 }
 
 fn boundary_start(boundary: BoundaryPiece) -> Point64 {

--- a/crates/tessellation/src/stroke_arcs.rs
+++ b/crates/tessellation/src/stroke_arcs.rs
@@ -1,0 +1,2033 @@
+//! Internal support geometry for constructing an SVG 2 `arcs` line join.
+//!
+//! This module deliberately stops before triangulation. `stroke` adapts Lyon's
+//! endpoint data into this module and owns the eventual mesh emission.
+
+use core::fmt;
+use core::ops::{Add, Mul, Neg, Sub};
+
+mod svg2;
+pub(crate) use svg2::construct_svg2;
+
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
+const PARALLEL_EPSILON: f64 = 1.0e-12;
+const GEOMETRY_EPSILON: f64 = 1.0e-12;
+
+/// A point represented with 64-bit coordinates.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Point64 {
+    /// Horizontal coordinate.
+    pub x: f64,
+    /// Vertical coordinate.
+    pub y: f64,
+}
+
+impl Point64 {
+    /// Creates a point from two coordinates.
+    #[must_use]
+    pub const fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+
+    fn is_finite(self) -> bool {
+        self.x.is_finite() && self.y.is_finite()
+    }
+}
+
+/// A two-dimensional vector represented with 64-bit components.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Vector64 {
+    /// Horizontal component.
+    pub x: f64,
+    /// Vertical component.
+    pub y: f64,
+}
+
+impl Vector64 {
+    /// Creates a vector from two components.
+    #[must_use]
+    pub const fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+
+    fn dot(self, other: Self) -> f64 {
+        self.x * other.x + self.y * other.y
+    }
+
+    pub(crate) fn cross(self, other: Self) -> f64 {
+        self.x * other.y - self.y * other.x
+    }
+
+    fn left_normal(self) -> Self {
+        Self::new(-self.y, self.x)
+    }
+
+    fn square_length(self) -> f64 {
+        self.dot(self)
+    }
+
+    fn is_finite(self) -> bool {
+        self.x.is_finite() && self.y.is_finite()
+    }
+}
+
+impl Add<Vector64> for Point64 {
+    type Output = Self;
+
+    fn add(self, vector: Vector64) -> Self::Output {
+        Self::new(self.x + vector.x, self.y + vector.y)
+    }
+}
+
+impl Sub<Vector64> for Point64 {
+    type Output = Self;
+
+    fn sub(self, vector: Vector64) -> Self::Output {
+        Self::new(self.x - vector.x, self.y - vector.y)
+    }
+}
+
+impl Sub<Point64> for Point64 {
+    type Output = Vector64;
+
+    fn sub(self, other: Point64) -> Self::Output {
+        Vector64::new(self.x - other.x, self.y - other.y)
+    }
+}
+
+impl Add for Vector64 {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        Self::new(self.x + other.x, self.y + other.y)
+    }
+}
+
+impl Sub for Vector64 {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Self::new(self.x - other.x, self.y - other.y)
+    }
+}
+
+impl Mul<f64> for Vector64 {
+    type Output = Self;
+
+    fn mul(self, scale: f64) -> Self::Output {
+        Self::new(self.x * scale, self.y * scale)
+    }
+}
+
+impl Neg for Vector64 {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::new(-self.x, -self.y)
+    }
+}
+
+/// Tangent and signed curvature of a path segment at the join point.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SegmentEnd {
+    /// Tangent following the path direction. It does not have to be normalized.
+    pub tangent: Vector64,
+    /// Signed curvature in inverse user units. A line has curvature zero.
+    pub curvature: f64,
+}
+
+/// Input required to analyze one outer `arcs` join.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct JoinInput {
+    /// Point shared by the incoming and outgoing path segments.
+    pub at: Point64,
+    /// Geometry at the end of the incoming segment.
+    pub incoming: SegmentEnd,
+    /// Geometry at the start of the outgoing segment.
+    pub outgoing: SegmentEnd,
+    /// Half of the stroke width in user units.
+    pub half_width: f64,
+    /// Maximum miter length as a multiple of the stroke width.
+    pub miter_limit: f64,
+}
+
+/// Direction in which the centerline turns at the join.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TurnSide {
+    /// The outgoing tangent lies to the left of the incoming tangent.
+    Left,
+    /// The outgoing tangent lies to the right of the incoming tangent.
+    Right,
+}
+
+/// Infinite line or circle extending one outer stroke edge.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SupportCurve {
+    /// A line used when the segment curvature is zero.
+    Line {
+        /// Point where the offset edge meets the join.
+        point: Point64,
+        /// Unit direction following the path.
+        direction: Vector64,
+    },
+    /// An osculating circle adjusted by half the stroke width.
+    Circle {
+        /// Center shared with the centerline osculating circle.
+        center: Point64,
+        /// Positive radius of the outer stroke edge.
+        radius: f64,
+    },
+}
+
+/// Result of intersecting two support curves.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Intersections {
+    /// The supports have no common point.
+    None,
+    /// The supports touch at one point.
+    One(Point64),
+    /// The supports cross at two points.
+    Two([Point64; 2]),
+    /// The supports describe the same infinite line or circle.
+    Coincident,
+}
+
+/// Compact representation of the symmetric roots produced by circle solvers.
+///
+/// Keeping the midpoint and offset separate lets join construction select the
+/// nearer root from one dot product, while diagnostics can still materialize
+/// both points through [`Self::all`].
+#[derive(Clone, Copy)]
+enum SymmetricIntersections {
+    None,
+    One(Point64),
+    Two { midpoint: Point64, offset: Vector64 },
+    Coincident,
+}
+
+impl SymmetricIntersections {
+    #[inline]
+    fn all(self) -> Intersections {
+        match self {
+            Self::None => Intersections::None,
+            Self::One(point) => Intersections::One(point),
+            Self::Two { midpoint, offset } => {
+                Intersections::Two([midpoint - offset, midpoint + offset])
+            }
+            Self::Coincident => Intersections::Coincident,
+        }
+    }
+
+    #[inline]
+    fn closest_to(self, at: Point64) -> Result<Point64, IntersectionProblem> {
+        match self {
+            Self::None => Err(IntersectionProblem::Disjoint),
+            Self::One(point) => Ok(point),
+            Self::Two { midpoint, offset } => {
+                if (at - midpoint).dot(offset) > 0.0 {
+                    Ok(midpoint + offset)
+                } else {
+                    Ok(midpoint - offset)
+                }
+            }
+            Self::Coincident => Err(IntersectionProblem::Coincident),
+        }
+    }
+}
+
+/// Diagnostic result for the first stage of `arcs` join construction.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg(test)]
+pub struct JoinAnalysis {
+    /// Direction of the centerline turn.
+    pub turn: TurnSide,
+    /// Join point on the outer incoming stroke edge.
+    pub incoming_offset_point: Point64,
+    /// Join point on the outer outgoing stroke edge.
+    pub outgoing_offset_point: Point64,
+    /// Extension of the incoming outer stroke edge.
+    pub incoming_support: SupportCurve,
+    /// Extension of the outgoing outer stroke edge.
+    pub outgoing_support: SupportCurve,
+    /// All intersections of the two infinite supports.
+    pub intersections: Intersections,
+}
+
+/// One finite edge of the outer `arcs` join boundary.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BoundaryPiece {
+    /// Straight extension of a zero-curvature offset edge.
+    Line {
+        /// Offset point where the extension begins.
+        start: Point64,
+        /// Resolved join vertex where the extension ends.
+        end: Point64,
+    },
+    /// Circular extension of a curved offset edge.
+    Arc {
+        /// Center of the final support circle.
+        center: Point64,
+        /// Positive radius of the final support circle.
+        radius: f64,
+        /// Offset point where the arc begins.
+        start: Point64,
+        /// Resolved join vertex where the arc ends.
+        end: Point64,
+        /// Lazily or eagerly resolved signed sweep from `start` to `end`.
+        sweep: ArcSweep,
+    },
+}
+
+/// A signed arc sweep whose zero representation defers the expensive angle.
+///
+/// Positive zero means counter-clockwise and negative zero means clockwise.
+/// A non-zero value contains the already resolved signed sweep in radians.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ArcSweep(f64);
+
+impl ArcSweep {
+    pub(crate) fn lazy(counter_clockwise: bool) -> Self {
+        Self(if counter_clockwise { 0.0 } else { -0.0 })
+    }
+
+    pub(crate) fn resolved(sweep_radians: f64) -> Self {
+        Self(sweep_radians)
+    }
+
+    pub(crate) fn counter_clockwise(self) -> bool {
+        self.0 > 0.0 || (self.0 == 0.0 && self.0.is_sign_positive())
+    }
+
+    pub(crate) fn resolve(self, start: Vector64, end: Vector64) -> f64 {
+        if self.0 == 0.0 {
+            directed_sweep_vectors(start, end, self.counter_clockwise())
+        } else {
+            self.0
+        }
+    }
+
+    pub(crate) fn resolved_radians(self) -> Option<f64> {
+        (self.0 != 0.0).then_some(self.0)
+    }
+
+    pub(crate) fn is_finite(self) -> bool {
+        self.0.is_finite()
+    }
+}
+
+#[cfg(not(test))]
+const _: () = assert!(core::mem::size_of::<BoundaryPiece>() <= 72);
+
+/// Edge introduced when the SVG miter limit clips an `arcs` join.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ClipEdge {
+    /// End of the clipped incoming boundary.
+    pub incoming: Point64,
+    /// End of the clipped outgoing boundary.
+    pub outgoing: Point64,
+    /// Point at the requested distance along the SVG miter-limit arc.
+    pub limit_point: Point64,
+    /// Unit direction of the clipping line, perpendicular to that arc.
+    pub line_direction: Vector64,
+}
+
+/// Fully resolved and miter-clipped support geometry for an `arcs` join.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ResolvedArcsJoin {
+    /// Direction of the centerline turn.
+    turn: TurnSide,
+    /// Finite continuation of the incoming offset edge toward the intersection.
+    incoming_boundary: BoundaryPiece,
+    /// Finite continuation of the outgoing offset edge toward the intersection.
+    outgoing_boundary: BoundaryPiece,
+    /// Whether a miter-limit edge connects the boundary endpoints.
+    clipped: bool,
+    /// Join point on the incoming outer stroke edge, retained for diagnostics.
+    #[cfg(test)]
+    pub incoming_offset_point: Point64,
+    /// Join point on the outgoing outer stroke edge, retained for diagnostics.
+    #[cfg(test)]
+    pub outgoing_offset_point: Point64,
+    /// Final incoming support after any radius correction, retained for diagnostics.
+    #[cfg(test)]
+    pub incoming_support: SupportCurve,
+    /// Final outgoing support after any radius correction, retained for diagnostics.
+    #[cfg(test)]
+    pub outgoing_support: SupportCurve,
+    /// Closest intersection of the final supports, retained for diagnostics.
+    #[cfg(test)]
+    pub intersection: Point64,
+    /// Common clipping edge, retained for diagnostics.
+    #[cfg(test)]
+    pub clip: Option<ClipEdge>,
+}
+
+impl ResolvedArcsJoin {
+    pub(crate) fn turn(&self) -> TurnSide {
+        self.turn
+    }
+
+    pub(crate) fn incoming_boundary(&self) -> BoundaryPiece {
+        self.incoming_boundary
+    }
+
+    pub(crate) fn outgoing_boundary(&self) -> BoundaryPiece {
+        self.outgoing_boundary
+    }
+
+    pub(crate) fn incoming_offset_point(&self) -> Point64 {
+        boundary_start(self.incoming_boundary)
+    }
+
+    pub(crate) fn outgoing_offset_point(&self) -> Point64 {
+        boundary_start(self.outgoing_boundary)
+    }
+
+    pub(crate) fn is_clipped(&self) -> bool {
+        self.clipped
+    }
+}
+
+#[cfg(not(test))]
+const _: () = assert!(core::mem::size_of::<ResolvedArcsJoin>() <= 152);
+
+/// Rectangle required by SVG 2 when opposite parallel tangents cannot be
+/// connected by adjusted support circles.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ParallelRectangleJoin {
+    /// Corner on the left of the incoming tangent at the join point.
+    pub near_left: Point64,
+    /// Corner on the right of the incoming tangent at the join point.
+    pub near_right: Point64,
+    /// Outer corner reached from `near_left` along the incoming tangent.
+    pub far_left: Point64,
+    /// Outer corner reached from `near_right` along the incoming tangent.
+    pub far_right: Point64,
+}
+
+/// Join whose miter-limit line crosses the radial bevel edges before the
+/// curved support extensions begin.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RadialClipJoin {
+    /// Direction of the centerline turn.
+    pub turn: TurnSide,
+    /// Outer stroke point at the end of the incoming segment.
+    pub incoming_offset_point: Point64,
+    /// Outer stroke point at the start of the outgoing segment.
+    pub outgoing_offset_point: Point64,
+    /// Intersection with the edge from the join point to the incoming offset.
+    pub incoming: Point64,
+    /// Intersection with the edge from the join point to the outgoing offset.
+    pub outgoing: Point64,
+    /// Point at the requested distance along the SVG miter-limit arc.
+    pub limit_point: Point64,
+    /// Unit direction of the clipping line, perpendicular to that arc.
+    pub line_direction: Vector64,
+}
+
+/// Result selected by the SVG 2 `arcs` fallback rules.
+#[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)] // A join in the tessellator's hot path must not allocate.
+pub enum JoinConstruction {
+    /// Equal tangents need no join region.
+    Empty,
+    /// Two straight supports use the `miter-clip` algorithm.
+    MiterClip,
+    /// Opposite parallel tangents use the SVG 2 rectangular fallback.
+    ParallelRectangle(ParallelRectangleJoin),
+    /// The miter-limit line crosses both radial bevel edges.
+    RadialClip(RadialClipJoin),
+    /// Curved supports were resolved to a single intersection.
+    Arcs(ResolvedArcsJoin),
+}
+
+#[cfg(not(test))]
+const _: () = assert!(core::mem::size_of::<JoinConstruction>() <= 152);
+
+/// An invalid or numerically degenerate join input.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct JoinError(JoinErrorKind);
+
+impl From<JoinErrorKind> for JoinError {
+    fn from(kind: JoinErrorKind) -> Self {
+        Self(kind)
+    }
+}
+
+impl fmt::Display for JoinError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            JoinErrorKind::ExcessiveOuterCurvature => {
+                formatter.write_str("SVG 2 outer curvature exceeds 2 / stroke-width")
+            }
+            JoinErrorKind::RadiusAdjustmentFailed => {
+                formatter.write_str("SVG 2 radius adjustment has no finite tangent solution")
+            }
+            JoinErrorKind::NonFinitePoint => {
+                formatter.write_str("join point contains a non-finite coordinate")
+            }
+            JoinErrorKind::NonFiniteTangent { segment } => {
+                write!(
+                    formatter,
+                    "{segment} tangent contains a non-finite component"
+                )
+            }
+            JoinErrorKind::ZeroTangent { segment } => {
+                write!(formatter, "{segment} tangent has zero length")
+            }
+            JoinErrorKind::NonFiniteCurvature { segment } => {
+                write!(formatter, "{segment} curvature is not finite")
+            }
+            JoinErrorKind::InvalidHalfWidth => {
+                formatter.write_str("half width must be finite and greater than zero")
+            }
+            JoinErrorKind::InvalidMiterLimit => {
+                formatter.write_str("miter limit must be finite and non-negative")
+            }
+            JoinErrorKind::CollinearTangents => {
+                formatter.write_str("collinear tangents do not define an outer side")
+            }
+            JoinErrorKind::NoUniqueIntersection => {
+                formatter.write_str("the original supports have no unique intersection")
+            }
+            JoinErrorKind::CollapsedOffsetCircle { segment } => {
+                write!(formatter, "{segment} offset circle collapses to a point")
+            }
+            JoinErrorKind::MiterClipMissesBoundary { segment } => write!(
+                formatter,
+                "the miter-limit line does not cross the {segment} join boundary"
+            ),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum JoinErrorKind {
+    ExcessiveOuterCurvature,
+    RadiusAdjustmentFailed,
+    NonFinitePoint,
+    NonFiniteTangent { segment: &'static str },
+    ZeroTangent { segment: &'static str },
+    NonFiniteCurvature { segment: &'static str },
+    InvalidHalfWidth,
+    InvalidMiterLimit,
+    CollinearTangents,
+    NoUniqueIntersection,
+    CollapsedOffsetCircle { segment: &'static str },
+    MiterClipMissesBoundary { segment: &'static str },
+}
+
+#[derive(Clone, Copy)]
+struct PreparedJoin {
+    turn: TurnSide,
+    incoming_tangent: Vector64,
+    outgoing_tangent: Vector64,
+    incoming_offset_point: Point64,
+    outgoing_offset_point: Point64,
+    incoming_support: SupportCurve,
+    outgoing_support: SupportCurve,
+}
+
+#[cfg(test)]
+pub(crate) fn construct(input: JoinInput) -> Result<JoinConstruction, JoinError> {
+    construct_svg2(input)
+}
+
+#[inline]
+pub(crate) fn outer_curvature_values(input: JoinInput, tangent_cross: f64) -> (f64, f64, f64) {
+    let curvature_limit = input.half_width.recip();
+    if tangent_cross.abs() <= PARALLEL_EPSILON {
+        return (
+            input.incoming.curvature.abs(),
+            input.outgoing.curvature.abs(),
+            curvature_limit,
+        );
+    }
+
+    let outer_side_sign = if tangent_cross > 0.0 { -1.0 } else { 1.0 };
+
+    (
+        input.incoming.curvature * outer_side_sign,
+        input.outgoing.curvature * outer_side_sign,
+        curvature_limit,
+    )
+}
+
+fn parallel_rectangle(input: JoinInput, incoming_tangent: Vector64) -> ParallelRectangleJoin {
+    let normal = incoming_tangent.left_normal() * input.half_width;
+    let extension = incoming_tangent * (input.half_width * input.miter_limit);
+    let near_left = input.at + normal;
+    let near_right = input.at - normal;
+    ParallelRectangleJoin {
+        near_left,
+        near_right,
+        far_left: near_left + extension,
+        far_right: near_right + extension,
+    }
+}
+
+/// Builds the two infinite supports required by an `arcs` join and intersects them.
+///
+/// The function uses a mathematical coordinate system where positive curvature
+/// turns left. It does not choose the closest intersection, adjust disjoint
+/// circles, apply the miter limit, or triangulate the join.
+///
+/// # Errors
+///
+/// Returns [`JoinError`] for non-finite values, zero tangents, collinear
+/// tangents, non-positive stroke width, or a collapsed offset circle.
+///
+#[must_use = "the support analysis must be handled"]
+#[cfg(test)]
+pub fn analyze(input: JoinInput) -> Result<JoinAnalysis, JoinError> {
+    validate_input(input)?;
+
+    let incoming_tangent = normalize(input.incoming.tangent, "incoming")?;
+    let outgoing_tangent = normalize(input.outgoing.tangent, "outgoing")?;
+    let prepared = prepare_join(input, incoming_tangent, outgoing_tangent)?;
+    let intersections = intersect_supports(prepared.incoming_support, prepared.outgoing_support);
+
+    Ok(JoinAnalysis {
+        turn: prepared.turn,
+        incoming_offset_point: prepared.incoming_offset_point,
+        outgoing_offset_point: prepared.outgoing_offset_point,
+        incoming_support: prepared.incoming_support,
+        outgoing_support: prepared.outgoing_support,
+        intersections,
+    })
+}
+
+fn prepare_join(
+    input: JoinInput,
+    incoming_tangent: Vector64,
+    outgoing_tangent: Vector64,
+) -> Result<PreparedJoin, JoinError> {
+    let turn_cross = incoming_tangent.cross(outgoing_tangent);
+    let (turn, offset_distance) = if turn_cross > PARALLEL_EPSILON {
+        (TurnSide::Left, -input.half_width)
+    } else if turn_cross < -PARALLEL_EPSILON {
+        (TurnSide::Right, input.half_width)
+    } else {
+        return Err(JoinErrorKind::CollinearTangents.into());
+    };
+
+    let incoming_offset_point = input.at + incoming_tangent.left_normal() * offset_distance;
+    let outgoing_offset_point = input.at + outgoing_tangent.left_normal() * offset_distance;
+    let incoming_support = build_support(
+        incoming_offset_point,
+        incoming_tangent,
+        input.incoming.curvature,
+        offset_distance,
+        "incoming",
+    )?;
+    let outgoing_support = build_support(
+        outgoing_offset_point,
+        outgoing_tangent,
+        input.outgoing.curvature,
+        offset_distance,
+        "outgoing",
+    )?;
+    Ok(PreparedJoin {
+        turn,
+        incoming_tangent,
+        outgoing_tangent,
+        incoming_offset_point,
+        outgoing_offset_point,
+        incoming_support,
+        outgoing_support,
+    })
+}
+
+fn validate_input(input: JoinInput) -> Result<(), JoinError> {
+    if !input.at.is_finite() {
+        return Err(JoinErrorKind::NonFinitePoint.into());
+    }
+    if !input.incoming.tangent.is_finite() {
+        return Err(JoinErrorKind::NonFiniteTangent {
+            segment: "incoming",
+        }
+        .into());
+    }
+    if !input.outgoing.tangent.is_finite() {
+        return Err(JoinErrorKind::NonFiniteTangent {
+            segment: "outgoing",
+        }
+        .into());
+    }
+    if !input.incoming.curvature.is_finite() {
+        return Err(JoinErrorKind::NonFiniteCurvature {
+            segment: "incoming",
+        }
+        .into());
+    }
+    if !input.outgoing.curvature.is_finite() {
+        return Err(JoinErrorKind::NonFiniteCurvature {
+            segment: "outgoing",
+        }
+        .into());
+    }
+    if !input.half_width.is_finite() || input.half_width <= 0.0 {
+        return Err(JoinErrorKind::InvalidHalfWidth.into());
+    }
+    if !input.miter_limit.is_finite() || input.miter_limit < 0.0 {
+        return Err(JoinErrorKind::InvalidMiterLimit.into());
+    }
+
+    Ok(())
+}
+
+fn normalize(vector: Vector64, segment: &'static str) -> Result<Vector64, JoinError> {
+    let length = vector.x.hypot(vector.y);
+    if length <= 0.0 {
+        return Err(JoinErrorKind::ZeroTangent { segment }.into());
+    }
+
+    Ok(vector * length.recip())
+}
+
+fn build_support(
+    offset_point: Point64,
+    tangent: Vector64,
+    curvature: f64,
+    offset_distance: f64,
+    segment: &'static str,
+) -> Result<SupportCurve, JoinError> {
+    let signed_center_radius = curvature.recip();
+    if !signed_center_radius.is_finite() {
+        return Ok(SupportCurve::Line {
+            point: offset_point,
+            direction: tangent,
+        });
+    }
+
+    let signed_offset_radius = signed_center_radius - offset_distance;
+    let radius = signed_offset_radius.abs();
+    let scale = signed_center_radius
+        .abs()
+        .max(offset_distance.abs())
+        .max(1.0);
+    if radius <= GEOMETRY_EPSILON * scale {
+        return Err(JoinErrorKind::CollapsedOffsetCircle { segment }.into());
+    }
+
+    let center_direction = if signed_offset_radius > 0.0 {
+        tangent.left_normal()
+    } else {
+        -tangent.left_normal()
+    };
+    Ok(SupportCurve::Circle {
+        center: offset_point + center_direction * radius,
+        radius,
+    })
+}
+
+fn resolve_boundaries<const EARLY_MITER_ACCEPT: bool, const EAGER_SWEEP: bool>(
+    input: JoinInput,
+    prepared: PreparedJoin,
+    intersection: Point64,
+) -> Result<JoinConstruction, JoinError> {
+    let incoming_support = prepared.incoming_support;
+    let outgoing_support = prepared.outgoing_support;
+    let incoming_boundary = build_boundary_piece::<EAGER_SWEEP>(
+        incoming_support,
+        prepared.incoming_offset_point,
+        intersection,
+        prepared.incoming_tangent,
+    );
+    let outgoing_boundary = build_boundary_piece::<EAGER_SWEEP>(
+        outgoing_support,
+        prepared.outgoing_offset_point,
+        intersection,
+        -prepared.outgoing_tangent,
+    );
+
+    // Equal curvatures already use the cheaper zero-denominator chord fallback.
+    let asymmetric_curvature =
+        input.incoming.curvature.to_bits() != input.outgoing.curvature.to_bits();
+    let clipped = if EARLY_MITER_ACCEPT && asymmetric_curvature {
+        apply_miter_limit::<true>(
+            input,
+            prepared,
+            intersection,
+            incoming_boundary,
+            outgoing_boundary,
+        )?
+    } else {
+        apply_miter_limit::<false>(
+            input,
+            prepared,
+            intersection,
+            incoming_boundary,
+            outgoing_boundary,
+        )?
+    };
+    let (incoming_boundary, outgoing_boundary, clip) = match clipped {
+        MiterLimitResult::SupportBoundaries {
+            incoming_boundary,
+            outgoing_boundary,
+            clip,
+        } => (incoming_boundary, outgoing_boundary, clip),
+        MiterLimitResult::RadialEdges(join) => {
+            return Ok(JoinConstruction::RadialClip(join));
+        }
+    };
+    Ok(JoinConstruction::Arcs(ResolvedArcsJoin {
+        turn: prepared.turn,
+        incoming_boundary,
+        outgoing_boundary,
+        clipped: clip.is_some(),
+        #[cfg(test)]
+        incoming_offset_point: prepared.incoming_offset_point,
+        #[cfg(test)]
+        outgoing_offset_point: prepared.outgoing_offset_point,
+        #[cfg(test)]
+        incoming_support,
+        #[cfg(test)]
+        outgoing_support,
+        #[cfg(test)]
+        intersection,
+        #[cfg(test)]
+        clip,
+    }))
+}
+
+#[derive(Clone, Copy)]
+struct ClipLine {
+    point: Point64,
+    direction: Vector64,
+}
+
+enum MiterLimitResult {
+    SupportBoundaries {
+        incoming_boundary: BoundaryPiece,
+        outgoing_boundary: BoundaryPiece,
+        clip: Option<ClipEdge>,
+    },
+    RadialEdges(RadialClipJoin),
+}
+
+fn apply_miter_limit<const EARLY_ACCEPT: bool>(
+    input: JoinInput,
+    prepared: PreparedJoin,
+    intersection: Point64,
+    incoming_boundary: BoundaryPiece,
+    outgoing_boundary: BoundaryPiece,
+) -> Result<MiterLimitResult, JoinError> {
+    let limit = input.half_width * input.miter_limit;
+    let Some(clip_line) = miter_clip_line::<EARLY_ACCEPT>(
+        input.at,
+        prepared.incoming_offset_point,
+        prepared.outgoing_offset_point,
+        intersection,
+        limit,
+    ) else {
+        return Ok(MiterLimitResult::SupportBoundaries {
+            incoming_boundary,
+            outgoing_boundary,
+            clip: None,
+        });
+    };
+    match (
+        clip_boundary(incoming_boundary, clip_line, "incoming"),
+        clip_boundary(outgoing_boundary, clip_line, "outgoing"),
+    ) {
+        (Ok(incoming_boundary), Ok(outgoing_boundary)) => {
+            let clip = ClipEdge {
+                incoming: boundary_end(incoming_boundary),
+                outgoing: boundary_end(outgoing_boundary),
+                limit_point: clip_line.point,
+                line_direction: clip_line.direction,
+            };
+            Ok(MiterLimitResult::SupportBoundaries {
+                incoming_boundary,
+                outgoing_boundary,
+                clip: Some(clip),
+            })
+        }
+        _ => Ok(MiterLimitResult::RadialEdges(RadialClipJoin {
+            turn: prepared.turn,
+            incoming_offset_point: prepared.incoming_offset_point,
+            outgoing_offset_point: prepared.outgoing_offset_point,
+            incoming: clip_radial_edge(
+                input.at,
+                prepared.incoming_offset_point,
+                clip_line,
+                "incoming",
+            )?,
+            outgoing: clip_radial_edge(
+                input.at,
+                prepared.outgoing_offset_point,
+                clip_line,
+                "outgoing",
+            )?,
+            limit_point: clip_line.point,
+            line_direction: clip_line.direction,
+        })),
+    }
+}
+
+fn clip_radial_edge(
+    at: Point64,
+    offset_point: Point64,
+    clip_line: ClipLine,
+    segment: &'static str,
+) -> Result<Point64, JoinError> {
+    let radial = offset_point - at;
+    let denominator = radial.cross(clip_line.direction);
+    if denominator.abs() <= PARALLEL_EPSILON {
+        return Err(JoinErrorKind::MiterClipMissesBoundary { segment }.into());
+    }
+
+    let parameter = (clip_line.point - at).cross(clip_line.direction) / denominator;
+    let epsilon = GEOMETRY_EPSILON * parameter.abs().max(1.0);
+    if parameter < -epsilon || parameter > 1.0 + epsilon {
+        return Err(JoinErrorKind::MiterClipMissesBoundary { segment }.into());
+    }
+
+    Ok(at + radial * parameter.clamp(0.0, 1.0))
+}
+
+fn miter_clip_line<const EARLY_ACCEPT: bool>(
+    at: Point64,
+    incoming_offset_point: Point64,
+    outgoing_offset_point: Point64,
+    intersection: Point64,
+    limit: f64,
+) -> Option<ClipLine> {
+    let bisector_vector = (incoming_offset_point - at) + (outgoing_offset_point - at);
+    let to_intersection = intersection - at;
+
+    if EARLY_ACCEPT && miter_arc_fits_limit(bisector_vector, to_intersection, limit) {
+        return None;
+    }
+    let bisector = normalized(bisector_vector)?;
+    let normal = bisector.left_normal();
+    let denominator = 2.0 * to_intersection.dot(normal);
+    let scale = to_intersection.x.hypot(to_intersection.y).max(1.0);
+
+    if denominator.abs() <= GEOMETRY_EPSILON * scale {
+        let total_length = to_intersection.x.hypot(to_intersection.y);
+        if total_length <= limit + GEOMETRY_EPSILON * total_length.max(1.0) {
+            return None;
+        }
+
+        return Some(ClipLine {
+            point: at + bisector * limit,
+            direction: normal,
+        });
+    }
+
+    let signed_center_distance = to_intersection.square_length() / denominator;
+    let center = at + normal * signed_center_distance;
+    let radius = signed_center_distance.abs();
+    let start_radius = at - center;
+    let end_radius = intersection - center;
+    let sweep = directed_sweep_vectors(start_radius, end_radius, signed_center_distance > 0.0);
+    let total_length = radius * sweep.abs();
+    if total_length <= limit + GEOMETRY_EPSILON * total_length.max(1.0) {
+        return None;
+    }
+
+    let limit_angle = sweep.signum() * limit / radius;
+    let (limit_sine, limit_cosine) = limit_angle.sin_cos();
+    let start_unit_radius = start_radius * radius.recip();
+    let limit_radius = Vector64::new(
+        start_unit_radius.x * limit_cosine - start_unit_radius.y * limit_sine,
+        start_unit_radius.x * limit_sine + start_unit_radius.y * limit_cosine,
+    );
+
+    Some(ClipLine {
+        point: center + limit_radius * radius,
+        direction: limit_radius,
+    })
+}
+
+/// Proves that the auxiliary miter arc fits without constructing its circle.
+///
+/// A minor circular arc is at most `π / 2` times its chord. Ambiguous
+/// orientations and zero denominators stay on the exact path so this check can
+/// only accept, never introduce clipping differences near a half turn.
+#[allow(clippy::float_cmp)] // Exact zero is routed to the existing tolerant fallback.
+#[inline(always)]
+fn miter_arc_fits_limit(bisector: Vector64, to_intersection: Vector64, limit: f64) -> bool {
+    const MAX_LENGTH_TO_CHORD_SQUARED: f64 =
+        core::f64::consts::FRAC_PI_2 * core::f64::consts::FRAC_PI_2;
+    const ROUNDING_MARGIN: f64 = 1.0 + 32.0 * f64::EPSILON;
+
+    let chord_squared = to_intersection.square_length();
+    let limit_squared = limit * limit;
+    let chord_upper_squared = chord_squared * ROUNDING_MARGIN;
+    let chord_fits = chord_upper_squared <= limit_squared;
+    if !chord_fits {
+        return false;
+    }
+
+    let normal = bisector.left_normal();
+    if normal.dot(to_intersection) == 0.0 {
+        return false;
+    }
+
+    let upper_length_squared = chord_upper_squared * MAX_LENGTH_TO_CHORD_SQUARED;
+    let minor_arc_fits = upper_length_squared <= limit_squared;
+    if !minor_arc_fits {
+        return false;
+    }
+
+    let orientation = normal.cross(to_intersection);
+    let orientation_scale =
+        (normal.x * to_intersection.y).abs() + (normal.y * to_intersection.x).abs();
+
+    orientation < -GEOMETRY_EPSILON * orientation_scale
+}
+
+fn clip_boundary(
+    boundary: BoundaryPiece,
+    clip_line: ClipLine,
+    segment: &'static str,
+) -> Result<BoundaryPiece, JoinError> {
+    match boundary {
+        BoundaryPiece::Line { start, end } => {
+            let boundary_direction = end - start;
+            let denominator = boundary_direction.cross(clip_line.direction);
+            if denominator.abs() <= PARALLEL_EPSILON {
+                return Err(JoinErrorKind::MiterClipMissesBoundary { segment }.into());
+            }
+            let parameter = (clip_line.point - start).cross(clip_line.direction) / denominator;
+            let epsilon = GEOMETRY_EPSILON * parameter.abs().max(1.0);
+            if parameter < -epsilon || parameter > 1.0 + epsilon {
+                return Err(JoinErrorKind::MiterClipMissesBoundary { segment }.into());
+            }
+
+            Ok(BoundaryPiece::Line {
+                start,
+                end: start + boundary_direction * parameter.clamp(0.0, 1.0),
+            })
+        }
+        BoundaryPiece::Arc {
+            center,
+            radius,
+            start,
+            end,
+            sweep,
+        } => {
+            let start_radius = start - center;
+            let end_radius = end - center;
+            let sweep_radians = sweep.resolve(start_radius, end_radius);
+            let intersections =
+                line_circle_intersections(clip_line.point, clip_line.direction, center, radius);
+            let clipped = intersection_points(intersections)
+                .iter()
+                .copied()
+                .flatten()
+                .filter_map(|point| {
+                    let candidate_radius = point - center;
+                    let candidate_sweep = directed_sweep_vectors(
+                        start_radius,
+                        candidate_radius,
+                        sweep.counter_clockwise(),
+                    );
+                    let epsilon = GEOMETRY_EPSILON * sweep_radians.abs().max(1.0);
+                    (candidate_sweep.abs() <= sweep_radians.abs() + epsilon).then_some((
+                        candidate_sweep.abs(),
+                        point,
+                        candidate_sweep,
+                    ))
+                })
+                .min_by(|first, second| first.0.total_cmp(&second.0));
+            let Some((_, clipped_end, clipped_sweep)) = clipped else {
+                return Err(JoinErrorKind::MiterClipMissesBoundary { segment }.into());
+            };
+
+            Ok(BoundaryPiece::Arc {
+                center,
+                radius,
+                start,
+                end: clipped_end,
+                sweep: ArcSweep::resolved(clipped_sweep),
+            })
+        }
+    }
+}
+
+fn normalized(vector: Vector64) -> Option<Vector64> {
+    let length = vector.x.hypot(vector.y);
+    (length > GEOMETRY_EPSILON).then_some(vector * length.recip())
+}
+
+fn intersection_points(intersections: Intersections) -> [Option<Point64>; 2] {
+    match intersections {
+        Intersections::None | Intersections::Coincident => [None, None],
+        Intersections::One(point) => [Some(point), None],
+        Intersections::Two([first, second]) => [Some(first), Some(second)],
+    }
+}
+
+fn boundary_end(boundary: BoundaryPiece) -> Point64 {
+    match boundary {
+        BoundaryPiece::Line { end, .. } | BoundaryPiece::Arc { end, .. } => end,
+    }
+}
+
+fn boundary_start(boundary: BoundaryPiece) -> Point64 {
+    match boundary {
+        BoundaryPiece::Line { start, .. } | BoundaryPiece::Arc { start, .. } => start,
+    }
+}
+
+fn build_boundary_piece<const EAGER_SWEEP: bool>(
+    support: SupportCurve,
+    start: Point64,
+    end: Point64,
+    desired_start_tangent: Vector64,
+) -> BoundaryPiece {
+    let SupportCurve::Circle { center, radius } = support else {
+        return BoundaryPiece::Line { start, end };
+    };
+
+    let start_radius = start - center;
+    let end_radius = end - center;
+    let counter_clockwise = start_radius.cross(desired_start_tangent) > 0.0;
+    let sweep = if EAGER_SWEEP {
+        ArcSweep::resolved(directed_sweep_vectors(
+            start_radius,
+            end_radius,
+            counter_clockwise,
+        ))
+    } else {
+        ArcSweep::lazy(counter_clockwise)
+    };
+
+    BoundaryPiece::Arc {
+        center,
+        radius,
+        start,
+        end,
+        sweep,
+    }
+}
+
+#[cfg(test)]
+fn directed_sweep(start: f64, end: f64, counter_clockwise: bool) -> f64 {
+    if counter_clockwise {
+        positive_modulo(end - start, core::f64::consts::TAU)
+    } else {
+        -positive_modulo(start - end, core::f64::consts::TAU)
+    }
+}
+
+pub(crate) fn directed_sweep_vectors(
+    start: Vector64,
+    end: Vector64,
+    counter_clockwise: bool,
+) -> f64 {
+    let signed_sweep = start.cross(end).atan2(start.dot(end));
+    if counter_clockwise {
+        if signed_sweep < 0.0 {
+            signed_sweep + core::f64::consts::TAU
+        } else {
+            signed_sweep
+        }
+    } else if signed_sweep > 0.0 {
+        signed_sweep - core::f64::consts::TAU
+    } else {
+        signed_sweep
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn directed_sweep_vectors_with_modulo(
+    start: Vector64,
+    end: Vector64,
+    counter_clockwise: bool,
+) -> f64 {
+    let signed_sweep = start.cross(end).atan2(start.dot(end));
+    if counter_clockwise {
+        positive_modulo(signed_sweep, core::f64::consts::TAU)
+    } else {
+        -positive_modulo(-signed_sweep, core::f64::consts::TAU)
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn directed_sweep_with_endpoint_angles(
+    start: Vector64,
+    end: Vector64,
+    counter_clockwise: bool,
+) -> f64 {
+    directed_sweep(
+        start.y.atan2(start.x),
+        end.y.atan2(end.x),
+        counter_clockwise,
+    )
+}
+
+fn positive_modulo(value: f64, modulus: f64) -> f64 {
+    let remainder = value % modulus;
+    if remainder < 0.0 {
+        remainder + modulus
+    } else {
+        remainder
+    }
+}
+
+#[derive(Clone, Copy)]
+enum IntersectionProblem {
+    Disjoint,
+    Coincident,
+}
+
+fn closest_intersection(
+    intersections: Intersections,
+    at: Point64,
+) -> Result<Point64, IntersectionProblem> {
+    match intersections {
+        Intersections::None => Err(IntersectionProblem::Disjoint),
+        Intersections::One(point) => Ok(point),
+        Intersections::Two([first, second]) => {
+            let first_distance = (first - at).square_length();
+            let second_distance = (second - at).square_length();
+            if first_distance <= second_distance {
+                Ok(first)
+            } else {
+                Ok(second)
+            }
+        }
+        Intersections::Coincident => Err(IntersectionProblem::Coincident),
+    }
+}
+
+fn intersect_supports(first: SupportCurve, second: SupportCurve) -> Intersections {
+    match (first, second) {
+        (
+            SupportCurve::Line {
+                point: first_point,
+                direction: first_direction,
+            },
+            SupportCurve::Line {
+                point: second_point,
+                direction: second_direction,
+            },
+        ) => line_line_intersections(first_point, first_direction, second_point, second_direction),
+        (SupportCurve::Line { point, direction }, SupportCurve::Circle { center, radius })
+        | (SupportCurve::Circle { center, radius }, SupportCurve::Line { point, direction }) => {
+            line_circle_intersections(point, direction, center, radius)
+        }
+        (
+            SupportCurve::Circle {
+                center: first_center,
+                radius: first_radius,
+            },
+            SupportCurve::Circle {
+                center: second_center,
+                radius: second_radius,
+            },
+        ) => circle_circle_intersections(first_center, first_radius, second_center, second_radius),
+    }
+}
+
+fn closest_support_intersection(
+    first: SupportCurve,
+    second: SupportCurve,
+    at: Point64,
+) -> Result<Point64, IntersectionProblem> {
+    match (first, second) {
+        (
+            SupportCurve::Line {
+                point: first_point,
+                direction: first_direction,
+            },
+            SupportCurve::Line {
+                point: second_point,
+                direction: second_direction,
+            },
+        ) => closest_intersection(
+            line_line_intersections(first_point, first_direction, second_point, second_direction),
+            at,
+        ),
+        (SupportCurve::Line { point, direction }, SupportCurve::Circle { center, radius })
+        | (SupportCurve::Circle { center, radius }, SupportCurve::Line { point, direction }) => {
+            solve_line_circle(point, direction, center, radius).closest_to(at)
+        }
+        (
+            SupportCurve::Circle {
+                center: first_center,
+                radius: first_radius,
+            },
+            SupportCurve::Circle {
+                center: second_center,
+                radius: second_radius,
+            },
+        ) => solve_circle_circle(first_center, first_radius, second_center, second_radius)
+            .closest_to(at),
+    }
+}
+
+fn line_line_intersections(
+    first_point: Point64,
+    first_direction: Vector64,
+    second_point: Point64,
+    second_direction: Vector64,
+) -> Intersections {
+    let denominator = first_direction.cross(second_direction);
+    let between = second_point - first_point;
+    if denominator.abs() <= PARALLEL_EPSILON {
+        let scale = between.x.abs().max(between.y.abs()).max(1.0);
+        if between.cross(first_direction).abs() <= GEOMETRY_EPSILON * scale {
+            return Intersections::Coincident;
+        }
+        return Intersections::None;
+    }
+
+    let first_parameter = between.cross(second_direction) / denominator;
+    Intersections::One(first_point + first_direction * first_parameter)
+}
+
+fn line_circle_intersections(
+    line_point: Point64,
+    line_direction: Vector64,
+    circle_center: Point64,
+    circle_radius: f64,
+) -> Intersections {
+    solve_line_circle(line_point, line_direction, circle_center, circle_radius).all()
+}
+
+fn solve_line_circle(
+    line_point: Point64,
+    line_direction: Vector64,
+    circle_center: Point64,
+    circle_radius: f64,
+) -> SymmetricIntersections {
+    let to_center = circle_center - line_point;
+    let closest = line_point + line_direction * to_center.dot(line_direction);
+    let closest_delta = closest - circle_center;
+    let radius_squared = circle_radius * circle_radius;
+    let distance_squared = closest_delta.square_length();
+    let remaining_squared = radius_squared - distance_squared;
+    let epsilon = GEOMETRY_EPSILON * radius_squared.max(distance_squared).max(1.0);
+
+    if remaining_squared < -epsilon {
+        return SymmetricIntersections::None;
+    }
+    if remaining_squared.abs() <= epsilon {
+        return SymmetricIntersections::One(closest);
+    }
+
+    let distance_along_line = remaining_squared.sqrt();
+    SymmetricIntersections::Two {
+        midpoint: closest,
+        offset: line_direction * distance_along_line,
+    }
+}
+
+fn circle_circle_intersections(
+    first_center: Point64,
+    first_radius: f64,
+    second_center: Point64,
+    second_radius: f64,
+) -> Intersections {
+    solve_circle_circle(first_center, first_radius, second_center, second_radius).all()
+}
+
+fn solve_circle_circle(
+    first_center: Point64,
+    first_radius: f64,
+    second_center: Point64,
+    second_radius: f64,
+) -> SymmetricIntersections {
+    let between = second_center - first_center;
+    let center_distance = between.x.hypot(between.y);
+    let scale = first_radius
+        .max(second_radius)
+        .max(center_distance)
+        .max(1.0);
+    let epsilon = GEOMETRY_EPSILON * scale;
+
+    if center_distance <= epsilon {
+        return if (first_radius - second_radius).abs() <= epsilon {
+            SymmetricIntersections::Coincident
+        } else {
+            SymmetricIntersections::None
+        };
+    }
+
+    let radius_sum = first_radius + second_radius;
+    let radius_difference = (first_radius - second_radius).abs();
+    if center_distance > radius_sum + epsilon || center_distance < radius_difference - epsilon {
+        return SymmetricIntersections::None;
+    }
+
+    let along_centers = (center_distance * center_distance + first_radius * first_radius
+        - second_radius * second_radius)
+        / (2.0 * center_distance);
+    let height_squared = first_radius * first_radius - along_centers * along_centers;
+    let squared_epsilon = GEOMETRY_EPSILON * first_radius.max(second_radius).max(1.0).powi(2);
+    let center_direction = between * center_distance.recip();
+    let midpoint = first_center + center_direction * along_centers;
+
+    if height_squared.abs() <= squared_epsilon {
+        return SymmetricIntersections::One(midpoint);
+    }
+    if height_squared < 0.0 {
+        return SymmetricIntersections::None;
+    }
+
+    let perpendicular = center_direction.left_normal() * height_squared.sqrt();
+    SymmetricIntersections::Two {
+        midpoint,
+        offset: perpendicular,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+
+    use super::*;
+
+    const TEST_EPSILON: f64 = 1.0e-9;
+
+    #[test]
+    fn vector_sweep_keeps_a_small_counter_clockwise_turn_small() {
+        let epsilon = 1.0e-6_f64;
+        let start = Vector64::new(1.0, 0.0);
+        let end = Vector64::new(epsilon.cos(), epsilon.sin());
+
+        let sweep = directed_sweep_vectors(start, end, true);
+
+        assert!(near(sweep, epsilon));
+    }
+
+    #[test]
+    fn vector_sweep_keeps_a_small_clockwise_turn_small() {
+        let epsilon = 1.0e-6_f64;
+        let start = Vector64::new(1.0, 0.0);
+        let end = Vector64::new(epsilon.cos(), -epsilon.sin());
+
+        let sweep = directed_sweep_vectors(start, end, false);
+
+        assert!(near(sweep, -epsilon));
+    }
+
+    #[test]
+    fn vector_sweep_selects_the_long_turn_in_each_direction() {
+        let epsilon = 1.0e-6_f64;
+        let start = Vector64::new(1.0, 0.0);
+        let above = Vector64::new(epsilon.cos(), epsilon.sin());
+        let below = Vector64::new(epsilon.cos(), -epsilon.sin());
+
+        let clockwise = directed_sweep_vectors(start, above, false);
+        let counter_clockwise = directed_sweep_vectors(start, below, true);
+
+        assert!(
+            near(clockwise, -(core::f64::consts::TAU - epsilon))
+                && near(counter_clockwise, core::f64::consts::TAU - epsilon)
+        );
+    }
+
+    #[test]
+    fn vector_sweep_preserves_the_direction_of_a_half_turn() {
+        let start = Vector64::new(1.0, 0.0);
+        let opposite = Vector64::new(-1.0, 0.0);
+
+        let counter_clockwise = directed_sweep_vectors(start, opposite, true);
+        let clockwise = directed_sweep_vectors(start, opposite, false);
+
+        assert!(
+            near(counter_clockwise, core::f64::consts::PI)
+                && near(clockwise, -core::f64::consts::PI)
+        );
+    }
+
+    #[test]
+    fn vector_sweep_maps_equal_radii_to_zero_in_both_directions() {
+        let radius = Vector64::new(3.0, -4.0);
+
+        let counter_clockwise = directed_sweep_vectors(radius, radius, true);
+        let clockwise = directed_sweep_vectors(radius, radius, false);
+
+        assert!(near(counter_clockwise, 0.0) && near(clockwise, 0.0));
+    }
+
+    #[test]
+    fn analyze_places_a_left_turn_outer_edge_on_the_right() {
+        let analysis =
+            analyze(right_angle_input(0.0, 0.0)).expect("a right-angle line join must be valid");
+
+        assert!(
+            point_is_near(analysis.incoming_offset_point, Point64::new(0.0, -2.0))
+                && point_is_near(analysis.outgoing_offset_point, Point64::new(2.0, 0.0))
+        );
+    }
+
+    #[test]
+    fn analyze_builds_the_expected_osculating_circle() {
+        let analysis =
+            analyze(right_angle_input(0.1, 0.0)).expect("the curved input must be valid");
+
+        let SupportCurve::Circle { center, radius } = analysis.incoming_support else {
+            panic!("incoming support should be a circle");
+        };
+        assert!(point_is_near(center, Point64::new(0.0, 10.0)) && near(radius, 12.0));
+    }
+
+    #[test]
+    fn analyze_rejects_a_zero_tangent() {
+        let mut input = right_angle_input(0.0, 0.0);
+        input.incoming.tangent = Vector64::new(0.0, 0.0);
+
+        let error = analyze(input).expect_err("a zero tangent must fail");
+
+        assert_eq!(error.to_string(), "incoming tangent has zero length");
+    }
+
+    #[test]
+    fn analyze_rejects_collinear_tangents() {
+        let mut input = right_angle_input(0.0, 0.0);
+        input.outgoing.tangent = Vector64::new(2.0, 0.0);
+
+        let error = analyze(input).expect_err("collinear tangents must fail for now");
+
+        assert_eq!(
+            error.to_string(),
+            "collinear tangents do not define an outer side"
+        );
+    }
+
+    #[test]
+    fn analyze_rejects_a_negative_miter_limit() {
+        let mut input = right_angle_input(0.0, 0.0);
+        input.miter_limit = -1.0;
+
+        let error = analyze(input).expect_err("a negative miter limit must fail");
+
+        assert_eq!(
+            error.to_string(),
+            "miter limit must be finite and non-negative"
+        );
+    }
+
+    #[test]
+    fn construct_returns_empty_for_equal_tangents() {
+        let mut input = right_angle_input(0.1, 0.1);
+        input.outgoing.tangent = Vector64::new(2.0, 0.0);
+
+        let result = construct(input).expect("equal tangents must be valid");
+
+        assert_eq!(result, JoinConstruction::Empty);
+    }
+
+    #[test]
+    fn construct_uses_miter_clip_for_two_lines() {
+        let result =
+            construct(right_angle_input(0.0, 0.0)).expect("a right-angle line join must be valid");
+
+        assert_eq!(result, JoinConstruction::MiterClip);
+    }
+
+    #[test]
+    fn construct_uses_a_rectangle_for_opposite_parallel_tangents() {
+        let mut input = right_angle_input(0.0, 0.1);
+        input.outgoing.tangent = Vector64::new(-1.0, 0.0);
+        input.miter_limit = 3.0;
+
+        let result = construct(input).expect("the parallel fallback must be valid");
+
+        assert_eq!(
+            result,
+            JoinConstruction::ParallelRectangle(ParallelRectangleJoin {
+                near_left: Point64::new(0.0, 2.0),
+                near_right: Point64::new(0.0, -2.0),
+                far_left: Point64::new(6.0, 2.0),
+                far_right: Point64::new(6.0, -2.0),
+            })
+        );
+    }
+
+    #[test]
+    fn opposite_parallel_tangents_apply_the_curvature_guard_first() {
+        let mut input = right_angle_input(0.0, 0.6);
+        input.outgoing.tangent = Vector64::new(-1.0, 0.0);
+        assert_eq!(
+            construct(input).unwrap_err().0,
+            JoinErrorKind::ExcessiveOuterCurvature
+        );
+    }
+
+    #[test]
+    fn construct_preserves_tight_curvature_toward_the_inner_side() {
+        let result = construct(right_angle_input(0.6, 0.0))
+            .expect("inner curvature has a valid outer offset");
+
+        assert!(
+            matches!(result, JoinConstruction::Arcs(_)),
+            "inner curvature should produce arcs, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn excessive_outer_curvature_requests_round_fallback() {
+        assert_eq!(
+            construct(right_angle_input(-0.6, 0.0)).unwrap_err().0,
+            JoinErrorKind::ExcessiveOuterCurvature
+        );
+    }
+
+    #[test]
+    fn collapsed_offset_circle_is_reported_as_degenerate() {
+        assert_eq!(
+            construct(right_angle_input(-0.5, 0.0)).unwrap_err().0,
+            JoinErrorKind::CollapsedOffsetCircle {
+                segment: "incoming"
+            }
+        );
+    }
+
+    #[test]
+    fn construct_preserves_tight_inner_curvature_for_a_right_turn() {
+        let mut input = right_angle_input(-0.6, 0.0);
+        input.outgoing.tangent = Vector64::new(0.0, -1.0);
+        let result = construct(input).expect("inner curvature has a valid outer offset");
+
+        assert!(
+            matches!(result, JoinConstruction::Arcs(_)),
+            "inner curvature should produce arcs, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn construct_selects_the_intersection_closest_to_the_join() {
+        let result =
+            construct(right_angle_input(0.0, 0.1)).expect("line and circle supports must resolve");
+        let JoinConstruction::Arcs(join) = result else {
+            panic!("line and circle supports should produce an arcs join");
+        };
+
+        assert!(point_is_near(
+            join.intersection,
+            Point64::new(-10.0 + 140.0_f64.sqrt(), -2.0)
+        ));
+    }
+
+    #[test]
+    fn construct_selects_the_near_circle_circle_intersection() {
+        let result =
+            construct(right_angle_input(0.1, 0.1)).expect("two crossing circles must resolve");
+        let JoinConstruction::Arcs(join) = result else {
+            panic!("the two curved supports should produce an arcs join");
+        };
+        let root = 47.0_f64.sqrt();
+
+        assert!(point_is_near(
+            join.intersection,
+            Point64::new(-5.0 + root, 5.0 - root)
+        ));
+    }
+
+    #[test]
+    fn disjoint_line_circle_supports_are_adjusted_to_contact() {
+        let JoinConstruction::Arcs(join) = construct(right_angle_input(0.0, -1.0 / 3.0)).unwrap()
+        else {
+            panic!("disjoint supports should resolve after radius adjustment");
+        };
+        assert!(point_is_near(join.intersection, Point64::new(4.0, -2.0)));
+        assert_eq!(
+            join.outgoing_support,
+            SupportCurve::Circle {
+                center: Point64::new(4.0, 0.0),
+                radius: 2.0,
+            }
+        );
+    }
+
+    #[test]
+    fn construct_builds_a_line_from_the_incoming_offset_to_the_vertex() {
+        let result =
+            construct(right_angle_input(0.0, 0.1)).expect("line and circle supports must resolve");
+        let JoinConstruction::Arcs(join) = result else {
+            panic!("line and circle supports should produce an arcs join");
+        };
+
+        assert!(matches!(
+            join.incoming_boundary,
+            BoundaryPiece::Line { start, end }
+                if point_is_near(start, join.incoming_offset_point)
+                    && point_is_near(end, join.intersection)
+        ));
+    }
+
+    #[test]
+    fn construct_orients_the_outgoing_arc_back_toward_the_join() {
+        let result =
+            construct(right_angle_input(0.0, 0.1)).expect("line and circle supports must resolve");
+        let JoinConstruction::Arcs(join) = result else {
+            panic!("line and circle supports should produce an arcs join");
+        };
+        let BoundaryPiece::Arc {
+            center,
+            start,
+            end,
+            sweep,
+            ..
+        } = join.outgoing_boundary
+        else {
+            panic!("the outgoing curved support should produce an arc");
+        };
+        let sweep_radians = sweep.resolve(start - center, end - center);
+
+        assert!(sweep_radians < 0.0 && sweep_radians.abs() < core::f64::consts::PI);
+    }
+
+    #[test]
+    fn a_large_miter_limit_keeps_the_resolved_boundaries() {
+        let result =
+            construct(right_angle_input(0.0, 0.1)).expect("line and circle supports must resolve");
+        let JoinConstruction::Arcs(join) = result else {
+            panic!("line and circle supports should produce an arcs join");
+        };
+
+        assert!(
+            join.clip.is_none()
+                && point_is_near(boundary_end(join.incoming_boundary), join.intersection)
+                && point_is_near(boundary_end(join.outgoing_boundary), join.intersection)
+        );
+    }
+
+    #[test]
+    fn miter_arc_bound_accepts_only_proven_no_clip_cases() {
+        let bisector = Vector64::new(1.0, 0.0);
+        let minor_chord = Vector64::new(1.0, 1.0);
+        let major_chord = Vector64::new(-1.0, 1.0);
+        let threshold = core::f64::consts::FRAC_PI_2 * 2.0_f64.sqrt();
+
+        assert!(miter_arc_fits_limit(
+            bisector,
+            minor_chord,
+            threshold * 1.000_001,
+        ));
+        assert!(!miter_arc_fits_limit(
+            bisector,
+            minor_chord,
+            threshold * 0.999_999,
+        ));
+        assert!(!miter_arc_fits_limit(
+            bisector,
+            major_chord,
+            threshold * 2.0,
+        ));
+        assert!(!miter_arc_fits_limit(
+            bisector,
+            Vector64::new(1.0, 0.0),
+            1.000_001,
+        ));
+    }
+
+    #[test]
+    fn miter_limit_clips_both_boundaries_with_one_line() {
+        let mut input = right_angle_input(0.0, 0.1);
+        input.miter_limit = 1.2;
+
+        let result = construct(input).expect("the miter limit must clip the arcs join");
+        let JoinConstruction::Arcs(join) = result else {
+            panic!("line and circle supports should produce an arcs join");
+        };
+        let clip = join
+            .clip
+            .expect("the resolved join should have a clip edge");
+
+        assert!(
+            (clip.incoming - clip.limit_point)
+                .cross(clip.line_direction)
+                .abs()
+                <= TEST_EPSILON
+                && (clip.outgoing - clip.limit_point)
+                    .cross(clip.line_direction)
+                    .abs()
+                    <= TEST_EPSILON
+                && point_is_near(boundary_end(join.incoming_boundary), clip.incoming)
+                && point_is_near(boundary_end(join.outgoing_boundary), clip.outgoing)
+                && !point_is_near(clip.incoming, join.intersection)
+                && !point_is_near(clip.outgoing, join.intersection)
+        );
+    }
+
+    #[test]
+    fn miter_limit_shortens_a_curved_boundary_without_moving_its_start() {
+        let unbounded =
+            construct(right_angle_input(0.0, 0.1)).expect("the reference arcs join must resolve");
+        let JoinConstruction::Arcs(unbounded) = unbounded else {
+            panic!("line and circle supports should produce an arcs join");
+        };
+        let mut clipped_input = right_angle_input(0.0, 0.1);
+        clipped_input.miter_limit = 1.2;
+        let clipped = construct(clipped_input).expect("the arcs join must be clipped");
+        let JoinConstruction::Arcs(clipped) = clipped else {
+            panic!("line and circle supports should produce an arcs join");
+        };
+        let BoundaryPiece::Arc {
+            center: unbounded_center,
+            start: unbounded_start,
+            end: unbounded_end,
+            sweep: unbounded_sweep,
+            ..
+        } = unbounded.outgoing_boundary
+        else {
+            panic!("the outgoing boundary should be curved");
+        };
+        let BoundaryPiece::Arc {
+            center: clipped_center,
+            start: clipped_start,
+            end: clipped_end,
+            sweep: clipped_sweep,
+            ..
+        } = clipped.outgoing_boundary
+        else {
+            panic!("the clipped outgoing boundary should remain curved");
+        };
+
+        let unbounded_sweep = unbounded_sweep.resolve(
+            unbounded_start - unbounded_center,
+            unbounded_end - unbounded_center,
+        );
+        let clipped_sweep =
+            clipped_sweep.resolve(clipped_start - clipped_center, clipped_end - clipped_center);
+        assert!(
+            point_is_near(clipped_start, unbounded_start)
+                && clipped_sweep.signum() == unbounded_sweep.signum()
+                && clipped_sweep.abs() < unbounded_sweep.abs()
+        );
+    }
+
+    #[test]
+    fn sub_unit_miter_limit_clips_the_radial_join_edges() {
+        let mut input = right_angle_input(0.0, 0.1);
+        input.miter_limit = 0.5;
+
+        let result = construct(input).expect("the inner clip must be representable");
+        let JoinConstruction::RadialClip(join) = result else {
+            panic!("a sub-unit miter limit should clip the radial join edges");
+        };
+
+        assert!(
+            near(join.incoming.x, 0.0)
+                && join.incoming.y > -input.half_width
+                && join.incoming.y < 0.0
+                && near(join.outgoing.y, 0.0)
+                && join.outgoing.x > 0.0
+                && join.outgoing.x < input.half_width
+                && (join.incoming - join.limit_point)
+                    .cross(join.line_direction)
+                    .abs()
+                    <= TEST_EPSILON
+                && (join.outgoing - join.limit_point)
+                    .cross(join.line_direction)
+                    .abs()
+                    <= TEST_EPSILON
+        );
+    }
+
+    #[test]
+    fn incoming_arc_starts_with_the_incoming_path_tangent() {
+        let result =
+            construct(right_angle_input(0.1, 0.1)).expect("two crossing circles must resolve");
+        let JoinConstruction::Arcs(join) = result else {
+            panic!("two curved supports should produce an arcs join");
+        };
+        let start_tangent = boundary_start_tangent(join.incoming_boundary);
+
+        assert!(start_tangent.dot(Vector64::new(1.0, 0.0)) > 1.0 - TEST_EPSILON);
+    }
+
+    #[test]
+    fn outgoing_arc_starts_opposite_to_the_outgoing_path_tangent() {
+        let result =
+            construct(right_angle_input(0.1, 0.1)).expect("two crossing circles must resolve");
+        let JoinConstruction::Arcs(join) = result else {
+            panic!("two curved supports should produce an arcs join");
+        };
+        let start_tangent = boundary_start_tangent(join.outgoing_boundary);
+
+        assert!(start_tangent.dot(Vector64::new(0.0, -1.0)) > 1.0 - TEST_EPSILON);
+    }
+
+    #[test]
+    fn line_line_returns_the_crossing_point() {
+        let result = line_line_intersections(
+            Point64::new(0.0, 2.0),
+            Vector64::new(1.0, 0.0),
+            Point64::new(1.0, 0.0),
+            Vector64::new(0.0, 1.0),
+        );
+
+        assert_eq!(result, Intersections::One(Point64::new(1.0, 2.0)));
+    }
+
+    #[test]
+    fn line_line_reports_distinct_parallel_lines() {
+        let result = line_line_intersections(
+            Point64::new(0.0, 0.0),
+            Vector64::new(1.0, 0.0),
+            Point64::new(0.0, 1.0),
+            Vector64::new(1.0, 0.0),
+        );
+
+        assert_eq!(result, Intersections::None);
+    }
+
+    #[test]
+    fn line_line_reports_the_same_line() {
+        let result = line_line_intersections(
+            Point64::new(0.0, 0.0),
+            Vector64::new(1.0, 0.0),
+            Point64::new(4.0, 0.0),
+            Vector64::new(-1.0, 0.0),
+        );
+
+        assert_eq!(result, Intersections::Coincident);
+    }
+
+    #[test]
+    fn line_circle_returns_two_crossing_points() {
+        let result = line_circle_intersections(
+            Point64::new(-10.0, 0.0),
+            Vector64::new(1.0, 0.0),
+            Point64::new(0.0, 0.0),
+            5.0,
+        );
+
+        assert!(two_points_are_near(
+            result,
+            Point64::new(-5.0, 0.0),
+            Point64::new(5.0, 0.0)
+        ));
+    }
+
+    #[test]
+    fn line_circle_returns_one_tangent_point() {
+        let result = line_circle_intersections(
+            Point64::new(-10.0, 5.0),
+            Vector64::new(1.0, 0.0),
+            Point64::new(0.0, 0.0),
+            5.0,
+        );
+
+        assert!(matches!(
+            result,
+            Intersections::One(point) if point_is_near(point, Point64::new(0.0, 5.0))
+        ));
+    }
+
+    #[test]
+    fn line_circle_reports_a_miss() {
+        let result = line_circle_intersections(
+            Point64::new(-10.0, 6.0),
+            Vector64::new(1.0, 0.0),
+            Point64::new(0.0, 0.0),
+            5.0,
+        );
+
+        assert_eq!(result, Intersections::None);
+    }
+
+    #[test]
+    fn circle_circle_returns_two_crossing_points() {
+        let result =
+            circle_circle_intersections(Point64::new(0.0, 0.0), 5.0, Point64::new(8.0, 0.0), 5.0);
+
+        assert!(two_points_are_near(
+            result,
+            Point64::new(4.0, -3.0),
+            Point64::new(4.0, 3.0)
+        ));
+    }
+
+    #[test]
+    fn circle_circle_returns_one_external_tangent_point() {
+        let result =
+            circle_circle_intersections(Point64::new(0.0, 0.0), 5.0, Point64::new(8.0, 0.0), 3.0);
+
+        assert!(matches!(
+            result,
+            Intersections::One(point) if point_is_near(point, Point64::new(5.0, 0.0))
+        ));
+    }
+
+    #[test]
+    fn circle_circle_reports_nested_circles_without_contact() {
+        let result =
+            circle_circle_intersections(Point64::new(0.0, 0.0), 5.0, Point64::new(1.0, 0.0), 1.0);
+
+        assert_eq!(result, Intersections::None);
+    }
+
+    #[test]
+    fn circle_circle_reports_the_same_circle() {
+        let result =
+            circle_circle_intersections(Point64::new(2.0, 3.0), 5.0, Point64::new(2.0, 3.0), 5.0);
+
+        assert_eq!(result, Intersections::Coincident);
+    }
+
+    fn right_angle_input(incoming_curvature: f64, outgoing_curvature: f64) -> JoinInput {
+        JoinInput {
+            at: Point64::new(0.0, 0.0),
+            incoming: SegmentEnd {
+                tangent: Vector64::new(1.0, 0.0),
+                curvature: incoming_curvature,
+            },
+            outgoing: SegmentEnd {
+                tangent: Vector64::new(0.0, 1.0),
+                curvature: outgoing_curvature,
+            },
+            half_width: 2.0,
+            miter_limit: 4.0,
+        }
+    }
+
+    fn near(actual: f64, expected: f64) -> bool {
+        (actual - expected).abs() <= TEST_EPSILON
+    }
+
+    fn point_is_near(actual: Point64, expected: Point64) -> bool {
+        near(actual.x, expected.x) && near(actual.y, expected.y)
+    }
+
+    fn two_points_are_near(
+        result: Intersections,
+        expected_a: Point64,
+        expected_b: Point64,
+    ) -> bool {
+        let Intersections::Two([actual_a, actual_b]) = result else {
+            return false;
+        };
+
+        (point_is_near(actual_a, expected_a) && point_is_near(actual_b, expected_b))
+            || (point_is_near(actual_a, expected_b) && point_is_near(actual_b, expected_a))
+    }
+
+    fn boundary_start_tangent(boundary: BoundaryPiece) -> Vector64 {
+        match boundary {
+            BoundaryPiece::Line { start, end } => {
+                let direction = end - start;
+                direction * direction.square_length().sqrt().recip()
+            }
+            BoundaryPiece::Arc {
+                center,
+                start,
+                sweep,
+                ..
+            } => {
+                let radius = start - center;
+                let tangent = if sweep.counter_clockwise() {
+                    radius.left_normal()
+                } else {
+                    -radius.left_normal()
+                };
+                tangent * tangent.square_length().sqrt().recip()
+            }
+        }
+    }
+}

--- a/crates/tessellation/src/stroke_arcs/svg2.rs
+++ b/crates/tessellation/src/stroke_arcs/svg2.rs
@@ -1,0 +1,392 @@
+//! SVG 2 CR / Editor's Draft radius adjustment (painting.html#LineJoinShape).
+//! Radius adjustment preserves each edge's attachment point and tangent.
+
+use super::*;
+
+pub(crate) fn construct_svg2(input: JoinInput) -> Result<JoinConstruction, JoinError> {
+    validate_input(input)?;
+    let incoming = normalize(input.incoming.tangent, "incoming")?;
+    let outgoing = normalize(input.outgoing.tangent, "outgoing")?;
+    let cross = incoming.cross(outgoing);
+    let dot = incoming.dot(outgoing);
+    if cross.abs() <= PARALLEL_EPSILON && dot > 0.0 {
+        return Ok(JoinConstruction::Empty);
+    }
+    if input.incoming.curvature == 0.0 && input.outgoing.curvature == 0.0 {
+        return Ok(JoinConstruction::MiterClip);
+    }
+    let (a, b, limit) = outer_curvature_values(input, cross);
+    if a > limit || b > limit {
+        return Err(JoinErrorKind::ExcessiveOuterCurvature.into());
+    }
+    if cross.abs() <= PARALLEL_EPSILON && dot < 0.0 {
+        return Ok(JoinConstruction::ParallelRectangle(parallel_rectangle(
+            input, incoming,
+        )));
+    }
+    let mut prepared = prepare_join(input, incoming, outgoing)?;
+    let intersection = match closest_support_intersection(
+        prepared.incoming_support,
+        prepared.outgoing_support,
+        input.at,
+    ) {
+        Ok(point) => point,
+        Err(_) => adjust_supports(&mut prepared).ok_or(JoinErrorKind::RadiusAdjustmentFailed)?,
+    };
+    resolve_boundaries::<true, false>(input, prepared, intersection)
+}
+
+/// Changes only radii and centers along the attachment normals. Both circles
+/// change by the same distance; straight supports remain fixed.
+fn adjust_supports(join: &mut PreparedJoin) -> Option<Point64> {
+    match (join.incoming_support, join.outgoing_support) {
+        (
+            SupportCurve::Circle {
+                center: a,
+                radius: ra,
+            },
+            SupportCurve::Circle {
+                center: b,
+                radius: rb,
+            },
+        ) => {
+            let na = (a - join.incoming_offset_point) * ra.recip();
+            let nb = (b - join.outgoing_offset_point) * rb.recip();
+            let distance = (b - a).square_length().sqrt();
+            let nested = distance < (ra - rb).abs();
+            let (sa, sb) = if nested {
+                if ra > rb {
+                    (-1.0, 1.0)
+                } else {
+                    (1.0, -1.0)
+                }
+            } else {
+                (1.0, 1.0)
+            };
+            // Normalize the tangency quadratic before solving, so its tolerances
+            // do not depend on canvas units or stroke width.
+            let scale = distance.max(ra).max(rb);
+            let d = (b - a) * scale.recip();
+            let v = nb * sb - na * sa;
+            let r = if nested { (ra - rb).abs() } else { ra + rb } / scale;
+            let dr = if nested { -2.0 } else { 2.0 };
+            let delta = first_nonnegative_root(
+                v.square_length() - dr * dr,
+                2.0 * (d.dot(v) - r * dr),
+                d.square_length() - r * r,
+            )? * scale;
+            if nested && delta > (ra - rb).abs() * 0.5 + scale * 1.0e-10 {
+                return None;
+            }
+            let new_ra = ra + sa * delta;
+            let new_rb = rb + sb * delta;
+            let new_a = a + na * (sa * delta);
+            let new_b = b + nb * (sb * delta);
+            let axis = new_b - new_a;
+            let length = axis.square_length().sqrt();
+            if new_ra <= 0.0 || new_rb <= 0.0 || length <= scale * 1.0e-12 {
+                return None;
+            }
+            let target = if nested {
+                (new_ra - new_rb).abs()
+            } else {
+                new_ra + new_rb
+            };
+            if (length - target).abs() > 1.0e-8 * scale.max(target) {
+                return None;
+            }
+            let point = if nested && new_rb > new_ra {
+                new_b - axis * (new_rb / length)
+            } else {
+                new_a + axis * (new_ra / length)
+            };
+            if !point.is_finite() {
+                return None;
+            }
+            join.incoming_support = SupportCurve::Circle {
+                center: new_a,
+                radius: new_ra,
+            };
+            join.outgoing_support = SupportCurve::Circle {
+                center: new_b,
+                radius: new_rb,
+            };
+            Some(point)
+        }
+        (line @ SupportCurve::Line { .. }, circle @ SupportCurve::Circle { .. }) => {
+            let (circle, point) = adjust_circle_to_line(line, circle, join.outgoing_offset_point)?;
+            join.outgoing_support = circle;
+            Some(point)
+        }
+        (circle @ SupportCurve::Circle { .. }, line @ SupportCurve::Line { .. }) => {
+            let (circle, point) = adjust_circle_to_line(line, circle, join.incoming_offset_point)?;
+            join.incoming_support = circle;
+            Some(point)
+        }
+        (SupportCurve::Line { .. }, SupportCurve::Line { .. }) => None,
+    }
+}
+
+fn adjust_circle_to_line(
+    line: SupportCurve,
+    circle: SupportCurve,
+    attachment: Point64,
+) -> Option<(SupportCurve, Point64)> {
+    let SupportCurve::Line { point, direction } = line else {
+        return None;
+    };
+    let SupportCurve::Circle { center, radius } = circle else {
+        return None;
+    };
+    let normal = (center - attachment) * radius.recip();
+    let line_normal = normalize(direction, "line").ok()?.left_normal();
+    let distance = (attachment - point).dot(line_normal);
+    let mut best = f64::INFINITY;
+    for side in [-1.0, 1.0] {
+        let denominator = side - normal.dot(line_normal);
+        if denominator.abs() <= PARALLEL_EPSILON {
+            continue;
+        }
+        let candidate = distance / denominator;
+        if candidate >= radius && candidate < best {
+            best = candidate;
+        }
+    }
+    if !best.is_finite() {
+        return None;
+    }
+    let center = attachment + normal * best;
+    let contact = center - line_normal * (center - point).dot(line_normal);
+    contact.is_finite().then_some((
+        SupportCurve::Circle {
+            center,
+            radius: best,
+        },
+        contact,
+    ))
+}
+
+/// Cancellation-resistant quadratic roots, including the linear limit.
+fn first_nonnegative_root(a: f64, b: f64, c: f64) -> Option<f64> {
+    let scale = a.abs().max(b.abs()).max(c.abs());
+    if scale == 0.0 || !scale.is_finite() {
+        return None;
+    }
+    let (a, b, c) = (a / scale, b / scale, c / scale);
+    if a.abs() <= 1.0e-14 {
+        let root = -c / b;
+        return (root >= 0.0 && root.is_finite()).then_some(root);
+    }
+    let discriminant = b * b - 4.0 * a * c;
+    if discriminant < -1.0e-14 {
+        return None;
+    }
+    let q = -0.5 * (b + discriminant.max(0.0).sqrt().copysign(b));
+    [q / a, c / q]
+        .iter()
+        .copied()
+        .filter(|root| root.is_finite() && *root >= 0.0)
+        .min_by(f64::total_cmp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(ka: f64, kb: f64) -> JoinInput {
+        JoinInput {
+            at: Point64::new(0.0, 0.0),
+            incoming: SegmentEnd {
+                tangent: Vector64::new(1.0, 0.0),
+                curvature: ka,
+            },
+            outgoing: SegmentEnd {
+                tangent: Vector64::new(0.0, 1.0),
+                curvature: kb,
+            },
+            half_width: 2.0,
+            miter_limit: 100.0,
+        }
+    }
+
+    fn circle(center: (f64, f64), radius: f64) -> SupportCurve {
+        SupportCurve::Circle {
+            center: Point64::new(center.0, center.1),
+            radius,
+        }
+    }
+
+    fn assert_contact(support: SupportCurve, point: Point64, epsilon: f64) {
+        let error = match support {
+            SupportCurve::Circle { center, radius } => {
+                ((point - center).square_length().sqrt() - radius).abs()
+            }
+            SupportCurve::Line {
+                point: start,
+                direction,
+            } => (point - start).cross(direction).abs(),
+        };
+        assert!(
+            error < epsilon,
+            "contact error {}: {:?}, {:?}",
+            error,
+            support,
+            point
+        );
+    }
+
+    #[test]
+    fn svg2_adjusts_disjoint_supports() {
+        for (ka, kb) in [(0.0, -0.4), (-0.4, 0.0), (-0.4, -0.4)] {
+            let input = input(ka, kb);
+            let result = construct_svg2(input);
+            let Ok(JoinConstruction::Arcs(join)) = result else {
+                panic!("{}, {}: {:?}", ka, kb, result);
+            };
+            assert!(!join.clipped);
+            assert_contact(join.incoming_support, join.intersection, 1.0e-9);
+            assert_contact(join.outgoing_support, join.intersection, 1.0e-9);
+            assert_contact(join.incoming_support, join.incoming_offset_point, 1.0e-9);
+            assert_contact(join.outgoing_support, join.outgoing_offset_point, 1.0e-9);
+        }
+    }
+
+    #[test]
+    fn nested_circles_shrink_larger_and_grow_smaller_by_equal_amounts() {
+        let mut join = prepare_join(
+            input(0.1, 0.2),
+            Vector64::new(1.0, 0.0),
+            Vector64::new(0.0, 1.0),
+        )
+        .unwrap();
+        join.incoming_support = circle((0.0, 0.0), 5.0);
+        join.incoming_offset_point = Point64::new(-5.0, 0.0);
+        join.outgoing_support = circle((1.0, 0.0), 1.0);
+        join.outgoing_offset_point = Point64::new(2.0, 0.0);
+        let contact = adjust_supports(&mut join).expect("internal tangency");
+        assert_eq!(join.incoming_support, circle((-1.5, 0.0), 3.5));
+        assert_eq!(join.outgoing_support, circle((-0.5, 0.0), 2.5));
+        assert_contact(join.incoming_support, contact, 1.0e-10);
+        assert_contact(join.outgoing_support, contact, 1.0e-10);
+    }
+
+    #[test]
+    fn separate_circles_grow_equally_and_keep_attachment_normals() {
+        let original = prepare_join(
+            input(-0.4, -0.4),
+            Vector64::new(1.0, 0.0),
+            Vector64::new(0.0, 1.0),
+        )
+        .unwrap();
+        let mut adjusted = original;
+        let contact = adjust_supports(&mut adjusted).expect("external tangency");
+        let mut deltas = [0.0; 2];
+        for (index, (before, after, attachment)) in [
+            (
+                original.incoming_support,
+                adjusted.incoming_support,
+                original.incoming_offset_point,
+            ),
+            (
+                original.outgoing_support,
+                adjusted.outgoing_support,
+                original.outgoing_offset_point,
+            ),
+        ]
+        .iter()
+        .copied()
+        .enumerate()
+        {
+            let SupportCurve::Circle {
+                center: old,
+                radius: old_r,
+            } = before
+            else {
+                unreachable!()
+            };
+            let SupportCurve::Circle {
+                center: new,
+                radius: new_r,
+            } = after
+            else {
+                unreachable!()
+            };
+            deltas[index] = new_r - old_r;
+            assert!(deltas[index] > 0.0);
+            assert!(
+                ((old - attachment) * old_r.recip() - (new - attachment) * new_r.recip())
+                    .square_length()
+                    < 1.0e-20
+            );
+            assert_contact(after, contact, 1.0e-9);
+        }
+        assert!((deltas[0] - deltas[1]).abs() < 1.0e-10);
+    }
+
+    #[test]
+    fn curvature_guard_uses_outer_side() {
+        let excessive = input(0.0, -0.6);
+        assert_eq!(
+            construct_svg2(excessive).unwrap_err().0,
+            JoinErrorKind::ExcessiveOuterCurvature
+        );
+        assert!(
+            construct_svg2(input(0.0, 0.6)).is_ok(),
+            "inward curvature is not the outer guard"
+        );
+    }
+
+    #[test]
+    fn adjusted_join_is_scale_and_reversal_invariant() {
+        for scale in [1.0e-4, 1.0, 1.0e4] {
+            let mut original = input(-0.4 / scale, -0.3 / scale);
+            original.half_width *= scale;
+            let reverse = JoinInput {
+                incoming: SegmentEnd {
+                    tangent: -original.outgoing.tangent,
+                    curvature: -original.outgoing.curvature,
+                },
+                outgoing: SegmentEnd {
+                    tangent: -original.incoming.tangent,
+                    curvature: -original.incoming.curvature,
+                },
+                ..original
+            };
+            let (Ok(JoinConstruction::Arcs(a)), Ok(JoinConstruction::Arcs(b))) =
+                (construct_svg2(original), construct_svg2(reverse))
+            else {
+                panic!("missing arcs at scale {}", scale);
+            };
+            assert!((a.intersection - b.intersection).square_length() < 1.0e-16 * scale * scale);
+            assert_contact(a.incoming_support, a.intersection, 1.0e-8 * scale);
+        }
+    }
+
+    #[test]
+    fn svg2_still_clips_refitted_arcs_at_the_miter_limit() {
+        let result = construct_svg2(JoinInput {
+            miter_limit: 1.0,
+            ..input(-0.4, -0.4)
+        })
+        .unwrap();
+        assert!(
+            matches!(
+                result,
+                JoinConstruction::Arcs(ResolvedArcsJoin { clipped: true, .. })
+                    | JoinConstruction::RadialClip(_)
+            ),
+            "{:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn opposite_parallel_tangents_use_the_svg2_rectangle() {
+        let mut input = input(0.1, 0.1);
+        input.outgoing.tangent = -input.incoming.tangent;
+        assert!(matches!(
+            construct_svg2(input),
+            Ok(JoinConstruction::ParallelRectangle(_))
+        ));
+    }
+}

--- a/crates/tessellation/src/stroke_arcs_mesh.rs
+++ b/crates/tessellation/src/stroke_arcs_mesh.rs
@@ -1,0 +1,1597 @@
+//! Internal flattening and triangulation for one resolved SVG 2 `arcs` join.
+
+use alloc::vec::Vec;
+use core::fmt;
+
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
+use crate::stroke_arcs::{ArcSweep, BoundaryPiece, Point64, ResolvedArcsJoin, Vector64};
+
+const MAX_VERTEX_COUNT: usize = 4_096;
+const MIN_FAN_VERTEX_COUNT: usize = 12;
+const TRIANGULATION_EPSILON: f64 = 1.0e-12;
+
+/// Reusable buffers for one outer `arcs` join region.
+#[derive(Debug, Default)]
+pub(crate) struct ArcsMesh {
+    vertices: Vec<Point64>,
+    indices: Vec<usize>,
+    remaining: Vec<usize>,
+    #[cfg(test)]
+    buffered_triangle_output: bool,
+    #[cfg(test)]
+    buffered_quad_output: bool,
+    #[cfg(test)]
+    buffered_fan_output: bool,
+}
+
+pub(crate) enum ArcsOutput<'a> {
+    Triangle(DirectArcsTriangle),
+    Quad(DirectArcsQuad),
+    Fan {
+        vertices: &'a [Point64],
+        fan: ValidatedFan,
+    },
+    Mesh {
+        vertices: &'a [Point64],
+        indices: &'a [usize],
+    },
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DirectArcsTriangle {
+    pub(crate) middle: Point64,
+    pub(crate) indices: [usize; 3],
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DirectArcsQuad {
+    pub(crate) middle: [Point64; 2],
+    pub(crate) indices: [u8; 6],
+}
+
+/// Compact topology for a fan already validated against its polygon boundary.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ValidatedFan {
+    root: usize,
+    vertex_count: usize,
+    forward: bool,
+}
+
+impl ValidatedFan {
+    pub(crate) fn triangles(self) -> impl ExactSizeIterator<Item = [usize; 3]> {
+        FanTriangles {
+            root: self.root,
+            current: next_fan_index(self.root, self.vertex_count, self.forward),
+            vertex_count: self.vertex_count,
+            remaining: self.vertex_count - 2,
+            forward: self.forward,
+        }
+    }
+
+    fn append_indices(self, indices: &mut Vec<usize>) {
+        for [first, second, third] in self.triangles() {
+            push_triangle(indices, first, second, third);
+        }
+    }
+}
+
+struct FanTriangles {
+    root: usize,
+    current: usize,
+    vertex_count: usize,
+    remaining: usize,
+    forward: bool,
+}
+
+impl Iterator for FanTriangles {
+    type Item = [usize; 3];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+
+        let next = next_fan_index(self.current, self.vertex_count, self.forward);
+        let triangle = [self.root, self.current, next];
+        self.current = next;
+        self.remaining -= 1;
+        Some(triangle)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for FanTriangles {}
+
+#[derive(Clone, Copy)]
+struct MeshLayout {
+    incoming_boundary: BoundaryPiece,
+    outgoing_boundary: BoundaryPiece,
+    incoming_sweep_radians: f64,
+    outgoing_sweep_radians: f64,
+    incoming_steps: usize,
+    outgoing_steps: usize,
+    clip_vertex_count: usize,
+    vertex_count: usize,
+}
+
+impl ArcsMesh {
+    pub(crate) fn tessellate(
+        &mut self,
+        join: &ResolvedArcsJoin,
+        tolerance: f64,
+    ) -> Result<(), ArcsMeshError> {
+        self.tessellate_impl::<true, true, true, true>(join, tolerance)
+            .map(|_| ())
+    }
+
+    pub(crate) fn tessellate_for_output(
+        &mut self,
+        join: &ResolvedArcsJoin,
+        tolerance: f64,
+    ) -> Result<ArcsOutput<'_>, ArcsMeshError> {
+        self.clear_buffers();
+        let layout = prepare_mesh_layout::<true>(join, tolerance)?;
+        if layout.vertex_count == 3 && self.direct_triangle_output_enabled() {
+            return direct_triangle(layout.incoming_boundary, layout.outgoing_boundary)
+                .map(ArcsOutput::Triangle);
+        }
+        if layout.vertex_count == 4
+            && layout.clip_vertex_count == 1
+            && self.direct_quad_output_enabled()
+        {
+            if let Some(quad) = direct_quad(layout.incoming_boundary, layout.outgoing_boundary) {
+                return Ok(ArcsOutput::Quad(quad));
+            }
+        }
+
+        self.tessellate_non_triangle_for_output(layout)
+    }
+
+    fn tessellate_non_triangle_for_output(
+        &mut self,
+        layout: MeshLayout,
+    ) -> Result<ArcsOutput<'_>, ArcsMeshError> {
+        self.append_layout_vertices::<true>(layout);
+        let preferred_fan_roots = [
+            layout.incoming_steps,
+            layout.incoming_steps + layout.clip_vertex_count,
+        ];
+        let preferred_fan_roots = if layout.vertex_count >= MIN_FAN_VERTEX_COUNT {
+            &preferred_fan_roots[..1 + layout.clip_vertex_count]
+        } else {
+            &[]
+        };
+        let signed_area = polygon_signed_area(&self.vertices);
+        if let Some(fan) = find_visible_fan(&self.vertices, preferred_fan_roots, signed_area) {
+            if self.direct_fan_output_enabled() {
+                return Ok(ArcsOutput::Fan {
+                    vertices: &self.vertices,
+                    fan,
+                });
+            }
+
+            self.reserve_triangulation_buffers(layout.vertex_count)?;
+            fan.append_indices(&mut self.indices);
+            return Ok(ArcsOutput::Mesh {
+                vertices: &self.vertices,
+                indices: &self.indices,
+            });
+        }
+
+        self.reserve_triangulation_buffers(layout.vertex_count)?;
+        triangulate_with_ear_clipping(
+            &mut self.indices,
+            &self.vertices,
+            &mut self.remaining,
+            signed_area,
+        )?;
+        Ok(ArcsOutput::Mesh {
+            vertices: &self.vertices,
+            indices: &self.indices,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_direct_triangle_output(&mut self, enabled: bool) {
+        self.buffered_triangle_output = !enabled;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_direct_quad_output(&mut self, enabled: bool) {
+        self.buffered_quad_output = !enabled;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_direct_fan_output(&mut self, enabled: bool) {
+        self.buffered_fan_output = !enabled;
+    }
+
+    #[inline]
+    fn direct_triangle_output_enabled(&self) -> bool {
+        #[cfg(test)]
+        {
+            !self.buffered_triangle_output
+        }
+        #[cfg(not(test))]
+        {
+            true
+        }
+    }
+
+    #[inline]
+    fn direct_quad_output_enabled(&self) -> bool {
+        #[cfg(test)]
+        {
+            !self.buffered_quad_output
+        }
+        #[cfg(not(test))]
+        {
+            true
+        }
+    }
+
+    #[inline]
+    fn direct_fan_output_enabled(&self) -> bool {
+        #[cfg(test)]
+        {
+            !self.buffered_fan_output
+        }
+        #[cfg(not(test))]
+        {
+            true
+        }
+    }
+
+    fn tessellate_impl<
+        const ALLOW_FAN: bool,
+        const RECURRENT_ROTATION: bool,
+        const SINGLE_CHORD_FAST_PATH: bool,
+        const DIRECT_TRIANGLE_FAST_PATH: bool,
+    >(
+        &mut self,
+        join: &ResolvedArcsJoin,
+        tolerance: f64,
+    ) -> Result<TriangulationMethod, ArcsMeshError> {
+        self.clear_buffers();
+        let layout = prepare_mesh_layout::<SINGLE_CHORD_FAST_PATH>(join, tolerance)?;
+        self.tessellate_layout::<ALLOW_FAN, RECURRENT_ROTATION, DIRECT_TRIANGLE_FAST_PATH>(layout)
+    }
+
+    fn clear_buffers(&mut self) {
+        self.vertices.clear();
+        self.indices.clear();
+        self.remaining.clear();
+    }
+
+    fn tessellate_layout<
+        const ALLOW_FAN: bool,
+        const RECURRENT_ROTATION: bool,
+        const DIRECT_TRIANGLE_FAST_PATH: bool,
+    >(
+        &mut self,
+        layout: MeshLayout,
+    ) -> Result<TriangulationMethod, ArcsMeshError> {
+        self.reserve_triangulation_buffers(layout.vertex_count)?;
+        self.append_layout_vertices::<RECURRENT_ROTATION>(layout);
+        let preferred_fan_roots = [
+            layout.incoming_steps,
+            layout.incoming_steps + layout.clip_vertex_count,
+        ];
+        let preferred_fan_roots = if ALLOW_FAN && layout.vertex_count >= MIN_FAN_VERTEX_COUNT {
+            &preferred_fan_roots[..1 + layout.clip_vertex_count]
+        } else {
+            &[]
+        };
+        triangulate_polygon_impl::<DIRECT_TRIANGLE_FAST_PATH>(
+            &mut self.indices,
+            &self.vertices,
+            &mut self.remaining,
+            preferred_fan_roots,
+        )
+    }
+
+    fn append_layout_vertices<const RECURRENT_ROTATION: bool>(&mut self, layout: MeshLayout) {
+        self.vertices.reserve(layout.vertex_count);
+        if RECURRENT_ROTATION {
+            append_boundary(
+                &mut self.vertices,
+                layout.incoming_boundary,
+                BoundaryTraversal::Forward,
+                true,
+                layout.incoming_steps,
+                layout.incoming_sweep_radians,
+            );
+        } else {
+            append_boundary_trigonometric(
+                &mut self.vertices,
+                layout.incoming_boundary,
+                BoundaryTraversal::Forward,
+                true,
+                layout.incoming_steps,
+                layout.incoming_sweep_radians,
+            );
+        }
+        if layout.clip_vertex_count != 0 {
+            self.vertices.push(boundary_end(layout.outgoing_boundary));
+        }
+        if RECURRENT_ROTATION {
+            append_boundary(
+                &mut self.vertices,
+                layout.outgoing_boundary,
+                BoundaryTraversal::Reverse,
+                false,
+                layout.outgoing_steps,
+                layout.outgoing_sweep_radians,
+            );
+        } else {
+            append_boundary_trigonometric(
+                &mut self.vertices,
+                layout.outgoing_boundary,
+                BoundaryTraversal::Reverse,
+                false,
+                layout.outgoing_steps,
+                layout.outgoing_sweep_radians,
+            );
+        }
+    }
+
+    fn reserve_triangulation_buffers(&mut self, vertex_count: usize) -> Result<(), ArcsMeshError> {
+        let index_count = vertex_count.saturating_sub(2).checked_mul(3).ok_or(
+            ArcsMeshError::TooManyVertices {
+                limit: MAX_VERTEX_COUNT,
+            },
+        )?;
+        self.indices.reserve(index_count);
+        self.remaining.reserve(vertex_count);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tessellate_with_ear_clipping(
+        &mut self,
+        join: &ResolvedArcsJoin,
+        tolerance: f64,
+    ) -> Result<(), ArcsMeshError> {
+        self.tessellate_impl::<false, true, true, true>(join, tolerance)
+            .map(|_| ())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tessellate_with_trigonometric_flattening(
+        &mut self,
+        join: &ResolvedArcsJoin,
+        tolerance: f64,
+    ) -> Result<(), ArcsMeshError> {
+        self.tessellate_impl::<true, false, true, true>(join, tolerance)
+            .map(|_| ())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tessellate_without_single_chord_fast_path(
+        &mut self,
+        join: &ResolvedArcsJoin,
+        tolerance: f64,
+    ) -> Result<(), ArcsMeshError> {
+        self.tessellate_impl::<true, true, false, true>(join, tolerance)
+            .map(|_| ())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tessellate_without_direct_triangle_fast_path(
+        &mut self,
+        join: &ResolvedArcsJoin,
+        tolerance: f64,
+    ) -> Result<(), ArcsMeshError> {
+        self.tessellate_impl::<true, true, true, false>(join, tolerance)
+            .map(|_| ())
+    }
+
+    pub(crate) fn vertices(&self) -> &[Point64] {
+        &self.vertices
+    }
+
+    pub(crate) fn indices(&self) -> &[usize] {
+        &self.indices
+    }
+
+    /// Returns the number of triangles in the mesh.
+    #[must_use]
+    pub(crate) fn triangle_count(&self) -> usize {
+        self.indices.len() / 3
+    }
+}
+
+/// Failure produced while flattening or indexing a resolved join.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ArcsMeshError {
+    InvalidTolerance,
+    InvalidBoundary { segment: &'static str },
+    TooManyVertices { limit: usize },
+    NonTriangulatableBoundary,
+}
+
+impl fmt::Display for ArcsMeshError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::InvalidTolerance => {
+                formatter.write_str("tolerance must be finite and greater than zero")
+            }
+            Self::InvalidBoundary { segment } => {
+                write!(formatter, "{segment} boundary contains invalid geometry")
+            }
+            Self::TooManyVertices { limit } => {
+                write!(
+                    formatter,
+                    "flattened join would exceed the limit of {limit} vertices"
+                )
+            }
+            Self::NonTriangulatableBoundary => {
+                formatter.write_str("join boundary is not a triangulatable simple polygon")
+            }
+        }
+    }
+}
+
+/// Flattens and triangulates one resolved `arcs` join.
+///
+/// Each circular boundary is split so the maximum distance between the arc
+/// and its chord does not exceed `tolerance`. The returned triangle winding is
+/// counter-clockwise in mathematical coordinates for either turn direction.
+///
+/// # Errors
+///
+/// Returns [`ArcsMeshError`] for invalid tolerance, non-finite geometry, or a
+/// subdivision that would exceed the module's safety limit, or a boundary
+/// which does not form a triangulatable simple polygon.
+#[must_use = "the generated join mesh must be handled"]
+pub(crate) fn tessellate_arcs_join(
+    join: &ResolvedArcsJoin,
+    tolerance: f64,
+) -> Result<ArcsMesh, ArcsMeshError> {
+    let mut mesh = ArcsMesh::default();
+    mesh.tessellate(join, tolerance)?;
+    Ok(mesh)
+}
+
+fn validate_boundary(boundary: BoundaryPiece, segment: &'static str) -> Result<(), ArcsMeshError> {
+    let valid = match boundary {
+        BoundaryPiece::Line { start, end } => point_is_finite(start) && point_is_finite(end),
+        BoundaryPiece::Arc {
+            center,
+            radius,
+            start,
+            end,
+            sweep,
+        } => {
+            point_is_finite(center)
+                && radius.is_finite()
+                && radius > 0.0
+                && point_is_finite(start)
+                && point_is_finite(end)
+                && sweep.is_finite()
+        }
+    };
+    if !valid {
+        return Err(ArcsMeshError::InvalidBoundary { segment });
+    }
+
+    Ok(())
+}
+
+#[inline]
+fn prepare_mesh_layout<const SINGLE_CHORD_FAST_PATH: bool>(
+    join: &ResolvedArcsJoin,
+    tolerance: f64,
+) -> Result<MeshLayout, ArcsMeshError> {
+    if !tolerance.is_finite() || tolerance <= 0.0 {
+        return Err(ArcsMeshError::InvalidTolerance);
+    }
+    validate_boundary(join.incoming_boundary(), "incoming")?;
+    validate_boundary(join.outgoing_boundary(), "outgoing")?;
+    let incoming_boundary = join.incoming_boundary();
+    let outgoing_boundary = join.outgoing_boundary();
+    let (incoming_steps, incoming_sweep_radians) =
+        prepare_boundary::<SINGLE_CHORD_FAST_PATH>(incoming_boundary, tolerance)?;
+    let (outgoing_steps, outgoing_sweep_radians) =
+        prepare_boundary::<SINGLE_CHORD_FAST_PATH>(outgoing_boundary, tolerance)?;
+    let clip_vertex_count = usize::from(join.is_clipped());
+    let vertex_count = 1usize
+        .checked_add(incoming_steps)
+        .and_then(|count| count.checked_add(clip_vertex_count))
+        .and_then(|count| count.checked_add(outgoing_steps))
+        .ok_or(ArcsMeshError::TooManyVertices {
+            limit: MAX_VERTEX_COUNT,
+        })?;
+    if vertex_count > MAX_VERTEX_COUNT {
+        return Err(ArcsMeshError::TooManyVertices {
+            limit: MAX_VERTEX_COUNT,
+        });
+    }
+
+    Ok(MeshLayout {
+        incoming_boundary,
+        outgoing_boundary,
+        incoming_sweep_radians,
+        outgoing_sweep_radians,
+        incoming_steps,
+        outgoing_steps,
+        clip_vertex_count,
+        vertex_count,
+    })
+}
+
+#[cfg(test)]
+fn boundary_steps(boundary: BoundaryPiece, tolerance: f64) -> Result<usize, ArcsMeshError> {
+    boundary_steps_impl::<true>(boundary, tolerance)
+}
+
+fn boundary_steps_impl<const SINGLE_CHORD_FAST_PATH: bool>(
+    boundary: BoundaryPiece,
+    tolerance: f64,
+) -> Result<usize, ArcsMeshError> {
+    prepare_boundary::<SINGLE_CHORD_FAST_PATH>(boundary, tolerance).map(|prepared| prepared.0)
+}
+
+fn prepare_boundary<const SINGLE_CHORD_FAST_PATH: bool>(
+    boundary: BoundaryPiece,
+    tolerance: f64,
+) -> Result<(usize, f64), ArcsMeshError> {
+    let BoundaryPiece::Arc {
+        radius,
+        start,
+        end,
+        center,
+        sweep,
+        ..
+    } = boundary
+    else {
+        return Ok((1, 0.0));
+    };
+
+    if SINGLE_CHORD_FAST_PATH
+        && sweep_is_minor(sweep, start - center, end - center)
+        && (tolerance >= radius
+            || point_distance_squared(start, end) <= 4.0 * tolerance * (2.0 * radius - tolerance))
+    {
+        return Ok((1, 0.0));
+    }
+
+    let sweep_radians = sweep.resolve(start - center, end - center);
+    let sine = (tolerance / (2.0 * radius)).sqrt().min(1.0);
+    let maximum_step = 4.0 * sine.asin();
+    let required_steps = (sweep_radians.abs() / maximum_step).ceil().max(1.0);
+    if !required_steps.is_finite() || required_steps > MAX_VERTEX_COUNT as f64 {
+        return Err(ArcsMeshError::TooManyVertices {
+            limit: MAX_VERTEX_COUNT,
+        });
+    }
+
+    Ok((required_steps as usize, sweep_radians))
+}
+
+fn sweep_is_minor(sweep: ArcSweep, start: Vector64, end: Vector64) -> bool {
+    if let Some(sweep_radians) = sweep.resolved_radians() {
+        return sweep_radians.abs() <= core::f64::consts::PI;
+    }
+
+    let cross = start.cross(end);
+    if sweep.counter_clockwise() {
+        cross >= 0.0
+    } else {
+        cross <= 0.0
+    }
+}
+
+#[derive(Clone, Copy)]
+enum BoundaryTraversal {
+    Forward,
+    Reverse,
+}
+
+fn append_boundary(
+    vertices: &mut Vec<Point64>,
+    boundary: BoundaryPiece,
+    traversal: BoundaryTraversal,
+    include_start: bool,
+    steps: usize,
+    sweep_radians: f64,
+) {
+    match boundary {
+        BoundaryPiece::Line { start, end } => {
+            let (start, end) = orient_endpoints(start, end, traversal);
+            if include_start {
+                vertices.push(start);
+            }
+            vertices.push(end);
+        }
+        BoundaryPiece::Arc {
+            center,
+            radius,
+            start,
+            end,
+            ..
+        } => {
+            let (start, end, sweep_radians) = match traversal {
+                BoundaryTraversal::Forward => (start, end, sweep_radians),
+                BoundaryTraversal::Reverse => (end, start, -sweep_radians),
+            };
+            if include_start {
+                vertices.push(start);
+            }
+            if steps > 1 {
+                let start_radius = start - center;
+                let scale = radius
+                    / (start_radius.x * start_radius.x + start_radius.y * start_radius.y).sqrt();
+                let mut radial = start_radius * scale;
+                let angle_step = sweep_radians / steps as f64;
+                let (sin_step, cos_step) = angle_step.sin_cos();
+                for _ in 1..steps {
+                    radial = crate::stroke_arcs::Vector64::new(
+                        radial.x * cos_step - radial.y * sin_step,
+                        radial.x * sin_step + radial.y * cos_step,
+                    );
+                    vertices.push(center + radial);
+                }
+            }
+            vertices.push(end);
+        }
+    }
+}
+
+#[allow(dead_code)] // Retained as the profiling baseline for recurrent rotation.
+fn append_boundary_trigonometric(
+    vertices: &mut Vec<Point64>,
+    boundary: BoundaryPiece,
+    traversal: BoundaryTraversal,
+    include_start: bool,
+    steps: usize,
+    sweep_radians: f64,
+) {
+    match boundary {
+        BoundaryPiece::Line { start, end } => {
+            let (start, end) = orient_endpoints(start, end, traversal);
+            if include_start {
+                vertices.push(start);
+            }
+            vertices.push(end);
+        }
+        BoundaryPiece::Arc {
+            center,
+            radius,
+            start,
+            end,
+            ..
+        } => {
+            let (start, end, sweep_radians) = match traversal {
+                BoundaryTraversal::Forward => (start, end, sweep_radians),
+                BoundaryTraversal::Reverse => (end, start, -sweep_radians),
+            };
+            if include_start {
+                vertices.push(start);
+            }
+            let start_radius = start - center;
+            let start_angle = start_radius.y.atan2(start_radius.x);
+            for step in 1..steps {
+                let angle = start_angle + sweep_radians * step as f64 / steps as f64;
+                vertices.push(Point64::new(
+                    center.x + radius * angle.cos(),
+                    center.y + radius * angle.sin(),
+                ));
+            }
+            vertices.push(end);
+        }
+    }
+}
+
+fn orient_endpoints(
+    start: Point64,
+    end: Point64,
+    traversal: BoundaryTraversal,
+) -> (Point64, Point64) {
+    match traversal {
+        BoundaryTraversal::Forward => (start, end),
+        BoundaryTraversal::Reverse => (end, start),
+    }
+}
+
+fn direct_triangle(
+    incoming_boundary: BoundaryPiece,
+    outgoing_boundary: BoundaryPiece,
+) -> Result<DirectArcsTriangle, ArcsMeshError> {
+    let vertices = [
+        boundary_start(incoming_boundary),
+        boundary_end(incoming_boundary),
+        boundary_start(outgoing_boundary),
+    ];
+    let signed_area = signed_triangle_area(vertices[0], vertices[1], vertices[2]);
+    let indices = if signed_area < 0.0 {
+        [2, 1, 0]
+    } else {
+        [0, 1, 2]
+    };
+    if signed_area.abs()
+        <= triangle_epsilon(
+            vertices[indices[0]],
+            vertices[indices[1]],
+            vertices[indices[2]],
+        )
+    {
+        return Err(ArcsMeshError::NonTriangulatableBoundary);
+    }
+
+    Ok(DirectArcsTriangle {
+        middle: vertices[1],
+        indices,
+    })
+}
+
+fn direct_quad(
+    incoming_boundary: BoundaryPiece,
+    outgoing_boundary: BoundaryPiece,
+) -> Option<DirectArcsQuad> {
+    let vertices = [
+        boundary_start(incoming_boundary),
+        boundary_end(incoming_boundary),
+        boundary_end(outgoing_boundary),
+        boundary_start(outgoing_boundary),
+    ];
+    let order = if polygon_signed_area(&vertices) < 0.0 {
+        [3, 2, 1, 0]
+    } else {
+        [0, 1, 2, 3]
+    };
+
+    for position in 0..4 {
+        let previous = order[(position + 3) % 4];
+        let current = order[position];
+        let next = order[(position + 1) % 4];
+        let opposite = order[(position + 2) % 4];
+        let first = vertices[previous];
+        let second = vertices[current];
+        let third = vertices[next];
+        if signed_triangle_area(first, second, third) <= triangle_epsilon(first, second, third)
+            || point_in_counter_clockwise_triangle(vertices[opposite], first, second, third)
+        {
+            continue;
+        }
+
+        let final_triangle = match position {
+            0 => [order[1], order[2], order[3]],
+            1 => [order[0], order[2], order[3]],
+            2 => [order[0], order[1], order[3]],
+            _ => [order[0], order[1], order[2]],
+        };
+        let [final_first, final_second, final_third] = final_triangle;
+        if signed_triangle_area(
+            vertices[final_first],
+            vertices[final_second],
+            vertices[final_third],
+        ) <= triangle_epsilon(
+            vertices[final_first],
+            vertices[final_second],
+            vertices[final_third],
+        ) {
+            return None;
+        }
+
+        // Every index comes from the four-element `order` array.
+        let indices = [
+            previous as u8,
+            current as u8,
+            next as u8,
+            final_first as u8,
+            final_second as u8,
+            final_third as u8,
+        ];
+        return Some(DirectArcsQuad {
+            middle: [vertices[1], vertices[2]],
+            indices,
+        });
+    }
+
+    None
+}
+
+#[cfg(test)]
+fn triangulate_polygon(
+    indices: &mut Vec<usize>,
+    vertices: &[Point64],
+    remaining: &mut Vec<usize>,
+    preferred_fan_roots: &[usize],
+) -> Result<TriangulationMethod, ArcsMeshError> {
+    triangulate_polygon_general(indices, vertices, remaining, preferred_fan_roots)
+}
+
+#[inline]
+fn triangulate_polygon_impl<const DIRECT_TRIANGLE_FAST_PATH: bool>(
+    indices: &mut Vec<usize>,
+    vertices: &[Point64],
+    remaining: &mut Vec<usize>,
+    preferred_fan_roots: &[usize],
+) -> Result<TriangulationMethod, ArcsMeshError> {
+    if DIRECT_TRIANGLE_FAST_PATH && vertices.len() == 3 {
+        let signed_area = signed_triangle_area(vertices[0], vertices[1], vertices[2]);
+        let (first, second, third) = if signed_area < 0.0 {
+            (2, 1, 0)
+        } else {
+            (0, 1, 2)
+        };
+        if signed_area.abs() <= triangle_epsilon(vertices[first], vertices[second], vertices[third])
+        {
+            return Err(ArcsMeshError::NonTriangulatableBoundary);
+        }
+        push_triangle(indices, first, second, third);
+        return Ok(TriangulationMethod::EarClipping);
+    }
+
+    triangulate_polygon_general(indices, vertices, remaining, preferred_fan_roots)
+}
+
+fn triangulate_polygon_general(
+    indices: &mut Vec<usize>,
+    vertices: &[Point64],
+    remaining: &mut Vec<usize>,
+    preferred_fan_roots: &[usize],
+) -> Result<TriangulationMethod, ArcsMeshError> {
+    let signed_area = polygon_signed_area(vertices);
+    if let Some(fan) = find_visible_fan(vertices, preferred_fan_roots, signed_area) {
+        fan.append_indices(indices);
+        return Ok(TriangulationMethod::Fan);
+    }
+
+    triangulate_with_ear_clipping(indices, vertices, remaining, signed_area)
+}
+
+fn triangulate_with_ear_clipping(
+    indices: &mut Vec<usize>,
+    vertices: &[Point64],
+    remaining: &mut Vec<usize>,
+    signed_area: f64,
+) -> Result<TriangulationMethod, ArcsMeshError> {
+    remaining.extend(0..vertices.len());
+    if signed_area < 0.0 {
+        remaining.reverse();
+    }
+
+    while remaining.len() > 3 {
+        if clip_one_ear(indices, vertices, remaining)? {
+            continue;
+        }
+        if let Some(position) = redundant_vertex_position(vertices, remaining) {
+            remaining.remove(position);
+            continue;
+        }
+
+        return Err(ArcsMeshError::NonTriangulatableBoundary);
+    }
+
+    let [first, second, third] = remaining[..] else {
+        return Err(ArcsMeshError::NonTriangulatableBoundary);
+    };
+    if signed_triangle_area(vertices[first], vertices[second], vertices[third])
+        <= triangle_epsilon(vertices[first], vertices[second], vertices[third])
+    {
+        return Err(ArcsMeshError::NonTriangulatableBoundary);
+    }
+    push_triangle(indices, first, second, third);
+    Ok(TriangulationMethod::EarClipping)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TriangulationMethod {
+    Fan,
+    EarClipping,
+}
+
+/// Finds an O(n) fan when a preferred root sees every boundary edge.
+/// The area check rejects fans that cross a concavity or overlap.
+fn find_visible_fan(
+    vertices: &[Point64],
+    preferred_roots: &[usize],
+    signed_polygon_area: f64,
+) -> Option<ValidatedFan> {
+    preferred_roots
+        .iter()
+        .copied()
+        .find_map(|root| validate_visible_fan(vertices, root, signed_polygon_area))
+}
+
+fn validate_visible_fan(
+    vertices: &[Point64],
+    root: usize,
+    signed_polygon_area: f64,
+) -> Option<ValidatedFan> {
+    if vertices.len() < 3 || root >= vertices.len() || signed_polygon_area == 0.0 {
+        return None;
+    }
+
+    let forward = signed_polygon_area > 0.0;
+    let polygon_area = signed_polygon_area.abs();
+    let fan = ValidatedFan {
+        root,
+        vertex_count: vertices.len(),
+        forward,
+    };
+    let mut triangle_area = 0.0;
+    for [root, first, second] in fan.triangles() {
+        let area = signed_triangle_area(vertices[root], vertices[first], vertices[second]);
+        if area <= triangle_epsilon(vertices[root], vertices[first], vertices[second]) {
+            return None;
+        }
+        triangle_area += area;
+    }
+
+    let scale = vertices
+        .iter()
+        .map(|point| point.x * point.x + point.y * point.y)
+        .fold(1.0, f64::max);
+    let area_epsilon = TRIANGULATION_EPSILON * scale.max(polygon_area) * vertices.len() as f64;
+    if (triangle_area - polygon_area).abs() > area_epsilon {
+        return None;
+    }
+
+    Some(fan)
+}
+
+#[inline]
+fn next_fan_index(index: usize, vertex_count: usize, forward: bool) -> usize {
+    if forward {
+        if index + 1 == vertex_count {
+            0
+        } else {
+            index + 1
+        }
+    } else if index == 0 {
+        vertex_count - 1
+    } else {
+        index - 1
+    }
+}
+
+fn clip_one_ear(
+    indices: &mut Vec<usize>,
+    vertices: &[Point64],
+    remaining: &mut Vec<usize>,
+) -> Result<bool, ArcsMeshError> {
+    for position in 0..remaining.len() {
+        let previous = remaining[(position + remaining.len() - 1) % remaining.len()];
+        let current = remaining[position];
+        let next = remaining[(position + 1) % remaining.len()];
+        let first = vertices[previous];
+        let second = vertices[current];
+        let third = vertices[next];
+        if signed_triangle_area(first, second, third) <= triangle_epsilon(first, second, third) {
+            continue;
+        }
+        let contains_vertex = remaining.iter().copied().any(|candidate| {
+            candidate != previous
+                && candidate != current
+                && candidate != next
+                && point_in_counter_clockwise_triangle(vertices[candidate], first, second, third)
+        });
+        if contains_vertex {
+            continue;
+        }
+
+        push_triangle(indices, previous, current, next);
+        remaining.remove(position);
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+fn push_triangle(indices: &mut Vec<usize>, first: usize, second: usize, third: usize) {
+    indices.push(first);
+    indices.push(second);
+    indices.push(third);
+}
+
+fn polygon_signed_area(vertices: &[Point64]) -> f64 {
+    vertices
+        .iter()
+        .copied()
+        .zip(vertices.iter().copied().cycle().skip(1))
+        .take(vertices.len())
+        .map(|(first, second)| first.x * second.y - first.y * second.x)
+        .sum::<f64>()
+        * 0.5
+}
+
+fn point_in_counter_clockwise_triangle(
+    point: Point64,
+    first: Point64,
+    second: Point64,
+    third: Point64,
+) -> bool {
+    let epsilon = triangle_epsilon(first, second, third);
+    signed_triangle_area(first, second, point) >= -epsilon
+        && signed_triangle_area(second, third, point) >= -epsilon
+        && signed_triangle_area(third, first, point) >= -epsilon
+}
+
+fn redundant_vertex_position(vertices: &[Point64], remaining: &[usize]) -> Option<usize> {
+    (0..remaining.len()).find(|position| {
+        let previous = vertices[remaining[(position + remaining.len() - 1) % remaining.len()]];
+        let current = vertices[remaining[*position]];
+        let next = vertices[remaining[(*position + 1) % remaining.len()]];
+        let incoming = current - previous;
+        let outgoing = next - current;
+        let area = signed_triangle_area(previous, current, next).abs();
+        let same_direction = incoming.x * outgoing.x + incoming.y * outgoing.y >= 0.0;
+
+        point_distance_squared(previous, current) <= TRIANGULATION_EPSILON
+            || point_distance_squared(current, next) <= TRIANGULATION_EPSILON
+            || (area <= triangle_epsilon(previous, current, next) && same_direction)
+    })
+}
+
+fn signed_triangle_area(first: Point64, second: Point64, third: Point64) -> f64 {
+    let first_edge = second - first;
+    let second_edge = third - first;
+    (first_edge.x * second_edge.y - first_edge.y * second_edge.x) * 0.5
+}
+
+fn triangle_epsilon(first: Point64, second: Point64, third: Point64) -> f64 {
+    TRIANGULATION_EPSILON
+        * point_distance_squared(first, second)
+            .max(point_distance_squared(first, third))
+            .max(1.0)
+}
+
+fn point_distance_squared(first: Point64, second: Point64) -> f64 {
+    let difference = second - first;
+    difference.x * difference.x + difference.y * difference.y
+}
+
+fn boundary_end(boundary: BoundaryPiece) -> Point64 {
+    match boundary {
+        BoundaryPiece::Line { end, .. } | BoundaryPiece::Arc { end, .. } => end,
+    }
+}
+
+fn boundary_start(boundary: BoundaryPiece) -> Point64 {
+    match boundary {
+        BoundaryPiece::Line { start, .. } | BoundaryPiece::Arc { start, .. } => start,
+    }
+}
+
+fn point_is_finite(point: Point64) -> bool {
+    point.x.is_finite() && point.y.is_finite()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+
+    use super::*;
+    use crate::stroke_arcs::{construct, JoinConstruction, JoinInput, SegmentEnd, Vector64};
+
+    const TEST_EPSILON: f64 = 1.0e-9;
+
+    #[test]
+    fn tessellation_rejects_zero_tolerance() {
+        let join = resolved_join(right_angle_input(0.0, 0.1));
+
+        let error = tessellate_arcs_join(&join, 0.0).expect_err("zero tolerance must fail");
+
+        assert_eq!(
+            error.to_string(),
+            "tolerance must be finite and greater than zero"
+        );
+    }
+
+    #[test]
+    fn finer_tolerance_adds_vertices_to_curved_boundaries() {
+        let join = resolved_join(right_angle_input(0.1, 0.1));
+
+        let coarse = tessellate_arcs_join(&join, 0.5).expect("coarse tessellation must succeed");
+        let fine = tessellate_arcs_join(&join, 0.001).expect("fine tessellation must succeed");
+
+        assert!(fine.vertices().len() > coarse.vertices().len());
+    }
+
+    #[test]
+    fn nearly_smooth_join_stays_inside_its_miter_limit() {
+        let input = JoinInput {
+            at: Point64::new(0.0, 0.0),
+            incoming: SegmentEnd {
+                tangent: Vector64::new(91.0, -144.0),
+                curvature: -0.004_263_384_207_957_165,
+            },
+            outgoing: SegmentEnd {
+                tangent: Vector64::new(100.0, -139.0),
+                curvature: 0.004_575_682_135_228_179_5,
+            },
+            half_width: 14.0,
+            miter_limit: 4.0,
+        };
+        let join = resolved_join(input);
+
+        let mesh = tessellate_arcs_join(&join, 0.1).expect("the join must tessellate");
+        let maximum_distance = mesh
+            .vertices()
+            .iter()
+            .map(|point| (point.x * point.x + point.y * point.y).sqrt())
+            .fold(0.0_f64, f64::max);
+
+        assert!(
+            maximum_distance <= input.half_width * input.miter_limit + TEST_EPSILON,
+            "join reached {}, beyond the miter limit",
+            maximum_distance,
+        );
+    }
+
+    #[test]
+    fn arc_subdivision_keeps_sagitta_within_tolerance() {
+        let tolerance = 0.1;
+        let radius = 10.0;
+        let sweep_radians = core::f64::consts::FRAC_PI_2;
+        let boundary = BoundaryPiece::Arc {
+            center: Point64::new(0.0, 0.0),
+            radius,
+            start: Point64::new(radius, 0.0),
+            end: Point64::new(0.0, radius),
+            sweep: ArcSweep::lazy(true),
+        };
+
+        let steps = boundary_steps(boundary, tolerance)
+            .expect("the finite arc should have a subdivision count");
+        let sagitta = radius * (1.0 - (sweep_radians / steps as f64 / 2.0).cos());
+
+        assert!(sagitta <= tolerance + TEST_EPSILON);
+    }
+
+    #[test]
+    fn quarter_circle_uses_one_chord_when_tolerance_exceeds_its_sagitta() {
+        let boundary = quarter_circle_boundary(10.0);
+
+        let steps =
+            boundary_steps(boundary, 3.0).expect("the finite arc should have a subdivision count");
+
+        assert_eq!(steps, 1);
+    }
+
+    #[test]
+    fn quarter_circle_is_subdivided_when_one_chord_exceeds_tolerance() {
+        let boundary = quarter_circle_boundary(10.0);
+
+        let steps =
+            boundary_steps(boundary, 2.0).expect("the finite arc should have a subdivision count");
+
+        assert_eq!(steps, 2);
+    }
+
+    #[test]
+    fn major_arc_does_not_use_the_minor_arc_chord_bound() {
+        let mut boundary = quarter_circle_boundary(10.0);
+        let BoundaryPiece::Arc { sweep, .. } = &mut boundary else {
+            unreachable!("the fixture is an arc");
+        };
+        *sweep = ArcSweep::resolved(3.0 * core::f64::consts::FRAC_PI_2);
+
+        let steps =
+            boundary_steps(boundary, 3.0).expect("the finite arc should have a subdivision count");
+
+        assert_eq!(steps, 3);
+    }
+
+    #[test]
+    fn lazy_major_arc_does_not_use_the_minor_arc_chord_bound() {
+        let boundary = BoundaryPiece::Arc {
+            center: Point64::new(0.0, 0.0),
+            radius: 10.0,
+            start: Point64::new(10.0, 0.0),
+            end: Point64::new(0.0, -10.0),
+            sweep: ArcSweep::lazy(true),
+        };
+
+        let steps =
+            boundary_steps(boundary, 3.0).expect("the finite arc should have a subdivision count");
+
+        assert_eq!(steps, 3);
+    }
+
+    #[test]
+    fn recurrent_arc_rotation_stays_on_the_requested_circle() {
+        let radius = 10.0;
+        let center = Point64::new(3.0, -7.0);
+        let end = Point64::new(center.x + radius, center.y);
+        let boundary = BoundaryPiece::Arc {
+            center,
+            radius,
+            start: end,
+            end,
+            sweep: ArcSweep::resolved(core::f64::consts::TAU),
+        };
+        let mut vertices = Vec::new();
+
+        append_boundary(
+            &mut vertices,
+            boundary,
+            BoundaryTraversal::Forward,
+            true,
+            MAX_VERTEX_COUNT,
+            core::f64::consts::TAU,
+        );
+
+        assert_eq!(vertices.first(), Some(&end));
+        assert_eq!(vertices.last(), Some(&end));
+        assert!(vertices.iter().all(|point| {
+            let radial = *point - center;
+            ((radial.x * radial.x + radial.y * radial.y).sqrt() - radius).abs() <= 1.0e-10
+        }));
+    }
+
+    #[test]
+    fn visible_polygon_uses_the_linear_fan_path() {
+        let vertices = [
+            Point64::new(0.0, 0.0),
+            Point64::new(2.0, 0.0),
+            Point64::new(1.0, 1.0),
+            Point64::new(2.0, 2.0),
+            Point64::new(0.0, 2.0),
+        ];
+        let mut indices = Vec::new();
+        let mut remaining = Vec::new();
+
+        let method = triangulate_polygon(&mut indices, &vertices, &mut remaining, &[2])
+            .expect("the visible concave polygon must triangulate");
+
+        assert_eq!(method, TriangulationMethod::Fan);
+        assert_eq!(indices.len(), (vertices.len() - 2) * 3);
+    }
+
+    #[test]
+    fn validated_fan_streams_the_buffered_index_order() {
+        let vertices = [
+            Point64::new(0.0, 0.0),
+            Point64::new(2.0, 0.0),
+            Point64::new(1.0, 1.0),
+            Point64::new(2.0, 2.0),
+            Point64::new(0.0, 2.0),
+        ];
+        let signed_area = polygon_signed_area(&vertices);
+        let fan = validate_visible_fan(&vertices, 2, signed_area)
+            .expect("the preferred root must see every boundary edge");
+        let streamed: Vec<_> = fan.triangles().flatten().collect();
+        let mut buffered = Vec::new();
+
+        fan.append_indices(&mut buffered);
+
+        assert_eq!(streamed, buffered);
+    }
+
+    #[test]
+    fn invisible_fan_root_falls_back_to_ear_clipping() {
+        let vertices = [
+            Point64::new(0.0, 0.0),
+            Point64::new(2.0, 0.0),
+            Point64::new(1.0, 1.0),
+            Point64::new(2.0, 2.0),
+            Point64::new(0.0, 2.0),
+        ];
+        let mut indices = Vec::new();
+        let mut remaining = Vec::new();
+
+        let method = triangulate_polygon(&mut indices, &vertices, &mut remaining, &[0])
+            .expect("ear clipping must handle an invisible preferred root");
+
+        assert_eq!(method, TriangulationMethod::EarClipping);
+        assert_eq!(indices.len(), (vertices.len() - 2) * 3);
+    }
+
+    #[test]
+    fn counter_clockwise_triangle_keeps_its_index_order() {
+        let vertices = [
+            Point64::new(0.0, 0.0),
+            Point64::new(2.0, 0.0),
+            Point64::new(0.0, 2.0),
+        ];
+        let mut indices = Vec::new();
+        let mut remaining = Vec::new();
+
+        triangulate_polygon(&mut indices, &vertices, &mut remaining, &[])
+            .expect("the triangle must triangulate");
+
+        assert_eq!(indices, [0, 1, 2]);
+    }
+
+    #[test]
+    fn clockwise_triangle_reverses_its_index_order() {
+        let vertices = [
+            Point64::new(0.0, 0.0),
+            Point64::new(0.0, 2.0),
+            Point64::new(2.0, 0.0),
+        ];
+        let mut indices = Vec::new();
+        let mut remaining = Vec::new();
+
+        triangulate_polygon(&mut indices, &vertices, &mut remaining, &[])
+            .expect("the triangle must triangulate");
+
+        assert_eq!(indices, [2, 1, 0]);
+    }
+
+    #[test]
+    fn representative_curved_join_uses_the_linear_fan_path() {
+        let join = resolved_join(right_angle_input(0.04, 0.04));
+        let mut mesh = ArcsMesh::default();
+
+        let method = mesh
+            .tessellate_impl::<true, true, true, true>(&join, 0.0001)
+            .expect("the representative join must tessellate");
+
+        assert_eq!(method, TriangulationMethod::Fan);
+    }
+
+    #[test]
+    fn representative_curved_join_returns_a_direct_fan() {
+        let join = resolved_join(right_angle_input(0.04, 0.04));
+        let mut mesh = ArcsMesh::default();
+
+        let output = mesh
+            .tessellate_for_output(&join, 0.0001)
+            .expect("the representative join must tessellate");
+
+        let ArcsOutput::Fan { vertices, fan } = output else {
+            panic!("the detailed visible join must use direct fan output");
+        };
+        assert_eq!(fan.triangles().len(), vertices.len() - 2);
+        assert!(mesh.indices.is_empty());
+    }
+
+    #[test]
+    fn representative_clipped_join_returns_a_direct_quad() {
+        let mut input = right_angle_input(0.0, 0.04);
+        input.miter_limit = 1.2;
+        let join = resolved_join(input);
+        let mut mesh = ArcsMesh::default();
+
+        let output = mesh
+            .tessellate_for_output(&join, 0.1)
+            .expect("the clipped join must tessellate");
+
+        assert!(
+            matches!(output, ArcsOutput::Quad(_))
+                && mesh.vertices.is_empty()
+                && mesh.indices.is_empty()
+                && mesh.remaining.is_empty()
+        );
+    }
+
+    #[test]
+    fn direct_quad_preserves_the_buffered_vertex_and_index_order() {
+        let mut input = right_angle_input(0.0, 0.04);
+        input.miter_limit = 1.2;
+        let join = resolved_join(input);
+        let buffered = tessellate_arcs_join(&join, 0.1).expect("the clipped join must tessellate");
+        let direct = direct_quad(join.incoming_boundary(), join.outgoing_boundary())
+            .expect("the four-vertex boundary must support direct output");
+        let direct_vertices = [
+            boundary_start(join.incoming_boundary()),
+            direct.middle[0],
+            direct.middle[1],
+            boundary_start(join.outgoing_boundary()),
+        ];
+        let direct_indices = direct.indices.map(usize::from);
+
+        assert_eq!(
+            (direct_vertices.as_slice(), direct_indices.as_slice()),
+            (buffered.vertices(), buffered.indices())
+        );
+    }
+
+    #[test]
+    fn direct_quad_matches_ear_clipping_for_both_windings_and_a_concavity() {
+        let cases = [
+            [
+                Point64::new(0.0, 0.0),
+                Point64::new(2.0, 0.0),
+                Point64::new(2.0, 2.0),
+                Point64::new(0.0, 2.0),
+            ],
+            [
+                Point64::new(0.0, 2.0),
+                Point64::new(2.0, 2.0),
+                Point64::new(2.0, 0.0),
+                Point64::new(0.0, 0.0),
+            ],
+            [
+                Point64::new(0.0, 0.0),
+                Point64::new(2.0, 0.0),
+                Point64::new(0.75, 0.5),
+                Point64::new(0.0, 2.0),
+            ],
+        ];
+
+        for vertices in cases {
+            let incoming = BoundaryPiece::Line {
+                start: vertices[0],
+                end: vertices[1],
+            };
+            let outgoing = BoundaryPiece::Line {
+                start: vertices[3],
+                end: vertices[2],
+            };
+            let direct = direct_quad(incoming, outgoing)
+                .expect("the valid four-vertex boundary must support direct output");
+            let mut buffered_indices = Vec::new();
+            let mut remaining = Vec::new();
+
+            triangulate_with_ear_clipping(
+                &mut buffered_indices,
+                &vertices,
+                &mut remaining,
+                polygon_signed_area(&vertices),
+            )
+            .expect("the valid four-vertex boundary must triangulate");
+
+            assert_eq!(direct.indices.map(usize::from).as_slice(), buffered_indices);
+        }
+    }
+
+    #[test]
+    fn direct_quad_rejects_a_degenerate_boundary_for_the_buffered_fallback() {
+        let incoming = BoundaryPiece::Line {
+            start: Point64::new(0.0, 0.0),
+            end: Point64::new(1.0, 0.0),
+        };
+        let outgoing = BoundaryPiece::Line {
+            start: Point64::new(3.0, 0.0),
+            end: Point64::new(2.0, 0.0),
+        };
+
+        assert!(direct_quad(incoming, outgoing).is_none());
+    }
+
+    #[test]
+    fn tessellation_uses_the_clip_edge_as_part_of_the_outer_chain() {
+        let mut input = right_angle_input(0.0, 0.1);
+        input.miter_limit = 1.2;
+        let join = resolved_join(input);
+        let clip = join.clip.expect("the input should produce a clip edge");
+
+        let mesh = tessellate_arcs_join(&join, 0.01).expect("the clipped join must tessellate");
+
+        assert!(mesh
+            .vertices()
+            .windows(2)
+            .any(|edge| point_is_near(edge[0], clip.incoming)
+                && point_is_near(edge[1], clip.outgoing)));
+    }
+
+    #[test]
+    fn every_triangle_has_counter_clockwise_winding_for_a_left_turn() {
+        let input = right_angle_input(0.1, 0.1);
+        let join = resolved_join(input);
+
+        let mesh = tessellate_arcs_join(&join, 0.01).expect("the curved join must tessellate");
+
+        assert!(all_triangles_are_counter_clockwise(&mesh));
+    }
+
+    #[test]
+    fn every_triangle_has_counter_clockwise_winding_for_a_right_turn() {
+        let mut input = right_angle_input(-0.1, -0.1);
+        input.outgoing.tangent = Vector64::new(0.0, -1.0);
+        let join = resolved_join(input);
+
+        let mesh =
+            tessellate_arcs_join(&join, 0.01).expect("the reflected curved join must tessellate");
+
+        assert!(all_triangles_are_counter_clockwise(&mesh));
+    }
+
+    #[test]
+    fn all_indices_reference_existing_vertices() {
+        let input = right_angle_input(0.1, 0.1);
+        let join = resolved_join(input);
+
+        let mesh = tessellate_arcs_join(&join, 0.01).expect("the curved join must tessellate");
+
+        assert!(mesh
+            .indices()
+            .iter()
+            .all(|index| *index < mesh.vertices().len()));
+    }
+
+    #[test]
+    fn representative_support_combinations_produce_valid_meshes() {
+        let cases = [(0.0, 0.04, 1.2), (0.04, 0.04, 4.0)];
+
+        for (incoming_curvature, outgoing_curvature, miter_limit) in cases {
+            let mut input = right_angle_input(incoming_curvature, outgoing_curvature);
+            input.half_width = 10.0;
+            input.miter_limit = miter_limit;
+            let join = resolved_join(input);
+            let mesh = tessellate_arcs_join(&join, 0.25).expect("diagnostic join must tessellate");
+
+            assert!(
+                all_triangles_are_counter_clockwise(&mesh),
+                "invalid mesh for curvatures {}, {}",
+                incoming_curvature,
+                outgoing_curvature
+            );
+        }
+    }
+
+    #[test]
+    fn triangles_cover_a_curved_join_without_overlap() {
+        let input = right_angle_input(0.1, 0.1);
+        let join = resolved_join(input);
+
+        let mesh = tessellate_arcs_join(&join, 0.25).expect("the curved join must tessellate");
+        let polygon_area = polygon_signed_area(mesh.vertices()).abs();
+        let triangle_area = mesh
+            .indices()
+            .chunks_exact(3)
+            .map(|triangle| {
+                signed_triangle_area(
+                    mesh.vertices()[triangle[0]],
+                    mesh.vertices()[triangle[1]],
+                    mesh.vertices()[triangle[2]],
+                )
+            })
+            .sum::<f64>();
+
+        assert!((triangle_area - polygon_area).abs() <= TEST_EPSILON * polygon_area.max(1.0));
+    }
+
+    fn resolved_join(input: JoinInput) -> ResolvedArcsJoin {
+        let construction = construct(input).expect("test join construction must succeed");
+        let JoinConstruction::Arcs(join) = construction else {
+            panic!("test input should produce an arcs join");
+        };
+
+        join
+    }
+
+    fn quarter_circle_boundary(radius: f64) -> BoundaryPiece {
+        BoundaryPiece::Arc {
+            center: Point64::new(0.0, 0.0),
+            radius,
+            start: Point64::new(radius, 0.0),
+            end: Point64::new(0.0, radius),
+            sweep: ArcSweep::lazy(true),
+        }
+    }
+
+    fn right_angle_input(incoming_curvature: f64, outgoing_curvature: f64) -> JoinInput {
+        JoinInput {
+            at: Point64::new(0.0, 0.0),
+            incoming: SegmentEnd {
+                tangent: Vector64::new(1.0, 0.0),
+                curvature: incoming_curvature,
+            },
+            outgoing: SegmentEnd {
+                tangent: Vector64::new(0.0, 1.0),
+                curvature: outgoing_curvature,
+            },
+            half_width: 2.0,
+            miter_limit: 4.0,
+        }
+    }
+
+    fn all_triangles_are_counter_clockwise(mesh: &ArcsMesh) -> bool {
+        mesh.indices().chunks_exact(3).all(|indices| {
+            let first = mesh.vertices()[indices[0]];
+            let second = mesh.vertices()[indices[1]];
+            let third = mesh.vertices()[indices[2]];
+            let first_edge = second - first;
+            let second_edge = third - first;
+            first_edge.x * second_edge.y - first_edge.y * second_edge.x > TEST_EPSILON
+        })
+    }
+
+    fn point_is_near(actual: Point64, expected: Point64) -> bool {
+        (actual.x - expected.x).abs() <= TEST_EPSILON
+            && (actual.y - expected.y).abs() <= TEST_EPSILON
+    }
+}

--- a/crates/tessellation/src/stroke_round_clip.rs
+++ b/crates/tessellation/src/stroke_round_clip.rs
@@ -1,0 +1,438 @@
+//! Experimental tangent-continuous biarc tips on actual SVG 2 miter cuts.
+//! Vertex metadata stays attached to the join, not to the displaced tip.
+
+use super::*;
+use crate::GeometryBuilderError;
+
+/// Append a convex biarc outside the existing cut without moving the base mesh.
+/// Both tangents point out of the retained stroke. Degenerate/non-convex fits
+/// retain the flat cut instead of adding a loop or overlapping the body.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit(
+    join: &EndpointData,
+    ends: [Point; 2],
+    tangents: [Vector64; 2],
+    side: usize,
+    tolerance: f32,
+    vertex: &mut StrokeVertexData,
+    attributes: &dyn AttributeStore,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
+) -> Result<(), TessellationError> {
+    let Some(cap) = RoundClip::new(join.position, ends, tangents, tolerance)? else {
+        return Ok(());
+    };
+    vertex.position_on_path = join.position;
+    vertex.half_width = join.half_width;
+    vertex.side = if side == SIDE_POSITIVE {
+        Side::Positive
+    } else {
+        Side::Negative
+    };
+    let center = emit_point(cap.center, vertex, attributes, output)?;
+    let mut previous = emit_point(cap.arcs[0].start, vertex, attributes, output)?;
+    for step in 1..=cap.steps() {
+        let next = emit_point(cap.sample(step), vertex, attributes, output)?;
+        if cap.clockwise {
+            output.add_triangle(center, previous, next);
+        } else {
+            output.add_triangle(center, next, previous);
+        }
+        previous = next;
+    }
+    Ok(())
+}
+
+pub(super) fn vector64(v: Vector) -> Vector64 {
+    Vector64::new(f64::from(v.x), f64::from(v.y))
+}
+
+/// Reconstruct the straight offset-edge direction before join clipping moved
+/// its endpoints. The next edge's attachment points may not be initialized yet.
+pub(super) fn edge_tangent(from: &EndpointData, to: &EndpointData, side: usize) -> Vector64 {
+    let edge = to.position - from.position;
+    let length = edge.length();
+    let width_delta = to.half_width - from.half_width;
+    let sin_angle = width_delta / length;
+    let width_angle = if sin_angle.abs() <= 1.0 {
+        sin_angle.asin()
+    } else {
+        0.0
+    };
+    let normal_angle =
+        edge.angle_from_x_axis().radians + side_sign(side) * (PI * 0.5 + width_angle);
+    vector64(edge + vector(normal_angle.cos(), normal_angle.sin()) * width_delta)
+}
+
+fn emit_point(
+    position: Point64,
+    vertex: &mut StrokeVertexData,
+    attributes: &dyn AttributeStore,
+    output: &mut (impl StrokeGeometryBuilder + ?Sized),
+) -> Result<VertexId, TessellationError> {
+    let position = point64_to_point(position).map_err(|_| GeometryBuilderError::InvalidVertex)?;
+    vertex.normal = (position - vertex.position_on_path) / vertex.half_width;
+    if !vertex.normal.x.is_finite() || !vertex.normal.y.is_finite() {
+        return Err(GeometryBuilderError::InvalidVertex.into());
+    }
+    Ok(output.add_stroke_vertex(StrokeVertex(vertex, attributes))?)
+}
+
+struct RoundClip {
+    center: Point64,
+    // Each arc runs from its cut endpoint to the shared meeting point.
+    arcs: [TipArc; 2],
+    clockwise: bool,
+}
+
+impl RoundClip {
+    fn new(
+        at: Point,
+        ends: [Point; 2],
+        tangents: [Vector64; 2],
+        tolerance: f32,
+    ) -> Result<Option<Self>, GeometryBuilderError> {
+        if !tolerance.is_finite() || tolerance <= 0.0 {
+            return Err(GeometryBuilderError::InvalidVertex);
+        }
+        let [a, b] = ends.map(|p| Point64::new(f64::from(p.x), f64::from(p.y)));
+        let chord = b - a;
+        let length = chord.x.hypot(chord.y);
+        if !length.is_finite() {
+            return Err(GeometryBuilderError::InvalidVertex);
+        }
+        if length == 0.0 {
+            return Ok(None);
+        }
+        let [Some(u), Some(v)] = tangents.map(unit) else {
+            return Ok(None);
+        };
+        let center = a + chord * 0.5;
+        let mut outward = Vector64::new(chord.y / length, -chord.x / length);
+        let to_tip = center - Point64::new(f64::from(at.x), f64::from(at.y));
+        if dot(outward, to_tip) < 0.0 {
+            outward = -outward;
+        }
+        if dot(u, outward) < -1.0e-10 || dot(v, outward) < -1.0e-10 {
+            return Ok(None);
+        }
+        // Equal-distance biarc, with second outline tangent -v. Solve in chord
+        // units and rationalize the positive root to avoid cancellation.
+        // Derivation: https://www.ryanjuckett.com/biarc-interpolation/
+        let axis = chord * length.recip();
+        let projection = dot(axis, u - v);
+        let denominator = 2.0 * (1.0 + dot(u, v)).max(0.0);
+        let root = (projection * projection + denominator).sqrt();
+        let distance = if projection >= 0.0 {
+            length / (root + projection)
+        } else {
+            length * (root - projection) / denominator
+        };
+        if !distance.is_finite() {
+            return Ok(None);
+        }
+        let meeting = center + (u + v) * (distance * 0.5);
+        let Some(first) = TipArc::new(a, meeting, u, f64::from(tolerance))? else {
+            return Ok(None);
+        };
+        let Some(second) = TipArc::new(b, meeting, v, f64::from(tolerance))? else {
+            return Ok(None);
+        };
+        let orientation = -chord.cross(outward).signum();
+        // Opposite curvature signs on endpoint-to-meeting arcs make a convex
+        // cap, so a fan rooted on the cut cannot overlap itself.
+        if first.angle * orientation < -1.0e-10 || second.angle * orientation > 1.0e-10 {
+            return Ok(None);
+        }
+        Ok(Some(Self {
+            center,
+            arcs: [first, second],
+            clockwise: orientation < 0.0,
+        }))
+    }
+
+    fn steps(&self) -> usize {
+        self.arcs[0].steps + self.arcs[1].steps
+    }
+
+    fn sample(&self, step: usize) -> Point64 {
+        if step <= self.arcs[0].steps {
+            self.arcs[0].sample(step)
+        } else {
+            self.arcs[1].sample(self.steps() - step)
+        }
+    }
+}
+
+struct TipArc {
+    start: Point64,
+    end: Point64,
+    tangent: Vector64,
+    signed_radius: f64,
+    angle: f64,
+    steps: usize,
+}
+
+impl TipArc {
+    fn new(
+        start: Point64,
+        end: Point64,
+        tangent: Vector64,
+        tolerance: f64,
+    ) -> Result<Option<Self>, GeometryBuilderError> {
+        let chord = end - start;
+        let normal = Vector64::new(-tangent.y, tangent.x);
+        let along = dot(chord, tangent);
+        let across = dot(chord, normal);
+        // Restrict to minor arcs; sample the exactly straight limit as a line.
+        if along < -1.0e-10 * chord.x.hypot(chord.y) {
+            return Ok(None);
+        }
+        let angle = 2.0 * across.atan2(along);
+        let radius = if across == 0.0 {
+            0.0
+        } else {
+            dot(chord, chord) / (2.0 * across)
+        };
+        let step_angle = if radius == 0.0 {
+            1.0
+        } else {
+            4.0 * (tolerance / (2.0 * radius.abs())).min(1.0).sqrt().asin()
+        };
+        let steps = (angle.abs() / step_angle).ceil().max(2.0);
+        if !steps.is_finite() || steps > 32_768.0 {
+            return Err(GeometryBuilderError::TooManyVertices);
+        }
+        Ok(Some(Self {
+            start,
+            end,
+            tangent,
+            signed_radius: radius,
+            angle,
+            steps: steps as usize,
+        }))
+    }
+
+    fn sample(&self, step: usize) -> Point64 {
+        if step == 0 {
+            return self.start;
+        }
+        if step == self.steps {
+            return self.end;
+        }
+        let fraction = step as f64 / self.steps as f64;
+        if self.signed_radius == 0.0 {
+            return self.start + (self.end - self.start) * fraction;
+        }
+        let angle = self.angle * fraction;
+        let normal = Vector64::new(-self.tangent.y, self.tangent.x);
+        // 2 sin²(theta/2) avoids cancellation for nearly flat arcs.
+        self.start
+            + self.tangent * (self.signed_radius * angle.sin())
+            + normal * (self.signed_radius * 2.0 * (angle * 0.5).sin().powi(2))
+    }
+}
+
+fn dot(a: Vector64, b: Vector64) -> f64 {
+    a.x * b.x + a.y * b.y
+}
+
+fn unit(v: Vector64) -> Option<Vector64> {
+    let length = v.x.hypot(v.y);
+    (length.is_finite() && length > 0.0).then(|| v * length.recip())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parallel_edges_retain_the_semicircle() {
+        let cap = RoundClip::new(
+            point(0.0, 0.0),
+            [point(10.0, -3.0), point(10.0, 3.0)],
+            [Vector64::new(1.0, 0.0); 2],
+            0.01,
+        )
+        .unwrap()
+        .unwrap();
+        let apex = cap.arcs[0].end;
+        assert!((apex.x - 13.0).abs() < 1.0e-10 && apex.y.abs() < 1.0e-10);
+    }
+
+    #[test]
+    fn converging_edges_produce_a_shallow_tangent_cap_not_a_half_circle() {
+        let cap = RoundClip::new(
+            point(0.0, 0.0),
+            [point(10.0, -3.0), point(10.0, 3.0)],
+            [Vector64::new(1.0, 2.0), Vector64::new(1.0, -2.0)],
+            0.001,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(cap.arcs[0].end.x > 10.0 && cap.arcs[0].end.x < 11.0);
+        assert!((cap.arcs[0].angle.abs() + cap.arcs[1].angle.abs()) < core::f64::consts::PI);
+        for arc in &cap.arcs {
+            let direction = unit(arc.sample(1) - arc.start).unwrap();
+            assert!(dot(direction, arc.tangent) > 0.999);
+            assert!(
+                arc.signed_radius.abs() * (1.0 - (arc.angle / (2.0 * arc.steps as f64)).cos())
+                    <= 0.001
+            );
+        }
+    }
+
+    #[test]
+    fn asymmetric_cap_matches_both_tangents_and_the_internal_tangent() {
+        let tangents = [Vector64::new(1.0, 0.2), Vector64::new(0.4, -1.0)];
+        let cap = RoundClip::new(
+            point(0.0, 0.0),
+            [point(10.0, -3.0), point(10.0, 3.0)],
+            tangents,
+            0.0001,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(cap.arcs[0].end.y.abs() > 0.1);
+        let [a, b] = &cap.arcs;
+        let ta = unit(a.end - a.sample(a.steps - 1)).unwrap();
+        let tb = unit(b.sample(b.steps - 1) - b.end).unwrap();
+        assert!(dot(ta, tb) > 0.999);
+        for i in 0..cap.steps() {
+            let p = cap.sample(i);
+            let q = cap.sample(i + 1);
+            assert!(p.x >= 10.0 - 1.0e-10);
+            assert!((p - cap.center).cross(q - cap.center) >= -1.0e-10);
+        }
+    }
+
+    #[test]
+    fn reversing_endpoints_preserves_the_cap() {
+        let ends = [point(10.0, -3.0), point(10.0, 3.0)];
+        let tangents = [Vector64::new(1.0, 0.2), Vector64::new(0.4, -1.0)];
+        let a = RoundClip::new(point(0.0, 0.0), ends, tangents, 0.01)
+            .unwrap()
+            .unwrap();
+        let b = RoundClip::new(
+            point(0.0, 0.0),
+            [ends[1], ends[0]],
+            [tangents[1], tangents[0]],
+            0.01,
+        )
+        .unwrap()
+        .unwrap();
+        assert_ne!(a.clockwise, b.clockwise);
+        for i in 0..=a.steps() {
+            let delta = a.sample(i) - b.sample(b.steps() - i);
+            assert!(delta.x.hypot(delta.y) < 1.0e-10);
+        }
+    }
+
+    #[test]
+    fn collapsed_cut_adds_no_vertices() {
+        assert!(RoundClip::new(
+            point(0.0, 0.0),
+            [point(1.0, 1.0); 2],
+            [Vector64::new(1.0, 0.0); 2],
+            0.01
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn curved_cuts_use_boundary_tangents_and_are_shallower_than_semicircles() {
+        // The two marked joins in the saved canvas, with width 80 / limit 1.5.
+        let cases = [
+            [
+                point(111.5625, 287.0),
+                point(334.5625, 409.0),
+                point(499.5625, 237.0),
+                point(316.15625, 114.0),
+                point(408.5625, 66.0),
+                point(495.5625, 63.0),
+                point(580.15625, 99.0),
+            ],
+            [
+                point(930.5625, 402.0),
+                point(806.5625, 656.0),
+                point(424.5625, 653.0),
+                point(237.5625, 605.0),
+                point(338.5625, 777.0),
+                point(630.5625, 737.0),
+                point(971.5625, 674.0),
+            ],
+        ];
+        for points in cases {
+            for mirror in [-1.0, 1.0] {
+                let [_, a, b, at, c, d, _] = points.map(|p| point(p.x, p.y * mirror));
+                let segment = |t: Vector, second: Vector| {
+                    let EndpointDifferential::Regular {
+                        unit_tangent,
+                        curvature,
+                    } = regular_differential(t, second)
+                    else {
+                        panic!("regular fixture");
+                    };
+                    SegmentEnd {
+                        tangent: vector64(unit_tangent),
+                        curvature,
+                    }
+                };
+                let input = JoinInput {
+                    at: Point64::new(f64::from(at.x), f64::from(at.y)),
+                    incoming: segment((at - b) * 3.0, ((at - b) - (b - a)) * 6.0),
+                    outgoing: segment((c - at) * 3.0, ((d - c) - (c - at)) * 6.0),
+                    half_width: 40.0,
+                    miter_limit: 1.5,
+                };
+                let JoinConstruction::Arcs(resolved) = stroke_arcs::construct_svg2(input).unwrap()
+                else {
+                    panic!("expected curved SVG2 join");
+                };
+                let ends = resolved
+                    .clip_endpoints()
+                    .unwrap()
+                    .map(|p| point64_to_point(p).unwrap());
+                for tolerance in [0.01, 1.1] {
+                    let cap = RoundClip::new(at, ends, resolved.clip_tangents(), tolerance)
+                        .unwrap()
+                        .unwrap();
+                    assert!(
+                        cap.arcs[0].angle.abs() + cap.arcs[1].angle.abs()
+                            < core::f64::consts::PI - 0.1
+                    );
+                    assert_eq!(
+                        cap.arcs[0].tangent,
+                        unit(resolved.clip_tangents()[0]).unwrap()
+                    );
+                    assert_eq!(
+                        cap.arcs[1].tangent,
+                        unit(resolved.clip_tangents()[1]).unwrap()
+                    );
+                    assert_eq!(
+                        cap.sample(0),
+                        Point64::new(f64::from(ends[0].x), f64::from(ends[0].y))
+                    );
+                    assert_eq!(
+                        cap.sample(cap.steps()),
+                        Point64::new(f64::from(ends[1].x), f64::from(ends[1].y))
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn inward_or_degenerate_tangents_do_not_emit_overlapping_tips() {
+        for tangents in [[Vector64::new(-1.0, 0.0); 2], [Vector64::new(0.0, 0.0); 2]] {
+            assert!(RoundClip::new(
+                point(0.0, 0.0),
+                [point(10.0, -3.0), point(10.0, 3.0)],
+                tangents,
+                0.01
+            )
+            .unwrap()
+            .is_none());
+        }
+    }
+}

--- a/crates/tessellation/tests/arcs_round_clip.rs
+++ b/crates/tessellation/tests/arcs_round_clip.rs
@@ -1,0 +1,258 @@
+//! Round clipping must change only the clipped join and preserve vertex metadata.
+
+use lyon_path::{geom::CubicBezierSegment, math::point, LineJoin, Path};
+use lyon_tessellation::{
+    ArcsClip, BuffersBuilder, StrokeOptions, StrokeTessellator, StrokeVertex, VertexBuffers,
+};
+
+fn segments(curvature: f32) -> [CubicBezierSegment<f32>; 2] {
+    [
+        CubicBezierSegment {
+            from: point(-40.0, 0.0),
+            ctrl1: point(-20.0, 0.0),
+            ctrl2: point(-10.0, 0.0),
+            to: point(0.0, 0.0),
+        },
+        CubicBezierSegment {
+            from: point(0.0, 0.0),
+            ctrl1: point(0.0, 10.0),
+            ctrl2: point(-150.0 * curvature, 20.0),
+            to: point(0.0, 40.0),
+        },
+    ]
+}
+
+fn options(mode: ArcsClip) -> StrokeOptions {
+    StrokeOptions::default()
+        .with_line_join(LineJoin::Arcs)
+        .with_arcs_clip(mode)
+        .with_line_width(4.0)
+        .with_miter_limit(20.0)
+        .with_tolerance(0.01)
+}
+
+fn path_from_segments(curvature: f32, mirror: f32) -> Path {
+    let mut builder = Path::builder();
+    let curves = segments(curvature);
+    let transform = |p: lyon_path::math::Point| point(p.x, p.y * mirror);
+    builder.begin(transform(curves[0].from));
+    for c in curves {
+        builder.cubic_bezier_to(transform(c.ctrl1), transform(c.ctrl2), transform(c.to));
+    }
+    builder.end(false);
+    builder.build()
+}
+
+fn mesh(path: &Path, options: &StrokeOptions) -> VertexBuffers<lyon_path::math::Point, u32> {
+    let mut mesh = VertexBuffers::new();
+    StrokeTessellator::new()
+        .tessellate_path(
+            path,
+            options,
+            &mut BuffersBuilder::new(&mut mesh, |v: StrokeVertex| v.position()),
+        )
+        .unwrap();
+    mesh
+}
+
+#[test]
+fn round_clip_preserves_unclipped_arcs_and_round_fallbacks_exactly() {
+    for curvature in [-0.4, -0.6, 0.1] {
+        let path = path_from_segments(curvature, 1.0);
+        let standard = mesh(&path, &options(ArcsClip::Butt));
+        let rounded = mesh(&path, &options(ArcsClip::Round));
+        assert_eq!(standard.vertices, rounded.vertices);
+        assert_eq!(standard.indices, rounded.indices);
+    }
+}
+
+#[test]
+fn rounded_cut_adds_geometry_for_both_turn_directions_and_keeps_original_vertices() {
+    for mirror in [-1.0, 1.0] {
+        let path = path_from_segments(-0.4, mirror);
+        let options = options(ArcsClip::Butt).with_miter_limit(1.6);
+        let standard = mesh(&path, &options);
+        let rounded = mesh(&path, &options.with_arcs_clip(ArcsClip::Round));
+        assert!(rounded.vertices.len() > standard.vertices.len());
+        assert!(
+            standard
+                .vertices
+                .iter()
+                .all(|p| rounded.vertices.contains(p)),
+            "base stroke moved"
+        );
+        assert!(rounded
+            .vertices
+            .iter()
+            .all(|p| p.x.is_finite() && p.y.is_finite()));
+        for triangle in rounded.indices.chunks_exact(3) {
+            let [a, b, c] =
+                [triangle[0], triangle[1], triangle[2]].map(|i| rounded.vertices[i as usize]);
+            if [a, b, c].iter().all(|p| standard.vertices.contains(p)) {
+                continue;
+            }
+            assert!(
+                (b - a).cross(c - a) <= 1.0e-4,
+                "inverted triangle {:?} {:?} {:?}",
+                a,
+                b,
+                c
+            );
+        }
+    }
+}
+
+#[test]
+fn round_cut_vertices_keep_join_metadata_instead_of_cap_center() {
+    let path = path_from_segments(-0.4, 1.0);
+    let options = options(ArcsClip::Round).with_miter_limit(1.6);
+    let mut mesh: VertexBuffers<_, u32> = VertexBuffers::new();
+    StrokeTessellator::new()
+        .tessellate_path(
+            &path,
+            &options,
+            &mut BuffersBuilder::new(&mut mesh, |v: StrokeVertex| {
+                (v.position(), v.position_on_path(), v.line_width())
+            }),
+        )
+        .unwrap();
+    assert!(mesh.vertices.iter().all(|v| v.2 == 4.0));
+    let original = mesh_positions_for_standard(&path, options);
+    let new: Vec<_> = mesh
+        .vertices
+        .iter()
+        .filter(|v| !original.vertices.contains(&v.0))
+        .collect();
+    assert!(!new.is_empty());
+    assert!(
+        new.iter().all(|v| v.1 == point(0.0, 0.0)),
+        "tip must retain the real join source"
+    );
+}
+
+fn mesh_positions_for_standard(
+    path: &Path,
+    options: StrokeOptions,
+) -> VertexBuffers<lyon_path::math::Point, u32> {
+    mesh(path, &options.with_arcs_clip(ArcsClip::Butt))
+}
+
+#[test]
+fn straight_segment_miter_cuts_are_rounded_too() {
+    let mut builder = Path::builder();
+    builder.begin(point(-40.0, 0.0));
+    builder.line_to(point(0.0, 0.0));
+    builder.line_to(point(-30.0, 10.0));
+    builder.end(false);
+    let path = builder.build();
+    let options = options(ArcsClip::Butt).with_miter_limit(2.0);
+    let standard = mesh(&path, &options);
+    let rounded = mesh(&path, &options.with_arcs_clip(ArcsClip::Round));
+    assert!(rounded.vertices.len() > standard.vertices.len());
+}
+
+#[test]
+fn zero_and_subunit_limits_produce_finite_rounded_geometry() {
+    let path = path_from_segments(-0.4, 1.0);
+    for limit in [0.0, 0.1, 0.5, 1.0, 1.6] {
+        let style = options(ArcsClip::Butt).with_miter_limit(limit);
+        let standard = mesh(&path, &style);
+        let rounded = mesh(&path, &style.with_arcs_clip(ArcsClip::Round));
+        assert!(rounded
+            .vertices
+            .iter()
+            .all(|p| p.x.is_finite() && p.y.is_finite()));
+        assert!(standard
+            .vertices
+            .iter()
+            .all(|p| rounded.vertices.contains(p)));
+        if limit == 0.0 {
+            assert_eq!(standard.vertices, rounded.vertices);
+            assert_eq!(standard.indices, rounded.indices);
+        }
+    }
+}
+
+#[test]
+fn asymmetric_curved_miter_cut_gets_a_round_tip() {
+    let mut builder = Path::builder();
+    builder.begin(point(137.5625, 221.0));
+    builder.cubic_bezier_to(
+        point(324.5625, 333.0),
+        point(441.5625, 125.0),
+        point(316.15625, 114.0),
+    );
+    builder.cubic_bezier_to(
+        point(400.5625, 104.0),
+        point(495.5625, 63.0),
+        point(580.15625, 99.0),
+    );
+    builder.end(false);
+    let path = builder.build();
+    let style = options(ArcsClip::Butt)
+        .with_line_width(80.0)
+        .with_miter_limit(2.5);
+    let standard = mesh(&path, &style);
+    let rounded = mesh(&path, &style.with_arcs_clip(ArcsClip::Round));
+    let extra: Vec<_> = rounded
+        .vertices
+        .iter()
+        .filter(|p| !standard.vertices.contains(p))
+        .collect();
+    assert!(!extra.is_empty());
+    assert!(
+        extra
+            .iter()
+            .all(|p| p.x < 225.0 && (70.0..160.0).contains(&p.y)),
+        "only the marked tip should change: {:?}",
+        extra
+    );
+}
+
+#[test]
+fn opposite_parallel_rectangle_gets_a_round_far_edge() {
+    let mut builder = Path::builder();
+    builder.begin(point(-40.0, 0.0));
+    builder.line_to(point(0.0, 0.0));
+    builder.cubic_bezier_to(point(-10.0, 0.0), point(-20.0, 5.0), point(-40.0, 5.0));
+    builder.end(false);
+    let path = builder.build();
+    let style = options(ArcsClip::Butt).with_miter_limit(3.0);
+    let standard = mesh(&path, &style);
+    let rounded = mesh(&path, &style.with_arcs_clip(ArcsClip::Round));
+    let old_x = standard
+        .vertices
+        .iter()
+        .map(|p| p.x)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let new_x = rounded
+        .vertices
+        .iter()
+        .map(|p| p.x)
+        .fold(f32::NEG_INFINITY, f32::max);
+    assert!(
+        (new_x - old_x - 2.0).abs() < 1.0e-4,
+        "round rectangle should extend by half its cut width"
+    );
+}
+
+#[test]
+fn svg2_flat_clipping_is_the_default() {
+    assert_eq!(StrokeOptions::default().arcs_clip, ArcsClip::Butt);
+}
+
+#[cfg(feature = "serialization")]
+#[test]
+fn old_options_without_clip_setting_load_as_standard_svg2() {
+    let json = r#"{"start_cap":"Butt","end_cap":"Round","line_join":"Miter","line_width":8.0,"variable_line_width":null,"miter_limit":4.0,"tolerance":0.1}"#;
+    let old: StrokeOptions = serde_json::from_str(json).unwrap();
+    assert_eq!(old.arcs_clip, ArcsClip::Butt);
+    let rounded = old
+        .with_line_join(LineJoin::Arcs)
+        .with_arcs_clip(ArcsClip::Round);
+    let encoded = serde_json::to_string(&rounded).unwrap();
+    assert_eq!(
+        serde_json::from_str::<StrokeOptions>(&encoded).unwrap(),
+        rounded
+    );
+}


### PR DESCRIPTION
The issue: #868 

## Summary

Adds `LineJoin::Arcs` to `lyon_path` and implements it in `lyon_tessellation`.
Original segment tangents and curvature are retained before flattening. Private
modules construct support geometry and triangulate the join, reusing scratch
allocations.

The construction follows the [SVG 2 Candidate Recommendation, 4 October 2018](https://www.w3.org/TR/2018/CR-SVG2-20181004/painting.html#LineJoinShape):
support-circle intersection and radius adjustment, the excessive-curvature guard,
opposite-parallel rectangle handling, and arc-length miter clipping. Nonnegative
miter limits are accepted, including zero and sub-unit limits.

A second, separable commit adds the nonstandard `ArcsClip::Round` extension.
It fits tangent-continuous biarcs to actual miter-cut directions, without moving
the existing stroke mesh. It is not necessarily a semicircle and may extend past
the miter limit. Invalid or non-convex fits retain the flat cut. SVG behavior
remains the default.

No editor, canvas persistence, support-preview API, historical join modes, or
public profiling switches are included.

## Commit sequence

1. `455ff35` — SVG 2 construction, regression tests, SVG example, and benchmarks.
2. `1692323` — optional rounded clipping, metadata/winding tests, and serialization migration test.

The first commit builds and passes the workspace tests independently. The second
can be considered separately if the extension is outside Lyon's desired scope.

## API

```rust
use lyon_tessellation::{ArcsClip, LineJoin, StrokeOptions};

let svg2 = StrokeOptions::default()
    .with_line_join(LineJoin::Arcs)
    .with_line_width(8.0)
    .with_miter_limit(4.0);

let rounded = svg2.with_arcs_clip(ArcsClip::Round);
```

Compatibility points requiring maintainer review:

- Adding a variant to the existing exhaustive `LineJoin` enum breaks downstream
  exhaustive matches. Release/version policy must be decided before merging.
  The new variant is appended so existing serialized variant indices are not shifted.
- `StrokeOptions` is already non-exhaustive. The second commit adds a field and
  builder method. Missing fields in old JSON default to flat clipping; binary
  serialization compatibility is **not** claimed.
- `MINIMUM_MITER_LIMIT` changes from 1 to 0 for all joins, not only arcs.
- There are no new production dependencies. `serde_json` is a dev dependency for
  the migration test.

## Validation

On Windows x86_64, stable Rust 1.90.0:

- `cargo test --workspace --all-features` passes.
- `cargo check -p lyon_tessellation --no-default-features` passes.
- `cargo check --workspace --target wasm32-unknown-unknown` passes.
- `cargo +nightly test -p lyon_tessellation --all-features` passes.
- Tessellation coverage: 281 unit tests, 9 integration tests, 9 doctests.
- `git diff --check` passes.
- Ordinary Clippy is blocked by the pre-existing `overly_complex_bool_expr`
  diagnostic in `crates/tessellation/src/fill.rs:772`, reproduced on the unchanged
  base. With that lint allowed, the check succeeds; existing test warnings remain.
  No warnings were reported in the newly added arcs modules, integration test, or example.

Linux CI and any maintainer-selected MSRV still need validation. Existing unused
`num_traits::Float` import warnings remain in the no-std build.

Generate a comparison rendered from the actual triangle meshes:

```sh
cargo run -p lyon_tessellation --example arcs -- joins.svg
```

The example compares Round, MiterClip, SVG 2 Arcs, and SVG 2 with rounded cuts,
without relying on browser support for arcs joins.

## Performance: open merge blocker

Do not merge on the assumption that existing joins are unaffected.

The unchanged upstream logo benchmarks were built separately at base
`994526f2766c7e9bc5bb16687232fd7e8999dbdf` and at this candidate. Four complete
alternating pairs were measured with default release settings on an Intel
Core i9-13900H, Windows x86_64, Rust 1.90.0. Medians of reported ns/iteration:

| Existing join | Upstream | Candidate | Change |
| --- | ---: | ---: | ---: |
| Miter | 43,633 | 47,754 | +9.4% |
| Bevel | 46,261.5 | 51,593.5 | +11.5% |
| Round | 56,916 | 66,268 | +16.4% |

This is a local microbenchmark result, not a cross-platform estimate. The
standard-only commit also regressed these cases in an earlier five-pair run.
Profiling and reducing this cost is required before calling the implementation
merge-ready.

Reproduce the existing tests in separate checkouts:

```sh
cargo run -p tess_bench --release -- stroke_
```

The new same-input, reused-buffer benchmarks can be selected with `arcs`,
`round_curved`, and `miter_clip_lines`. Initial smoke measurements were noisy;
they are not sufficient to quantify the overhead of rounded clipping.

## Remaining correctness/scope questions

- The SVG comparison example currently combines triangles into one nonzero-filled
  path without normalizing their winding. Overlapping triangles with opposite
  winding cancel, producing apparent holes. Coordinate checks confirm coverage
  in those regions. The exporter needs correction, and mixed mesh winding needs
  a separate review for back-face culling. This has not been fixed in these commits.
- Degenerate or numerically unmeshable joins currently use a round safety
  fallback. SVG 2 describes a line construction for degenerate Bezier handles;
  that behavior still needs reconciliation and dedicated conformance tests.
  This PR does not claim complete SVG conformance.
- Variable-width supports use width at the join, not derivatives of the width
  profile.
- Pre-flattened paths have no curvature and use the straight-segment behavior.
  Elliptical arcs converted to Beziers use those Beziers' curvature.
- Existing stroke self-overlap/alpha-compositing limitations remain.

Please review the public API and desired scope of the rounded-cut extension while
the performance and degenerate-handle questions are addressed.
