### PR TITLE
Prevent the merge vertex fixup during error recovery from placing the…

### DIFF
--- a/crates/tessellation/src/fill.rs
+++ b/crates/tessellation/src/fill.rs
@@ -1921,32 +1921,66 @@ impl FillTessellator {
             return;
         }
 
+        let num_edges = self.active.edges.len();
         let mut winding_number = 0;
-        for i in 0..self.active.edges.len() {
-            let needs_swap = {
-                let edge = &self.active.edges[i];
-                if edge.is_merge {
-                    !self.fill_rule.is_in(winding_number)
-                } else {
-                    winding_number += edge.winding;
-                    false
+        let mut i = 0;
+        while i < num_edges {
+            if !self.active.edges[i].is_merge {
+                winding_number += self.active.edges[i].winding;
+                i += 1;
+                continue;
+            }
+
+            if self.fill_rule.is_in(winding_number) {
+                i += 1;
+                continue;
+            }
+
+            tess_log!(self, "Fixing up merge vertex after sort.");
+
+            // Look for the closest position at which the merge vertex is inside
+            // the shape, first towards the left and then towards the right.
+            // Index zero is not a candidate since the winding number before the
+            // first active edge is always zero (outside).
+            let mut target = None;
+            let mut w = winding_number;
+            for idx in (1..i).rev() {
+                // Roll back the winding of the edge the merge vertex moves past.
+                w -= self.active.edges[idx].winding;
+                if self.fill_rule.is_in(w) {
+                    target = Some(idx);
+                    break;
                 }
-            };
+            }
 
-            if needs_swap {
-                let mut w = winding_number;
-                tess_log!(self, "Fixing up merge vertex after sort.");
-                let mut idx = i;
-                while idx > 0 {
-                    // Roll back previous edge winding and swap.
-                    w -= self.active.edges[idx - 1].winding;
-                    self.active.edges.swap(idx, idx - 1);
+            if let Some(idx) = target {
+                self.active.edges[idx..=i].rotate_right(1);
+                // The set of edges in 0..=i did not change, so the winding number
+                // after this position is still the same.
+                i += 1;
+                continue;
+            }
 
-                    if self.fill_rule.is_in(w) {
-                        break;
-                    }
+            let mut w = winding_number;
+            for idx in (i + 1)..num_edges {
+                w += self.active.edges[idx].winding;
+                if self.fill_rule.is_in(w) {
+                    target = Some(idx);
+                    break;
+                }
+            }
 
-                    idx -= 1;
+            match target {
+                Some(idx) => {
+                    self.active.edges[i..=idx].rotate_left(1);
+                    // Continue from the same index: the edges that the merge
+                    // vertex moved past have not been counted in the winding
+                    // number yet.
+                }
+                // The merge vertex is outside of the shape wherever it is
+                // placed. Leave it where it is.
+                None => {
+                    i += 1;
                 }
             }
         }

--- a/crates/tessellation/src/fill_tests.rs
+++ b/crates/tessellation/src/fill_tests.rs
@@ -2501,3 +2501,57 @@ fn test_triangle_winding() {
     )
     .unwrap();
 }
+
+// Sweeping this path runs into an internal error. Error recovery must not
+// leave a merge vertex as the first active edge.
+#[test]
+fn issue_963_1() {
+    let a = [
+        (5.498809e2, 1.6776793e7),
+        (5.581379e2, 1.6776795e7),
+        (5.498809e2, 1.6776793e7),
+        (-1.1754944e-38, 1.6777215e7),
+    ];
+    let b = [
+        (1.2064563e7, 1.2452183e7),
+        (1.6776785e1, 1.6743695e7),
+        (0.0, 1.6777215e7),
+    ];
+
+    let mut builder = Path::builder();
+    for contour in [&a[..], &b[..]] {
+        builder.begin(point(contour[0].0, contour[0].1));
+        for p in &contour[1..] {
+            builder.line_to(point(p.0, p.1));
+        }
+        builder.close();
+    }
+    let path = builder.build();
+
+    let mut buffers: VertexBuffers<Point, u16> = VertexBuffers::new();
+    let mut tess = FillTessellator::new();
+    tess.tessellate_path(
+        &path,
+        &FillOptions::default().with_fill_rule(FillRule::NonZero),
+        &mut simple_builder(&mut buffers),
+    )
+    .unwrap();
+}
+
+// Same failure as issue_963 with a single contour.
+#[test]
+fn issue_963_2() {
+    let mut builder = Path::builder();
+    builder.begin(point(3669135.8, 4760474.5));
+    builder.line_to(point(3669135.8, 3669135.8));
+    builder.line_to(point(3669135.8, 4760474.5));
+    builder.line_to(point(5290038.5, 3154107.0));
+    builder.line_to(point(4760475.0, 3669135.8));
+    builder.line_to(point(3154105.3, 3154105.3));
+    builder.line_to(point(4760475.0, 4760475.0));
+    builder.line_to(point(3154105.3, 4760474.5));
+    builder.line_to(point(4760475.0, 4760474.5));
+    builder.close();
+
+    test_path(builder.build().as_slice());
+}


### PR DESCRIPTION
… merge vertex outside of the shape

The test case provided in issue 963 triggered the error recorvery path which sorts all acitve edges. After the sort there is a fixup pass for merge vertices which swaps them with the previous edge if the merge vertex is outside of the shape (working under the over-simplified assumption that if the merge vertex is outside, then the previous edge is the in-out boundary). However if the previous edge was the result of fusing two overlapping edges with opposite windings, that edge would have zero-winding and would therefore not be the boundary, leaving the merge vertex outside of the shape, still. The fix is to search for the closest edge that is inside of the shape instead of blindly picking the previous one. If none is found on the left, then search on the right side. It is still technically possible that all active edges have zero-winding, which means that there is nowhere to put the merge vertex. That case seems pretty difficult to construct, and there isn't much that can be done in this case.

Fixes #963.